### PR TITLE
Fallback to Helm .Release.Namespace when .namespace not defined

### DIFF
--- a/charts/pulsar/templates/_helpers.tpl
+++ b/charts/pulsar/templates/_helpers.tpl
@@ -19,6 +19,13 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
+Expand the name of the chart.
+*/}}
+{{- define "pulsar.namespace" -}}
+{{- default .Release.Namespace .Values.namespace -}}
+{{- end -}}
+
+{{/*
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.

--- a/charts/pulsar/templates/_helpers.tpl
+++ b/charts/pulsar/templates/_helpers.tpl
@@ -19,7 +19,7 @@ Expand the name of the chart.
 {{- end -}}
 
 {{/*
-Expand the name of the chart.
+Expand to the namespace pulsar installs into.
 */}}
 {{- define "pulsar.namespace" -}}
 {{- default .Release.Namespace .Values.namespace -}}

--- a/charts/pulsar/templates/alert-manager/alertmanager-configmap.yaml
+++ b/charts/pulsar/templates/alert-manager/alertmanager-configmap.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.alert_manager.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.alert_manager.component }}

--- a/charts/pulsar/templates/alert-manager/alertmanager-service.yaml
+++ b/charts/pulsar/templates/alert-manager/alertmanager-service.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.alert_manager.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.alert_manager.component }}

--- a/charts/pulsar/templates/alert-manager/alertmanager-statefulset.yaml
+++ b/charts/pulsar/templates/alert-manager/alertmanager-statefulset.yaml
@@ -22,7 +22,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.alert_manager.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.alert_manager.component }}

--- a/charts/pulsar/templates/bookkeeper/bookkeeper-autorecovery-configmap.yaml
+++ b/charts/pulsar/templates/bookkeeper/bookkeeper-autorecovery-configmap.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.autorecovery.component }}

--- a/charts/pulsar/templates/bookkeeper/bookkeeper-autorecovery-service.yaml
+++ b/charts/pulsar/templates/bookkeeper/bookkeeper-autorecovery-service.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.autorecovery.component }}

--- a/charts/pulsar/templates/bookkeeper/bookkeeper-autorecovery-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper/bookkeeper-autorecovery-statefulset.yaml
@@ -22,7 +22,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.autorecovery.component }}

--- a/charts/pulsar/templates/bookkeeper/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper/bookkeeper-cluster-initialize.yaml
@@ -23,7 +23,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-init"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: "{{ .Values.bookkeeper.component }}-init"
@@ -37,7 +37,7 @@ spec:
         command: ["sh", "-c"]
         args:
           - >-
-            until nslookup {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ add (.Values.zookeeper.replicaCount | int) -1 }}.{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}.{{ .Values.namespace }}; do
+            until nslookup {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ add (.Values.zookeeper.replicaCount | int) -1 }}.{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}.{{ template "pulsar.namespace" . }}; do
               sleep 3;
             done;
       containers:

--- a/charts/pulsar/templates/bookkeeper/bookkeeper-cluster-role-binding.yaml
+++ b/charts/pulsar/templates/bookkeeper/bookkeeper-cluster-role-binding.yaml
@@ -32,7 +32,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-acct"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/charts/pulsar/templates/bookkeeper/bookkeeper-configmap.yaml
+++ b/charts/pulsar/templates/bookkeeper/bookkeeper-configmap.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.bookkeeper.component }}

--- a/charts/pulsar/templates/bookkeeper/bookkeeper-pdb.yaml
+++ b/charts/pulsar/templates/bookkeeper/bookkeeper-pdb.yaml
@@ -23,7 +23,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.bookkeeper.component }}

--- a/charts/pulsar/templates/bookkeeper/bookkeeper-service-account.yaml
+++ b/charts/pulsar/templates/bookkeeper/bookkeeper-service-account.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-acct"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.bookkeeper.component }}

--- a/charts/pulsar/templates/bookkeeper/bookkeeper-service.yaml
+++ b/charts/pulsar/templates/bookkeeper/bookkeeper-service.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.bookkeeper.component }}

--- a/charts/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
@@ -22,7 +22,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.bookkeeper.component }}

