### PR TITLE
Update grafana dashboard image to 0.0.5

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -152,7 +152,7 @@ images:
     pullPolicy: IfNotPresent
   grafana:
     repository: streamnative/apache-pulsar-grafana-dashboard-k8s
-    tag: 0.0.4
+    tag: 0.0.5
     pullPolicy: IfNotPresent
   pulsar_manager:
     repository: streamnative/pulsar-manager


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

Fixes: #49 

Update grafana dashboard image to 0.0.5