### PR TITLE
Don't substitute environment variables

### DIFF
--- a/charts/pulsar/templates/bookkeeper/bookkeeper-autorecovery-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper/bookkeeper-autorecovery-statefulset.yaml
@@ -120,7 +120,6 @@ spec:
         args:
         - >
           bin/apply-config-from-env.py conf/bookkeeper.conf;
-          bin/apply-config-from-env.py conf/bkenv.sh;
           {{- include "pulsar.autorecovery.zookeeper.tls.settings" . | nindent 10 }}
           bin/bookkeeper autorecovery
         ports:

--- a/charts/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
@@ -149,7 +149,6 @@ spec:
         args:
         - >
           bin/apply-config-from-env.py conf/bookkeeper.conf;
-          bin/apply-config-from-env.py conf/pulsar_env.sh;
           {{- include "pulsar.bookkeeper.zookeeper.tls.settings" . | nindent 10 }}
           {{- if eq .Values.images.bookie.repository "streamnative/sn-pulsar" }}
           scripts/run-bookie.sh;

--- a/charts/pulsar/templates/broker/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker/broker-statefulset.yaml
@@ -181,7 +181,6 @@ spec:
         - >
           {{- include "pulsar.broker.kop.settings" . | nindent 10 }}
           bin/apply-config-from-env.py conf/broker.conf;
-          bin/apply-config-from-env.py conf/pulsar_env.sh;
           bin/gen-yml-from-env.py conf/functions_worker.yml;
           echo "OK" > status;
           {{- include "pulsar.broker.zookeeper.tls.settings" . | nindent 10 }}
@@ -191,7 +190,6 @@ spec:
             sleep 10;
             bin/pulsar zookeeper-shell -server {{ template "pulsar.zookeeper.connect" . }} get {{ template "pulsar.broker.znode" . }};
           done;
-          cat conf/pulsar_env.sh;
           bin/pulsar broker;
         ports:
         # prometheus needs to access /metrics endpoint

--- a/charts/pulsar/templates/proxy/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy/proxy-statefulset.yaml
@@ -163,7 +163,6 @@ spec:
           ls .;
           ls conf;
           bin/apply-config-from-env.py conf/proxy.conf;
-          bin/apply-config-from-env.py conf/pulsar_env.sh;
           echo "OK" > status;
           bin/pulsar proxy;
         ports:

--- a/charts/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
@@ -106,7 +106,6 @@ spec:
         args:
         - >
           bin/apply-config-from-env.py conf/zookeeper.conf;
-          bin/apply-config-from-env.py conf/pulsar_env.sh;
           {{- include "pulsar.zookeeper.tls.settings" . | nindent 10 }}
           bin/generate-zookeeper-config.sh conf/zookeeper.conf;
           bin/pulsar zookeeper;


### PR DESCRIPTION
*Motivation*

environment variables are already taken by bash scripts. We don't need to substitute them.