--- a/charts/pulsar/templates/bookkeeper/bookkeeper-storageclass.yaml
+++ b/charts/pulsar/templates/bookkeeper/bookkeeper-storageclass.yaml
@@ -24,7 +24,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.journal.name }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.bookkeeper.component }}
@@ -43,7 +43,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.ledgers.name }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.bookkeeper.component }}

--- a/charts/pulsar/templates/broker/broker-cluster-role-binding.yaml
+++ b/charts/pulsar/templates/broker/broker-cluster-role-binding.yaml
@@ -32,7 +32,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-acct"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/charts/pulsar/templates/broker/broker-configmap.yaml
+++ b/charts/pulsar/templates/broker/broker-configmap.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.broker.component }}
@@ -90,7 +90,7 @@ data:
   PF_functionRuntimeFactoryConfigs_pulsarDockerImageName: "{{ .Values.images.functions.repository }}:{{ .Values.images.functions.tag }}"
   PF_functionRuntimeFactoryConfigs_submittingInsidePod: "true"
   PF_functionRuntimeFactoryConfigs_installUserCodeDependencies: "true"
-  PF_functionRuntimeFactoryConfigs_jobNamespace: {{ .Values.namespace }}
+  PF_functionRuntimeFactoryConfigs_jobNamespace: {{ template "pulsar.namespace" . }}
   PF_functionRuntimeFactoryConfigs_expectedMetricsCollectionInterval: "30"
   {{- if not (and .Values.tls.enabled .Values.tls.broker.enabled) }}
   PF_functionRuntimeFactoryConfigs_pulsarAdminUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.http }}/"
@@ -101,12 +101,12 @@ data:
   PF_functionRuntimeFactoryConfigs_pulsarServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.pulsarssl }}/"
   {{- end }}
   PF_functionRuntimeFactoryConfigs_changeConfigMap: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-config"
-  PF_functionRuntimeFactoryConfigs_changeConfigMapNamespace: {{ .Values.namespace }}
+  PF_functionRuntimeFactoryConfigs_changeConfigMapNamespace: {{ template "pulsar.namespace" . }}
   # support version < 2.5.0
   PF_kubernetesContainerFactory_pulsarDockerImageName: "{{ .Values.images.functions.repository }}:{{ .Values.images.functions.tag }}"
   PF_kubernetesContainerFactory_submittingInsidePod: "true"
   PF_kubernetesContainerFactory_installUserCodeDependencies: "true"
-  PF_kubernetesContainerFactory_jobNamespace: {{ .Values.namespace }}
+  PF_kubernetesContainerFactory_jobNamespace: {{ template "pulsar.namespace" . }}
   PF_kubernetesContainerFactory_expectedMetricsCollectionInterval: "30"
   {{- if not (and .Values.tls.enabled .Values.tls.broker.enabled) }}
   PF_kubernetesContainerFactory_pulsarAdminUrl: "http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.http }}/"
@@ -117,7 +117,7 @@ data:
   PF_kubernetesContainerFactory_pulsarServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.pulsarssl }}/"
   {{- end }}
   PF_kubernetesContainerFactory_changeConfigMap: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-config"
-  PF_kubernetesContainerFactory_changeConfigMapNamespace: {{ .Values.namespace }}
+  PF_kubernetesContainerFactory_changeConfigMapNamespace: {{ template "pulsar.namespace" . }}
   {{- end }}
 
   # prometheus needs to access /metrics endpoint

--- a/charts/pulsar/templates/broker/broker-pdb.yaml
+++ b/charts/pulsar/templates/broker/broker-pdb.yaml
@@ -23,7 +23,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.broker.component }}

--- a/charts/pulsar/templates/broker/broker-service-account.yaml
+++ b/charts/pulsar/templates/broker/broker-service-account.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-acct"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.broker.component }}

--- a/charts/pulsar/templates/broker/broker-service.yaml
+++ b/charts/pulsar/templates/broker/broker-service.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.broker.component }}

--- a/charts/pulsar/templates/broker/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker/broker-statefulset.yaml
@@ -22,7 +22,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.broker.component }}

--- a/charts/pulsar/templates/broker/function-worker-configmap.yaml
+++ b/charts/pulsar/templates/broker/function-worker-configmap.yaml
@@ -23,7 +23,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-config"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.functions.component }}

