### PR TITLE
Fix empty redirect.host value

### DIFF
--- a/charts/pulsar/templates/control-center/_control_center.tpl
+++ b/charts/pulsar/templates/control-center/_control_center.tpl
@@ -6,11 +6,7 @@ control center domain
     {{- if .Values.ingress.control_center.external_domain }}
 {{- printf "%s" .Values.ingress.control_center.external_domain -}}
     {{- else -}}
-        {{- if .Values.domain.enabled }}
 {{- printf "admin.%s.%s" .Release.Name .Values.domain.suffix -}}
-        {{- else -}}
-{{- printf "" -}}
-        {{- end -}}
     {{- end -}}
 {{- else -}}
 {{- print "" -}}


### PR DESCRIPTION
*Motivation*

Fixes #111

In 1.2.1, we refactor the chart to support providing a domain suffix. This refactor
introduces an empty domain for control_center_domain.

*Modification*

Change the code to always generate a domain name for redirect.host.