### PR TITLE
[Issue:105]Fallback to Helm .Release.Namespace when .namespace not defined

### DIFF
--- a/charts/pulsar/templates/bookkeeper/_autorecovery.tpl
+++ b/charts/pulsar/templates/bookkeeper/_autorecovery.tpl
@@ -9,7 +9,7 @@ Define the pulsar autorecovery service
 Define the autorecovery hostname
 */}}
 {{- define "pulsar.autorecovery.hostname" -}}
-${HOSTNAME}.{{ template "pulsar.autorecovery.service" . }}.{{ .Values.namespace }}.svc.cluster.local
+${HOSTNAME}.{{ template "pulsar.autorecovery.service" . }}.{{ template "pulsar.namespace" . }}.svc.cluster.local
 {{- end -}}
 
 {{/*

--- a/charts/pulsar/templates/bookkeeper/_bookkeeper.tpl
+++ b/charts/pulsar/templates/bookkeeper/_bookkeeper.tpl
@@ -9,7 +9,7 @@ Define the pulsar bookkeeper service
 Define the bookkeeper hostname
 */}}
 {{- define "pulsar.bookkeeper.hostname" -}}
-${HOSTNAME}.{{ template "pulsar.bookkeeper.service" . }}.{{ .Values.namespace }}.svc.cluster.local
+${HOSTNAME}.{{ template "pulsar.bookkeeper.service" . }}.{{ template "pulsar.namespace" . }}.svc.cluster.local
 {{- end -}}
 
 

--- a/charts/pulsar/templates/broker/_broker.tpl
+++ b/charts/pulsar/templates/broker/_broker.tpl
@@ -9,7 +9,7 @@ Define the pulsar brroker service
 Define the hostname
 */}}
 {{- define "pulsar.broker.hostname" -}}
-${HOSTNAME}.{{ template "pulsar.broker.service" . }}.{{ .Values.namespace }}.svc.cluster.local
+${HOSTNAME}.{{ template "pulsar.broker.service" . }}.{{ template "pulsar.namespace" . }}.svc.cluster.local
 {{- end -}}
 
 {{/*

--- a/charts/pulsar/templates/pulsar-manager/_pulsar_manager.tpl
+++ b/charts/pulsar/templates/pulsar-manager/_pulsar_manager.tpl
@@ -52,7 +52,7 @@ Define the pulsar-manager service
 Define the pulsar-manager hostname
 */}}
 {{- define "pulsar.pulsar_manager.hostname" -}}
-${HOSTNAME}.{{ template "pulsar.pulsar_manager.service" . }}.{{ .Values.namespace }}.svc.cluster.local
+${HOSTNAME}.{{ template "pulsar.pulsar_manager.service" . }}.{{ template "pulsar.namespace" . }}.svc.cluster.local
 {{- end -}}
 
 

--- a/charts/pulsar/templates/toolset/_toolset.tpl
+++ b/charts/pulsar/templates/toolset/_toolset.tpl
@@ -9,7 +9,7 @@ Define the pulsar toolset service
 Define the toolset hostname
 */}}
 {{- define "pulsar.toolset.hostname" -}}
-${HOSTNAME}.{{ template "pulsar.toolset.service" . }}.{{ .Values.namespace }}.svc.cluster.local
+${HOSTNAME}.{{ template "pulsar.toolset.service" . }}.{{ template "pulsar.namespace" . }}.svc.cluster.local
 {{- end -}}
 
 {{/*

--- a/charts/pulsar/templates/zookeeper/_zookeeper.tpl
+++ b/charts/pulsar/templates/zookeeper/_zookeeper.tpl
@@ -21,7 +21,7 @@ Define the pulsar zookeeper
 Define the zookeeper hostname
 */}}
 {{- define "pulsar.zookeeper.hostname" -}}
-${HOSTNAME}.{{ template "pulsar.zookeeper.service" . }}.{{ .Values.namespace }}.svc.cluster.local
+${HOSTNAME}.{{ template "pulsar.zookeeper.service" . }}.{{ template "pulsar.namespace" . }}.svc.cluster.local
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

Fixes: #105 

Fix missed instances of the old way of setting the namespace in some of the .tpl files:

- autorecovery
- bookkeeper
- broker
- pulsar_manager
- toolset
- zookeeper