--- a/charts/pulsar/templates/control-center/control-center-ingress.yaml
+++ b/charts/pulsar/templates/control-center/control-center-ingress.yaml
@@ -26,7 +26,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.ingress.control_center.component }}-ingress"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
   annotations:

--- a/charts/pulsar/templates/control-center/ingress-controller-configmap.yaml
+++ b/charts/pulsar/templates/control-center/ingress-controller-configmap.yaml
@@ -22,7 +22,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: "{{ template "pulsar.fullname" . }}-nginx-configuration"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.ingress.controller.component }}
@@ -34,7 +34,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: "{{ template "pulsar.fullname" . }}-tcp-services"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.ingress.controller.component }}
@@ -43,7 +43,7 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: "{{ template "pulsar.fullname" . }}-udp-services"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.ingress.controller.component }}

--- a/charts/pulsar/templates/control-center/ingress-controller-deployment.yaml
+++ b/charts/pulsar/templates/control-center/ingress-controller-deployment.yaml
@@ -23,7 +23,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.ingress.controller.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.ingress.controller.component }}
@@ -60,10 +60,10 @@ spec:
         imagePullPolicy: {{ .Values.images.nginx_ingress_controller.pullPolicy }}
         args:
         - /nginx-ingress-controller
-        - --configmap={{ .Values.namespace }}/{{ template "pulsar.fullname" . }}-nginx-configuration
-        - --tcp-services-configmap={{ .Values.namespace }}/{{ template "pulsar.fullname" . }}-tcp-services
-        - --udp-services-configmap={{ .Values.namespace }}/{{ template "pulsar.fullname" . }}-udp-services
-        - --publish-service={{ .Values.namespace }}/{{ template "pulsar.fullname" . }}-{{ .Values.ingress.controller.component }}
+        - --configmap={{ template "pulsar.namespace" . }}/{{ template "pulsar.fullname" . }}-nginx-configuration
+        - --tcp-services-configmap={{ template "pulsar.namespace" . }}/{{ template "pulsar.fullname" . }}-tcp-services
+        - --udp-services-configmap={{ template "pulsar.namespace" . }}/{{ template "pulsar.fullname" . }}-udp-services
+        - --publish-service={{ template "pulsar.namespace" . }}/{{ template "pulsar.fullname" . }}-{{ .Values.ingress.controller.component }}
         - --annotations-prefix=nginx.ingress.kubernetes.io
         securityContext:
           allowPrivilegeEscalation: true

--- a/charts/pulsar/templates/control-center/ingress-controller-rbac.yaml
+++ b/charts/pulsar/templates/control-center/ingress-controller-rbac.yaml
@@ -23,7 +23,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: "{{ template "pulsar.fullname" . }}-nginx-ingress-serviceaccount"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -88,7 +88,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: "{{ template "pulsar.fullname" . }}-nginx-ingress-role"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     app: {{ template "pulsar.name" . }}
     chart: {{ template "pulsar.chart" . }}
@@ -133,7 +133,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: "{{ template "pulsar.fullname" . }}-nginx-ingress-role-nisa-binding"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     app: {{ template "pulsar.name" . }}
     chart: {{ template "pulsar.chart" . }}
@@ -145,7 +145,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: "{{ template "pulsar.fullname" . }}-nginx-ingress-serviceaccount"
-    namespace: {{ .Values.namespace }}
+    namespace: {{ template "pulsar.namespace" . }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -159,7 +159,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: "{{ template "pulsar.fullname" . }}-nginx-ingress-serviceaccount"
-    namespace: {{ .Values.namespace }}
+    namespace: {{ template "pulsar.namespace" . }}
 
 ---
 {{- end }}

--- a/charts/pulsar/templates/control-center/ingress-controller-service.yaml
+++ b/charts/pulsar/templates/control-center/ingress-controller-service.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.ingress.controller.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.ingress.controller.component }}

--- a/charts/pulsar/templates/detector/pulsar-detector-pdb.yaml
+++ b/charts/pulsar/templates/detector/pulsar-detector-pdb.yaml
@@ -23,7 +23,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_detector.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.pulsar_detector.component }}

--- a/charts/pulsar/templates/detector/pulsar-detector-service-account.yaml
+++ b/charts/pulsar/templates/detector/pulsar-detector-service-account.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_detector.component }}-acct"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.pulsar_detector.component }}

