### PR TITLE
Fix proxy cluster IP

### DIFF
--- a/charts/pulsar/templates/proxy-service.yaml
+++ b/charts/pulsar/templates/proxy-service.yaml
@@ -59,6 +59,7 @@ spec:
       port: {{ .Values.proxy.ports.pulsarssl }}
       protocol: TCP
     {{- end }}
+  clusterIP: None
   selector:
     app: {{ template "pulsar.name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

- Fix proxy cluster IP

Maybe we don't need to assign a clusterIP:

```
sn-platform-pulsar-proxy                    ClusterIP      10.12.14.249   <none>          8080/TCP,6650/TCP            4m8s
```