### PR TITLE
[Bug Fix] Fix some default value about secret

### DIFF
--- a/pulsar/charts/pulsar/values.yaml
+++ b/pulsar/charts/pulsar/values.yaml
@@ -19,7 +19,7 @@
 
 ## Namespace to deploy pulsar
 namespace: pulsar
-namespaceCreate: false
+namespaceCreate: true
 
 ## Pulsar Metadata Prefix
 ##
@@ -99,7 +99,7 @@ ingress:
 # TLS
 # templates/tls-certs.yaml
 tls:
-  enabled: true
+  enabled: false
   # common settings for generating certs
   common:
     # 90d
@@ -113,7 +113,7 @@ tls:
     keyEncoding: pkcs8
   # settings for generating certs for proxy
   proxy:
-    enabled: true
+    enabled: false
     cert_name: tls-proxy
     commonName: example.com
     dnsNames:
@@ -138,11 +138,11 @@ tls:
 # templates/tls-cert-issuer.yaml
 certs:
   internal_issuer:
-    enabled: true
+    enabled: false
     component: internal-cert-issuer
     type: selfsigning
   public_issuer:
-    enabled: true
+    enabled: false
     component: public-cert-issuer
     type: acme
   issuers:


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

### Motivation

Due to the addition of some secret-related functions, the current helm chart cannot be started quickly. Maybe we need to configure the secret-related functions first, but this process is not user-friendly. We should first provide a simplified version to ensure that users Quick and correct startup. If users need secret related functions, they can be configured according to the documents provided by us.

### Modifications

- Fix some default value about secret

kubectl version:

```
Client Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.6", GitCommit:"72c30166b2105cd7d3350f2c28a219e6abcd79eb", GitTreeState:"clean", BuildDate:"2020-01-18T23:31:31Z", GoVersion:"go1.13.5", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.6", GitCommit:"72c30166b2105cd7d3350f2c28a219e6abcd79eb", GitTreeState:"clean", BuildDate:"2020-01-18T23:23:21Z", GoVersion:"go1.13.5", Compiler:"gc", Platform:"linux/amd64"}
```

helm version:

```
version.BuildInfo{Version:"v3.0.3", GitCommit:"ac925eb7279f4a6955df663a0128044a8a6b7593", GitTreeState:"clean", GoVersion:"go1.13.7"}
```