--- a/charts/pulsar/templates/detector/pulsar-detector-service.yaml
+++ b/charts/pulsar/templates/detector/pulsar-detector-service.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_detector.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.pulsar_detector.component }}

--- a/charts/pulsar/templates/detector/pulsar-detector-statefulset.yaml
+++ b/charts/pulsar/templates/detector/pulsar-detector-statefulset.yaml
@@ -22,7 +22,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_detector.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.pulsar_detector.component }}

--- a/charts/pulsar/templates/external-dns/external-dns-rbac.yaml
+++ b/charts/pulsar/templates/external-dns/external-dns-rbac.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.external_dns.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   annotations:
 {{- with .Values.external_dns.serviceAcct.annotations }}
 {{ toYaml . | indent 4 }}
@@ -62,5 +62,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.external_dns.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 {{- end }}

--- a/charts/pulsar/templates/external-dns/external-dns.yaml
+++ b/charts/pulsar/templates/external-dns/external-dns.yaml
@@ -22,7 +22,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.external_dns.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 spec:
   strategy:
     type: Recreate

--- a/charts/pulsar/templates/grafana/grafana-admin-secret.yaml
+++ b/charts/pulsar/templates/grafana/grafana-admin-secret.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.grafana.component }}-secret"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.grafana.component }}

--- a/charts/pulsar/templates/grafana/grafana-configmap.yaml
+++ b/charts/pulsar/templates/grafana/grafana-configmap.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.grafana.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.grafana.component }}

--- a/charts/pulsar/templates/grafana/grafana-deployment.yaml
+++ b/charts/pulsar/templates/grafana/grafana-deployment.yaml
@@ -22,7 +22,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.grafana.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.grafana.component }}

--- a/charts/pulsar/templates/grafana/grafana-service.yaml
+++ b/charts/pulsar/templates/grafana/grafana-service.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.grafana.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.grafana.component }}

--- a/charts/pulsar/templates/image-puller/_daemonset-helper.yaml
+++ b/charts/pulsar/templates/image-puller/_daemonset-helper.yaml
@@ -28,7 +28,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "pulsar.fullname" . }}-{{ print .componentPrefix "image-puller" }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
   {{- if .hook }}

--- a/charts/pulsar/templates/image-puller/job.yaml
+++ b/charts/pulsar/templates/image-puller/job.yaml
@@ -30,7 +30,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "pulsar.fullname" . }}-hook-image-awaiter
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.imagePuller.component }}
@@ -59,6 +59,6 @@ spec:
             - -ca-path=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
             - -auth-token-path=/var/run/secrets/kubernetes.io/serviceaccount/token
             - -api-server-address=https://$(KUBERNETES_SERVICE_HOST):$(KUBERNETES_SERVICE_PORT)
-            - -namespace={{ .Values.namespace }}
+            - -namespace={{ template "pulsar.namespace" . }}
             - -daemonset={{ template "pulsar.fullname" . }}-hook-image-puller
 {{- end }}

--- a/charts/pulsar/templates/image-puller/rbac.yaml
+++ b/charts/pulsar/templates/image-puller/rbac.yaml
@@ -30,7 +30,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "pulsar.fullname" . }}-hook-image-awaiter
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
   annotations:
@@ -46,7 +46,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "pulsar.fullname" . }}-hook-image-awaiter
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
   annotations:
@@ -66,7 +66,7 @@ kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ template "pulsar.fullname" . }}-hook-image-awaiter
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
   annotations:
@@ -76,7 +76,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: {{ template "pulsar.fullname" . }}-hook-image-awaiter
-    namespace: {{ .Values.namespace }}
+    namespace: {{ template "pulsar.namespace" . }}
 roleRef:
   kind: Role
   name: {{ template "pulsar.fullname" . }}-hook-image-awaiter

--- a/charts/pulsar/templates/namespace.yaml
+++ b/charts/pulsar/templates/namespace.yaml
@@ -21,5 +21,5 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: {{ .Values.namespace }}
+  name: {{ template "pulsar.namespace" . }}
 {{- end }}

--- a/charts/pulsar/templates/node-exporter/node-exporter.yaml
+++ b/charts/pulsar/templates/node-exporter/node-exporter.yaml
@@ -22,7 +22,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.node_exporter.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.node_exporter.component }}

