### PR TITLE
A few enhancements for geo-replication

### DIFF
--- a/charts/pulsar/templates/_helpers.tpl
+++ b/charts/pulsar/templates/_helpers.tpl
@@ -77,3 +77,14 @@ Create the match labels.
 app: {{ template "pulsar.name" . }}
 release: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Pulsar Cluster Name.
+*/}}
+{{- define "pulsar.cluster" -}}
+{{- if .Values.pulsar_metadata.clusterName }}
+{{- .Values.pulsar_metadata.clusterName }}
+{{- else }}
+{{- template "pulsar.fullname" . }}
+{{- end }}
+{{- end }}

--- a/charts/pulsar/templates/broker/broker-configmap.yaml
+++ b/charts/pulsar/templates/broker/broker-configmap.yaml
@@ -37,11 +37,7 @@ data:
   {{- end }}
 
   # Broker settings
-  {{- if .Values.pulsar_metadata.clusterName }}
-  clusterName: {{ .Values.pulsar_metadata.clusterName }}
-  {{- else }}
-  clusterName: {{ template "pulsar.fullname" . }}
-  {{- end }}
+  clusterName: "{{ template "pulsar.cluster" . }}"
   exposeTopicLevelMetricsInPrometheus: "true"
   numHttpServerThreads: "8"
   zooKeeperSessionTimeoutMillis: "30000"

--- a/charts/pulsar/templates/broker/broker-configmap.yaml
+++ b/charts/pulsar/templates/broker/broker-configmap.yaml
@@ -37,7 +37,11 @@ data:
   {{- end }}
 
   # Broker settings
+  {{- if .Values.pulsar_metadata.clusterName }}
+  clusterName: {{ .Values.pulsar_metadata.clusterName }}
+  {{- else }}
   clusterName: {{ template "pulsar.fullname" . }}
+  {{- end }}
   exposeTopicLevelMetricsInPrometheus: "true"
   numHttpServerThreads: "8"
   zooKeeperSessionTimeoutMillis: "30000"

--- a/charts/pulsar/templates/broker/broker-service-ingress.yaml
+++ b/charts/pulsar/templates/broker/broker-service-ingress.yaml
@@ -1,0 +1,63 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+{{- if and .Values.components.broker .Values.ingress.broker.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-ingress"
+  namespace: {{ template "pulsar.namespace" . }}
+  labels:
+    {{- include "pulsar.standardLabels" . | nindent 4 }}
+    component: {{ .Values.broker.component }}
+  annotations:
+  {{- with .Values.ingress.broker.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.ingress.broker.type }}
+  ports:
+  # prometheus needs to access /metrics endpoint
+  - name: http
+    port: {{ .Values.broker.ports.http }}
+  {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
+  - name: https
+    port: {{ .Values.broker.ports.https }}
+  - name: pulsarssl
+    port: {{ .Values.broker.ports.pulsarssl }}
+  {{- if .Values.components.kop }}
+  - name: kafkassl
+    port: {{ .Values.kop.ports.ssl }}
+  {{- end }}
+  {{- else }}
+  - name: pulsar
+    port: {{ .Values.broker.ports.pulsar }}
+  {{- if .Values.components.kop }}
+  - name: kafkaPlainText
+    port: {{ .Values.kop.ports.plaintext }}
+  {{- end }}
+  {{- end }}
+  selector:
+    app: {{ template "pulsar.name" . }}
+    release: {{ .Release.Name }}
+    component: {{ .Values.broker.component }}
+  {{- with .Values.ingress.broker.extraSpec }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/pulsar/templates/broker/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker/broker-statefulset.yaml
@@ -99,10 +99,10 @@ spec:
           - >-
             {{- include "pulsar.broker.zookeeper.tls.settings" . | nindent 12 }}
             {{- if .Values.pulsar_metadata.configurationStore }}
-            until bin/bookkeeper org.apache.zookeeper.ZooKeeperMain -server {{ .Values.pulsar_metadata.configurationStore}} get {{ .Values.configurationStoreMetadataPrefix }}/admin/clusters/{{ template "pulsar.fullname" . }}; do
+            until bin/bookkeeper org.apache.zookeeper.ZooKeeperMain -server {{ .Values.pulsar_metadata.configurationStore}} get {{ .Values.configurationStoreMetadataPrefix }}/admin/clusters/"{{ template "pulsar.cluster" . }}"; do
             {{- end }}
             {{- if not .Values.pulsar_metadata.configurationStore }}
-            until bin/bookkeeper org.apache.zookeeper.ZooKeeperMain -server {{ template "pulsar.zookeeper.connect" . }} get {{ .Values.metadataPrefix }}/admin/clusters/{{ template "pulsar.fullname" . }}; do
+            until bin/bookkeeper org.apache.zookeeper.ZooKeeperMain -server {{ template "pulsar.zookeeper.connect" . }} get {{ .Values.metadataPrefix }}/admin/clusters/{{ template "pulsar.cluster" . }}; do
             {{- end }}
               echo "pulsar cluster {{ template "pulsar.fullname" . }} isn't initialized yet ... check in 3 seconds ..." && sleep 3;
             done;

--- a/charts/pulsar/templates/broker/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker/broker-statefulset.yaml
@@ -214,6 +214,13 @@ spec:
           containerPort: {{ .Values.kop.ports.plaintext }}
         {{- end }}
         {{- end }}
+        env:
+        {{- if .Values.broker.advertisedPodIP }}
+        - name: advertisedAddress
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        {{- end }}
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"

--- a/charts/pulsar/templates/detector/pulsar-detector-statefulset.yaml
+++ b/charts/pulsar/templates/detector/pulsar-detector-statefulset.yaml
@@ -53,7 +53,7 @@ spec:
         command: ["sh", "-c"]
         args:
           - >-
-            until bin/pulsar zookeeper-shell -server {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }} get {{ .Values.metadataPrefix }}/admin/clusters/{{ template "pulsar.fullname" . }}; do
+            until bin/pulsar zookeeper-shell -server {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }} get {{ .Values.metadataPrefix }}/admin/clusters/{{ template "pulsar.cluster" . }}; do
               sleep 3;
             done;
       # This init container will wait for at least one broker to be ready before

--- a/charts/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/charts/pulsar/templates/proxy/proxy-configmap.yaml
@@ -27,7 +27,11 @@ metadata:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.proxy.component }}
 data:
+  {{- if .Values.pulsar_metadata.clusterName }}
+  clusterName: {{ .Values.pulsar_metadata.clusterName }}
+  {{- else }}
   clusterName: {{ template "pulsar.fullname" . }}
+  {{- end }}
   httpNumThreads: "8"
   statusFilePath: "{{ template "pulsar.home" . }}/status"
   # prometheus needs to access /metrics endpoint

--- a/charts/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/charts/pulsar/templates/proxy/proxy-configmap.yaml
@@ -27,11 +27,7 @@ metadata:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.proxy.component }}
 data:
-  {{- if .Values.pulsar_metadata.clusterName }}
-  clusterName: {{ .Values.pulsar_metadata.clusterName }}
-  {{- else }}
-  clusterName: {{ template "pulsar.fullname" . }}
-  {{- end }}
+  clusterName: {{ template "pulsar.cluster" . }}
   httpNumThreads: "8"
   statusFilePath: "{{ template "pulsar.home" . }}/status"
   # prometheus needs to access /metrics endpoint

--- a/charts/pulsar/templates/proxy/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy/proxy-statefulset.yaml
@@ -97,7 +97,7 @@ spec:
         command: ["sh", "-c"]
         args:
           - >-
-            until bin/pulsar zookeeper-shell -server {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }} get {{ .Values.metadataPrefix }}/admin/clusters/{{ template "pulsar.fullname" . }}; do
+            until bin/pulsar zookeeper-shell -server {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }} get {{ .Values.metadataPrefix }}/admin/clusters/{{ template "pulsar.cluster" . }}; do
               sleep 3;
             done;
       # This init container will wait for at least one broker to be ready before

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -749,7 +749,7 @@ broker:
   tolerations: []
   securityContext: {}
   gracePeriod: 30
-  # flag to advertise pod ip address  
+  # flag to advertise pod ip address
   advertisedPodIP: false
   resources:
     requests:

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -328,6 +328,14 @@ ingress:
     type: LoadBalancer
     annotations: {}
     extraSpec: {}
+  ## templates/broker-service-ingress.yaml
+  ##
+  ## Ingresses for exposing pulsar service publicly
+  broker:
+    enabled: false
+    type: LoadBalancer
+    annotations: {}
+    extraSpec: {}
   ## templates/control-center-ingress.yaml
   ##
   ## Ingresses for exposing monitoring/management services publicly
@@ -694,6 +702,9 @@ pulsar_metadata:
   ## set an existing configuration store
   # configurationStore:
   configurationStoreMetadataPrefix: ""
+  # set the cluster name. if empty or not specified,
+  # it will use helm release name to generate a cluster name.
+  clusterName: ""
 
 ## Pulsar: KoP Protocol Handler
 kop:
@@ -738,6 +749,8 @@ broker:
   tolerations: []
   securityContext: {}
   gracePeriod: 30
+  # flag to advertise pod ip address  
+  advertisedPodIP: false
   resources:
     requests:
       memory: 512Mi


### PR DESCRIPTION
- Allow broker to advertise PodIP as the broker addresses. This would simplify vpc peering setup.
- Add `clusterName` setting. So the cluster name can be set separately.
- Add a broker ingress. The broker integress can be used for internal accesses (including geo-replication).