### PR TITLE
Fix a few issues in prometheus and grafana in helm charts

### DIFF
--- a/pulsar/charts/pulsar/templates/pulsar-manager-deployment.yaml
+++ b/pulsar/charts/pulsar/templates/pulsar-manager-deployment.yaml
@@ -74,7 +74,7 @@ spec:
           - name: PULSAR_CLUSTER
             value: {{ template "pulsar.fullname" . }}
           - name: REDIRECT_HOST
-            value: http://127.0.0.1
+            value: {{ .Values.pulsar_manager.redirect_host }}
           - name: REDIRECT_PORT
             value: "9527"
           - name: DRIVER_CLASS_NAME

--- a/pulsar/charts/pulsar/values.yaml
+++ b/pulsar/charts/pulsar/values.yaml
@@ -204,7 +204,7 @@ images:
 ## This admin credentials will be used for configuring both grafana and
 ## pulsar-manager
 admin:
-  user: pulsaradmin
+  user: pulsar
   password: happypulsaring
 
 ## Pulsar: Zookeeper cluster
@@ -625,7 +625,7 @@ prometheus:
     data:
       name: data
       size: 10Gi
-      local_storage: true
+      local_storage: false
       ## If the storage class is left undefined when using persistence
       ## the default storage class for the cluster will be used.
       ##
@@ -711,6 +711,7 @@ pulsar_manager:
     ports:
       - name: server
         port: 9527
+  redirect_host: 127.0.0.1
 
 ## Components Stack: pulsar operators rbac
 ## templates/pulsar-operators-rbac.yaml


### PR DESCRIPTION
- redirect-hosts should be configurable since it should be the ip of frontend component of pulsar-manager
- use `pulsar` as the default username since pulsar-manager has a hard-coded user name.
- disable local_storage by default for prometheus