--- a/charts/pulsar/templates/presto/presto-coordinator-configmap.yaml
+++ b/charts/pulsar/templates/presto/presto-coordinator-configmap.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.presto.coordinator.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.presto.coordinator.component }}

--- a/charts/pulsar/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/pulsar/templates/presto/presto-coordinator-statefulset.yaml
@@ -22,7 +22,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "presto.coordinator" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.presto.coordinator.component }}

--- a/charts/pulsar/templates/presto/presto-service.yaml
+++ b/charts/pulsar/templates/presto/presto-service.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "presto.service" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
 spec:

--- a/charts/pulsar/templates/presto/presto-worker-configmap.yaml
+++ b/charts/pulsar/templates/presto/presto-worker-configmap.yaml
@@ -23,7 +23,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.presto.worker.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.presto.worker.component }}

--- a/charts/pulsar/templates/presto/presto-worker-statefulset.yaml
+++ b/charts/pulsar/templates/presto/presto-worker-statefulset.yaml
@@ -22,7 +22,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "presto.worker" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.presto.worker.component }}

--- a/charts/pulsar/templates/prometheus/prometheus-configmap.yaml
+++ b/charts/pulsar/templates/prometheus/prometheus-configmap.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.prometheus.component }}

--- a/charts/pulsar/templates/prometheus/prometheus-pvc.yaml
+++ b/charts/pulsar/templates/prometheus/prometheus-pvc.yaml
@@ -23,7 +23,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}-{{ .Values.prometheus.volumes.data.name }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 spec:
   resources:
     requests:

--- a/charts/pulsar/templates/prometheus/prometheus-service.yaml
+++ b/charts/pulsar/templates/prometheus/prometheus-service.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.prometheus.component }}

--- a/charts/pulsar/templates/prometheus/prometheus-statefulset.yaml
+++ b/charts/pulsar/templates/prometheus/prometheus-statefulset.yaml
@@ -22,7 +22,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.prometheus.component }}

--- a/charts/pulsar/templates/prometheus/prometheus-storageclass.yaml
+++ b/charts/pulsar/templates/prometheus/prometheus-storageclass.yaml
@@ -24,7 +24,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}-{{ .Values.prometheus.volumes.data.name }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.prometheus.component }}

--- a/charts/pulsar/templates/prometheus/pulsar-operators-rbac.yaml
+++ b/charts/pulsar/templates/prometheus/pulsar-operators-rbac.yaml
@@ -87,7 +87,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.rbac.roleName }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -101,6 +101,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.rbac.roleName }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 
 {{- end }}

--- a/charts/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/charts/pulsar/templates/proxy/proxy-configmap.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.proxy.component }}

--- a/charts/pulsar/templates/proxy/proxy-pdb.yaml
+++ b/charts/pulsar/templates/proxy/proxy-pdb.yaml
@@ -23,7 +23,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.proxy.component }}

--- a/charts/pulsar/templates/proxy/proxy-service-account.yaml
+++ b/charts/pulsar/templates/proxy/proxy-service-account.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}-acct"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.proxy.component }}

--- a/charts/pulsar/templates/proxy/proxy-service-ingress.yaml
+++ b/charts/pulsar/templates/proxy/proxy-service-ingress.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}-ingress"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.proxy.component }}

--- a/charts/pulsar/templates/proxy/proxy-service.yaml
+++ b/charts/pulsar/templates/proxy/proxy-service.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.proxy.component }}

--- a/charts/pulsar/templates/proxy/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy/proxy-statefulset.yaml
@@ -22,7 +22,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.proxy.component }}

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -23,7 +23,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_metadata.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.pulsar_metadata.component }}
@@ -49,7 +49,7 @@ spec:
         command: ["sh", "-c"]
         args:
           - >-
-            until nslookup {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ add (.Values.zookeeper.replicaCount | int) -1 }}.{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}.{{ .Values.namespace }}; do
+            until nslookup {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ add (.Values.zookeeper.replicaCount | int) -1 }}.{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}.{{ template "pulsar.namespace" . }}; do
               sleep 3;
             done;
       # This initContainer will wait for bookkeeper initnewcluster to complete
@@ -91,10 +91,10 @@ spec:
               {{- if not .Values.pulsar_metadata.configurationStore }}
               --configuration-store {{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }} \
               {{- end }}
-              --web-service-url http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Values.namespace }}.svc.cluster.local:8080/ \
-              --web-service-url-tls https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Values.namespace }}.svc.cluster.local:8443/ \
-              --broker-service-url pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Values.namespace }}.svc.cluster.local:6650/ \
-              --broker-service-url-tls pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Values.namespace }}.svc.cluster.local:6651/ || true;
+              --web-service-url http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.cluster.local:8080/ \
+              --web-service-url-tls https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.cluster.local:8443/ \
+              --broker-service-url pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.cluster.local:6650/ \
+              --broker-service-url-tls pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.cluster.local:6651/ || true;
         volumeMounts:
         {{- include "pulsar.toolset.certs.volumeMounts" . | nindent 8 }}
       volumes:

--- a/charts/pulsar/templates/pulsar-manager/pulsar-manager-backend-service.yaml
+++ b/charts/pulsar/templates/pulsar-manager/pulsar-manager-backend-service.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-backend"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.pulsar_manager.component }}

--- a/charts/pulsar/templates/pulsar-manager/pulsar-manager-configmap.yaml
+++ b/charts/pulsar/templates/pulsar-manager/pulsar-manager-configmap.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-configmap"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.pulsar_manager.component }}

--- a/charts/pulsar/templates/pulsar-manager/pulsar-manager-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-manager/pulsar-manager-initialize.yaml
@@ -23,7 +23,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-init"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.pulsar_manager.component }}

--- a/charts/pulsar/templates/pulsar-manager/pulsar-manager-pvc.yaml
+++ b/charts/pulsar/templates/pulsar-manager/pulsar-manager-pvc.yaml
@@ -23,7 +23,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-{{ .Values.pulsar_manager.volumes.data.name }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 spec:
   resources:
     requests:

--- a/charts/pulsar/templates/pulsar-manager/pulsar-manager-service.yaml
+++ b/charts/pulsar/templates/pulsar-manager/pulsar-manager-service.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.pulsar_manager.component }}

--- a/charts/pulsar/templates/pulsar-manager/pulsar-manager-statefulset.yaml
+++ b/charts/pulsar/templates/pulsar-manager/pulsar-manager-statefulset.yaml
@@ -22,7 +22,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.pulsar_manager.component }}

--- a/charts/pulsar/templates/pulsar-manager/pulsar-manager-storageclass.yaml
+++ b/charts/pulsar/templates/pulsar-manager/pulsar-manager-storageclass.yaml
@@ -24,7 +24,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-{{ .Values.pulsar_manager.volumes.data.name }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.pulsar_manager.component }}

--- a/charts/pulsar/templates/tls/keytool.yaml
+++ b/charts/pulsar/templates/tls/keytool.yaml
@@ -24,7 +24,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ template "pulsar.fullname" . }}-keytool-configmap"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: keytool 

--- a/charts/pulsar/templates/tls/tls-cert-internal-issuer.yaml
+++ b/charts/pulsar/templates/tls/tls-cert-internal-issuer.yaml
@@ -23,7 +23,7 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.certs.internal_issuer.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 spec:
   selfSigned: {}
 ---
@@ -32,10 +32,10 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-ca"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 spec:
   secretName: "{{ .Release.Name }}-ca-tls"
-  commonName: "{{ .Values.namespace }}.svc.cluster.local"
+  commonName: "{{ template "pulsar.namespace" . }}.svc.cluster.local"
   usages:
     - server auth
     - client auth
@@ -54,7 +54,7 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.certs.internal_issuer.component }}-ca-issuer"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 spec:
   ca:
     secretName: "{{ .Release.Name }}-ca-tls"

--- a/charts/pulsar/templates/tls/tls-cert-public-issuer.yaml
+++ b/charts/pulsar/templates/tls/tls-cert-public-issuer.yaml
@@ -24,7 +24,7 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.certs.public_issuer.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 spec:
   acme:
     email: {{ .Values.certs.issuers.acme.email }}

--- a/charts/pulsar/templates/tls/tls-certs-internal.yaml
+++ b/charts/pulsar/templates/tls/tls-certs-internal.yaml
@@ -27,7 +27,7 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.tls.proxy.cert_name }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 spec:
   # Secret names are always required.
   secretName: "{{ .Release.Name }}-{{ .Values.tls.proxy.cert_name }}"
@@ -37,7 +37,7 @@ spec:
 {{ toYaml .Values.tls.common.organization | indent 2 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
-  commonName: "*.{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Values.namespace }}.svc.cluster.local"
+  commonName: "*.{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.namespace" . }}.svc.cluster.local"
   isCA: false
   keySize: {{ .Values.tls.common.keySize }}
   keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
@@ -47,7 +47,7 @@ spec:
     - client auth
   # At least one of a DNS Name, USI SAN, or IP address is required.
   dnsNames:
-    -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ .Values.namespace }}.svc.cluster.local"
+    -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.namespace" . }}.svc.cluster.local"
     -  "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
   # Issuer references are always required.
   issuerRef:
@@ -67,7 +67,7 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.tls.broker.cert_name }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 spec:
   # Secret names are always required.
   secretName: "{{ .Release.Name }}-{{ .Values.tls.broker.cert_name }}"
@@ -77,7 +77,7 @@ spec:
 {{ toYaml .Values.tls.common.organization | indent 2 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
-  commonName: "*.{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Values.namespace }}.svc.cluster.local"
+  commonName: "*.{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.cluster.local"
   isCA: false
   keySize: {{ .Values.tls.common.keySize }}
   keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
@@ -87,7 +87,7 @@ spec:
     - client auth
   # At least one of a DNS Name, USI SAN, or IP address is required.
   dnsNames:
-    -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ .Values.namespace }}.svc.cluster.local"
+    -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.cluster.local"
     -  "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
   # Issuer references are always required.
   issuerRef:
@@ -106,7 +106,7 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.tls.bookie.cert_name }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 spec:
   # Secret names are always required.
   secretName: "{{ .Release.Name }}-{{ .Values.tls.bookie.cert_name }}"
@@ -116,7 +116,7 @@ spec:
 {{ toYaml .Values.tls.common.organization | indent 2 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
-  commonName: "*.{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}.{{ .Values.namespace }}.svc.cluster.local"
+  commonName: "*.{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}.{{ template "pulsar.namespace" . }}.svc.cluster.local"
   isCA: false
   keySize: {{ .Values.tls.common.keySize }}
   keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
@@ -125,7 +125,7 @@ spec:
     - server auth
     - client auth
   dnsNames:
-    -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}.{{ .Values.namespace }}.svc.cluster.local"
+    -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}.{{ template "pulsar.namespace" . }}.svc.cluster.local"
     -  "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
   # Issuer references are always required.
   issuerRef:
@@ -144,7 +144,7 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.tls.autorecovery.cert_name }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 spec:
   # Secret names are always required.
   secretName: "{{ .Release.Name }}-{{ .Values.tls.autorecovery.cert_name }}"
@@ -154,7 +154,7 @@ spec:
 {{ toYaml .Values.tls.common.organization | indent 2 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
-  commonName: "*.{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}.{{ .Values.namespace }}.svc.cluster.local"
+  commonName: "*.{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}.{{ template "pulsar.namespace" . }}.svc.cluster.local"
   isCA: false
   keySize: {{ .Values.tls.common.keySize }}
   keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
@@ -163,7 +163,7 @@ spec:
     - server auth
     - client auth
   dnsNames:
-    -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}.{{ .Values.namespace }}.svc.cluster.local"
+    -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}.{{ template "pulsar.namespace" . }}.svc.cluster.local"
     -  "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
   # Issuer references are always required.
   issuerRef:
@@ -179,7 +179,7 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.tls.zookeeper.cert_name }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 spec:
   # Secret names are always required.
   secretName: "{{ .Release.Name }}-{{ .Values.tls.zookeeper.cert_name }}"
@@ -189,7 +189,7 @@ spec:
 {{ toYaml .Values.tls.common.organization | indent 2 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
-  commonName: "*.{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}.{{ .Values.namespace }}.svc.cluster.local"
+  commonName: "*.{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}.{{ template "pulsar.namespace" . }}.svc.cluster.local"
   isCA: false
   keySize: {{ .Values.tls.common.keySize }}
   keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
@@ -198,7 +198,7 @@ spec:
     - server auth
     - client auth
   dnsNames:
-    -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}.{{ .Values.namespace }}.svc.cluster.local"
+    -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}.{{ template "pulsar.namespace" . }}.svc.cluster.local"
     -  "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
   # Issuer references are always required.
   issuerRef:
@@ -217,7 +217,7 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.tls.pulsar_manager.cert_name }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 spec:
   # Secret names are always required.
   secretName: "{{ .Release.Name }}-{{ .Values.tls.pulsar_manager.cert_name }}"
@@ -227,7 +227,7 @@ spec:
 {{ toYaml .Values.tls.common.organization | indent 2 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
-  commonName: "*.{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}.{{ .Values.namespace }}.svc.cluster.local"
+  commonName: "*.{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}.{{ template "pulsar.namespace" . }}.svc.cluster.local"
   isCA: false
   keySize: {{ .Values.tls.common.keySize }}
   keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
@@ -237,7 +237,7 @@ spec:
     - client auth
   # At least one of a DNS Name, USI SAN, or IP address is required.
   dnsNames:
-    -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}.{{ .Values.namespace }}.svc.cluster.local"
+    -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}.{{ template "pulsar.namespace" . }}.svc.cluster.local"
     -  "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
   # Issuer references are always required.
   issuerRef:
@@ -256,7 +256,7 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.tls.toolset.cert_name }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 spec:
   # Secret names are always required.
   secretName: "{{ .Release.Name }}-{{ .Values.tls.toolset.cert_name }}"
@@ -266,7 +266,7 @@ spec:
 {{ toYaml .Values.tls.common.organization | indent 2 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
-  commonName: "*.{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}.{{ .Values.namespace }}.svc.cluster.local"
+  commonName: "*.{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}.{{ template "pulsar.namespace" . }}.svc.cluster.local"
   isCA: false
   keySize: {{ .Values.tls.common.keySize }}
   keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
@@ -275,7 +275,7 @@ spec:
     - server auth
     - client auth
   dnsNames:
-    -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}.{{ .Values.namespace }}.svc.cluster.local"
+    -  "*.{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}.{{ template "pulsar.namespace" . }}.svc.cluster.local"
     -  "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
   # Issuer references are always required.
   issuerRef:

--- a/charts/pulsar/templates/tls/tls-certs-public.yaml
+++ b/charts/pulsar/templates/tls/tls-certs-public.yaml
@@ -25,7 +25,7 @@ apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.tls.proxy.cert_name }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
 spec:
   # Secret names are always required.
   secretName: "{{ .Release.Name }}-{{ .Values.tls.proxy.cert_name }}"

--- a/charts/pulsar/templates/toolset/toolset-configmap.yaml
+++ b/charts/pulsar/templates/toolset/toolset-configmap.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.toolset.component }}

--- a/charts/pulsar/templates/toolset/toolset-service.yaml
+++ b/charts/pulsar/templates/toolset/toolset-service.yaml
@@ -22,7 +22,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.toolset.component }}

--- a/charts/pulsar/templates/toolset/toolset-statefulset.yaml
+++ b/charts/pulsar/templates/toolset/toolset-statefulset.yaml
@@ -22,7 +22,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.toolset.component }}

--- a/charts/pulsar/templates/zookeeper/zookeeper-configmap.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-configmap.yaml
@@ -23,7 +23,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.zookeeper.component }}

--- a/charts/pulsar/templates/zookeeper/zookeeper-pdb.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-pdb.yaml
@@ -24,7 +24,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.zookeeper.component }}

--- a/charts/pulsar/templates/zookeeper/zookeeper-service.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-service.yaml
@@ -23,7 +23,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.zookeeper.component }}

--- a/charts/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
@@ -23,7 +23,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.zookeeper.component }}

--- a/charts/pulsar/templates/zookeeper/zookeeper-storageclass.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-storageclass.yaml
@@ -27,7 +27,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.data.name }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.zookeeper.component }}
@@ -44,7 +44,7 @@ apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.dataLog.name }}"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.zookeeper.component }}


### PR DESCRIPTION
This defaults the pulsar namespace to helms default .Release.Namespace if namespace is not defined. This is implemented in the new "pulsar.namespace" template.

The .namespace is set to "pulsar" in the default values.yaml, in order to unset it `--set namespace=null` can be passed to the `helm install` command.

closes #100 