### PR TITLE
Changes to support migrating a Pulsar cluster to another

### DIFF
--- a/.ci/clusters/values-bk-tls.yaml
+++ b/.ci/clusters/values-bk-tls.yaml
@@ -18,13 +18,16 @@
 #
 
 components:
+  # disable auto recovery
   pulsar_manager: false
+  autorecovery: false
 
 monitoring:
   prometheus: false
   grafana: false
   node_exporter: false
   alert_manager: false
+  loki: false
 
 volumes:
   local_storage: true
@@ -32,10 +35,6 @@ volumes:
 # disabled AntiAffinity
 affinity:
   anti_affinity: false
-
-# disable auto recovery
-components:
-  autorecovery: false
 
 zookeeper:
   replicaCount: 1

--- a/.ci/clusters/values-broker-tls.yaml
+++ b/.ci/clusters/values-broker-tls.yaml
@@ -19,12 +19,15 @@
 
 components:
   pulsar_manager: false
+  # disable auto recovery
+  autorecovery: false
 
 monitoring:
   prometheus: false
   grafana: false
   node_exporter: false
   alert_manager: false
+  loki: false
 
 volumes:
   local_storage: true
@@ -32,10 +35,6 @@ volumes:
 # disabled AntiAffinity
 affinity:
   anti_affinity: false
-
-# disable auto recovery
-components:
-  autorecovery: false
 
 zookeeper:
   replicaCount: 1

--- a/.ci/clusters/values-function.yaml
+++ b/.ci/clusters/values-function.yaml
@@ -19,12 +19,15 @@
 
 components:
   pulsar_manager: false
+  # disable auto recovery
+  autorecovery: false
 
 monitoring:
   prometheus: false
   grafana: false
   node_exporter: false
   alert_manager: false
+  loki: false
 
 volumes:
   local_storage: true
@@ -32,10 +35,6 @@ volumes:
 # disabled AntiAffinity
 affinity:
   anti_affinity: false
-
-# disable auto recovery
-components:
-  autorecovery: false
 
 zookeeper:
   replicaCount: 1

--- a/.ci/clusters/values-jwt-asymmetric.yaml
+++ b/.ci/clusters/values-jwt-asymmetric.yaml
@@ -19,12 +19,15 @@
 
 components:
   pulsar_manager: false
+  # disable auto recovery
+  autorecovery: false
 
 monitoring:
   prometheus: false
   grafana: false
   node_exporter: false
   alert_manager: false
+  loki: false
 
 volumes:
   local_storage: true
@@ -32,10 +35,6 @@ volumes:
 # disabled AntiAffinity
 affinity:
   anti_affinity: false
-
-# disable auto recovery
-components:
-  autorecovery: false
 
 zookeeper:
   replicaCount: 1

--- a/.ci/clusters/values-jwt-symmetric.yaml
+++ b/.ci/clusters/values-jwt-symmetric.yaml
@@ -19,12 +19,15 @@
 
 components:
   pulsar_manager: false
+  # disable auto recovery
+  autorecovery: false
 
 monitoring:
   prometheus: false
   grafana: false
   node_exporter: false
   alert_manager: false
+  loki: false
 
 volumes:
   local_storage: true
@@ -32,10 +35,6 @@ volumes:
 # disabled AntiAffinity
 affinity:
   anti_affinity: false
-
-# disable auto recovery
-components:
-  autorecovery: false
 
 zookeeper:
   replicaCount: 1

--- a/.ci/clusters/values-local-pv.yaml
+++ b/.ci/clusters/values-local-pv.yaml
@@ -19,23 +19,22 @@
 
 components:
   pulsar_manager: false
+  # disable auto recovery
+  autorecovery: false
 
 monitoring:
   prometheus: false
   grafana: false
   node_exporter: false
   alert_manager: false
+  loki: false
 
 volumes:
-  local_storage: true
+  local_storage: false
 
 # disabled AntiAffinity
 affinity:
   anti_affinity: false
-
-# disable auto recovery
-components:
-  autorecovery: false
 
 zookeeper:
   replicaCount: 1

--- a/.ci/clusters/values-pulsar-image.yaml
+++ b/.ci/clusters/values-pulsar-image.yaml
@@ -19,12 +19,15 @@
 
 components:
   pulsar_manager: false
+  # disable auto recovery
+  autorecovery: false
 
 monitoring:
   prometheus: false
   grafana: false
   node_exporter: false
   alert_manager: false
+  loki: false
 
 volumes:
   persistence: false
@@ -32,10 +35,6 @@ volumes:
 # disabled AntiAffinity
 affinity:
   anti_affinity: false
-
-# disable auto recovery
-components:
-  autorecovery: false
 
 zookeeper:
   replicaCount: 1
@@ -74,24 +73,24 @@ toolset:
 images:
   zookeeper:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: latest
   bookie:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: latest
   autorecovery:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: latest
   broker:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: latest
   functions:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: latest
   proxy:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: latest
 
 pulsar_metadata:
   image:
     repository: apachepulsar/pulsar-all
-    tag: 2.5.0
+    tag: latest

--- a/.ci/clusters/values-tls.yaml
+++ b/.ci/clusters/values-tls.yaml
@@ -19,12 +19,15 @@
 
 components:
   pulsar_manager: false
+  # disable auto recovery
+  autorecovery: false
 
 monitoring:
   prometheus: false
   grafana: false
   node_exporter: false
   alert_manager: false
+  loki: false
 
 volumes:
   local_storage: true
@@ -32,10 +35,6 @@ volumes:
 # disabled AntiAffinity
 affinity:
   anti_affinity: false
-
-# disable auto recovery
-components:
-  autorecovery: false
 
 zookeeper:
   replicaCount: 1

--- a/.ci/clusters/values-zk-tls.yaml
+++ b/.ci/clusters/values-zk-tls.yaml
@@ -19,12 +19,15 @@
 
 components:
   pulsar_manager: false
+  # disable auto recovery
+  autorecovery: false
 
 monitoring:
   prometheus: false
   grafana: false
   node_exporter: false
   alert_manager: false
+  loki: false
 
 volumes:
   local_storage: true
@@ -32,10 +35,6 @@ volumes:
 # disabled AntiAffinity
 affinity:
   anti_affinity: false
-
-# disable auto recovery
-components:
-  autorecovery: false
 
 zookeeper:
   replicaCount: 1

--- a/.ci/clusters/values-zkbk-tls.yaml
+++ b/.ci/clusters/values-zkbk-tls.yaml
@@ -19,12 +19,15 @@
 
 components:
   pulsar_manager: false
+  # disable auto recovery
+  autorecovery: false
 
 monitoring:
   prometheus: false
   grafana: false
   node_exporter: false
   alert_manager: false
+  loki: false
 
 volumes:
   local_storage: true
@@ -32,10 +35,6 @@ volumes:
 # disabled AntiAffinity
 affinity:
   anti_affinity: false
-
-# disable auto recovery
-components:
-  autorecovery: false
 
 zookeeper:
   replicaCount: 1

--- a/.ci/helm.sh
+++ b/.ci/helm.sh
@@ -117,6 +117,8 @@ function ci::test_pulsar_producer() {
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-bookie-0 -- cat conf/bookkeeper.conf
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/bookkeeper shell listbookies -rw
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/bookkeeper shell listbookies -ro
+    ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-admin clusters list
+    ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-admin clusters get pulsar-ci
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-admin tenants create --allowed-clusters pulsar-ci pulsar-ci
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-admin namespaces create pulsar-ci/test
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-client produce -m "test-message" pulsar-ci/test/test-topic

--- a/.ci/helm.sh
+++ b/.ci/helm.sh
@@ -117,7 +117,7 @@ function ci::test_pulsar_producer() {
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-bookie-0 -- cat conf/bookkeeper.conf
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/bookkeeper shell listbookies -rw
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/bookkeeper shell listbookies -ro
-    ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-admin tenants create pulsar-ci
+    ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-admin tenants create --allowed-clusters pulsar-ci pulsar-ci
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-admin namespaces create pulsar-ci/test
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-client produce -m "test-message" pulsar-ci/test/test-topic
 }

--- a/.ci/helm.sh
+++ b/.ci/helm.sh
@@ -119,28 +119,27 @@ function ci::test_pulsar_producer() {
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/bookkeeper shell listbookies -ro
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-admin clusters list
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-admin clusters get pulsar-ci
-    ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-admin tenants create --allowed-clusters pulsar-ci pulsar-ci
-    ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-admin namespaces create pulsar-ci/test
-    ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-client produce -m "test-message" pulsar-ci/test/test-topic
+    ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-admin namespaces create public/test
+    ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-client produce -m "test-message" public/test/test-topic
 }
 
 function ci::wait_function_running() {
-    num_running=$(${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bash -c 'bin/pulsar-admin functions status --tenant pulsar-ci --namespace test --name test-function | bin/jq .numRunning') 
+    num_running=$(${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bash -c 'bin/pulsar-admin functions status --tenant public --namespace test --name test-function | bin/jq .numRunning') 
     while [[ ${num_running} -lt 1 ]]; do
       echo ${num_running}
       sleep 15
       ${KUBECTL} get pods -n ${NAMESPACE} --field-selector=status.phase=Running
-      num_running=$(${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bash -c 'bin/pulsar-admin functions status --tenant pulsar-ci --namespace test --name test-function | bin/jq .numRunning') 
+      num_running=$(${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bash -c 'bin/pulsar-admin functions status --tenant public --namespace test --name test-function | bin/jq .numRunning') 
     done
 }
 
 function ci::wait_message_processed() {
-    num_processed=$(${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bash -c 'bin/pulsar-admin functions stats --tenant pulsar-ci --namespace test --name test-function | bin/jq .processedSuccessfullyTotal') 
+    num_processed=$(${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bash -c 'bin/pulsar-admin functions stats --tenant public --namespace test --name test-function | bin/jq .processedSuccessfullyTotal') 
     while [[ ${num_processed} -lt 1 ]]; do
       echo ${num_processed}
       sleep 15
-      ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-admin functions stats --tenant pulsar-ci --namespace test --name test-function
-      num_processed=$(${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bash -c 'bin/pulsar-admin functions stats --tenant pulsar-ci --namespace test --name test-function | bin/jq .processedSuccessfullyTotal') 
+      ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-admin functions stats --tenant public --namespace test --name test-function
+      num_processed=$(${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bash -c 'bin/pulsar-admin functions stats --tenant public --namespace test --name test-function | bin/jq .processedSuccessfullyTotal') 
     done
 }
 
@@ -153,11 +152,11 @@ function ci::test_pulsar_function() {
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/bookkeeper shell listbookies -ro
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- curl --retry 10 -L -o bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
     ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- chmod +x bin/jq
-    ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-admin functions create --tenant pulsar-ci --namespace test --name test-function --inputs "pulsar-ci/test/test_input" --output "pulsar-ci/test/test_output" --parallelism 1 --classname org.apache.pulsar.functions.api.examples.ExclamationFunction --jar /pulsar/examples/api-examples.jar
+    ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-admin functions create --tenant public --namespace test --name test-function --inputs "public/test/test_input" --output "public/test/test_output" --parallelism 1 --classname org.apache.pulsar.functions.api.examples.ExclamationFunction --jar /pulsar/examples/api-examples.jar
 
     # wait until the function is running
     # TODO: re-enable function test
     # ci::wait_function_running
-    # ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-client produce -m "hello pulsar function!" pulsar-ci/test/test_input
+    # ${KUBECTL} exec -n ${NAMESPACE} ${CLUSTER}-toolset-0 -- bin/pulsar-client produce -m "hello pulsar function!" public/test/test_input
     # ci::wait_message_processed
 }

--- a/charts/pulsar/templates/control-center/control-center-ingress.yaml
+++ b/charts/pulsar/templates/control-center/control-center-ingress.yaml
@@ -80,5 +80,10 @@ spec:
             backend:
               serviceName: "{{ $fullName }}-{{ .Values.pulsar_manager.component }}"
               servicePort: {{ .Values.pulsar_manager.ports.frontend }}
+          {{- else }}
+          - path: /
+            backend:
+              serviceName: default
+              servicePort: 80
           {{- end }}
 {{- end }}

--- a/charts/pulsar/templates/proxy/_proxy.tpl
+++ b/charts/pulsar/templates/proxy/_proxy.tpl
@@ -191,3 +191,47 @@ pulsar ingress target port for http endpoint
 {{- print "pulsar" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Pulsar Broker Service URL
+*/}}
+{{- define "pulsar.proxy.broker.service.url" -}}
+{{- if .Values.proxy.brokerServiceURL -}}
+{{- .Values.proxy.brokerServiceURL -}}
+{{- else -}}
+pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.pulsar }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Pulsar Web Service URL
+*/}}
+{{- define "pulsar.proxy.web.service.url" -}}
+{{- if .Values.proxy.brokerWebServiceURL -}}
+{{- .Values.proxy.brokerWebServiceURL -}}
+{{- else -}}
+http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.http }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Pulsar Broker Service URL TLS
+*/}}
+{{- define "pulsar.proxy.broker.service.url.tls" -}}
+{{- if .Values.proxy.brokerServiceURLTLS -}}
+{{- .Values.proxy.brokerServiceURLTLS -}}
+{{- else -}}
+pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.pulsarssl }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Pulsar Web Service URL
+*/}}
+{{- define "pulsar.proxy.web.service.url.tls" -}}
+{{- if .Values.proxy.brokerWebServiceURLTLS -}}
+{{- .Values.proxy.brokerWebServiceURLTLS -}}
+{{- else -}}
+https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.https }}
+{{- end -}}
+{{- end -}}

--- a/charts/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/charts/pulsar/templates/proxy/proxy-configmap.yaml
@@ -34,8 +34,8 @@ data:
   webServicePort: "{{ .Values.proxy.ports.http }}"
   {{- if or (not .Values.tls.enabled) (not .Values.tls.proxy.enabled) }}
   servicePort: "{{ .Values.proxy.ports.pulsar }}"
-  brokerServiceURL: pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.pulsar }}
-  brokerWebServiceURL: http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.http }}
+  brokerServiceURL: {{ template "pulsar.proxy.broker.service.url" . }} 
+  brokerWebServiceURL: {{ template "pulsar.proxy.web.service.url" . }}  
   {{- end }}
   {{- if and .Values.tls.enabled .Values.tls.proxy.enabled }}
   tlsEnabledInProxy: "true"
@@ -47,15 +47,15 @@ data:
   {{- end }}
   {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
   # if broker enables TLS, configure proxy to talk to broker using TLS
-  brokerServiceURLTLS: pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.pulsarssl }}
-  brokerWebServiceURLTLS: https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.https }}
+  brokerServiceURLTLS: {{ template "pulsar.proxy.broker.service.url.tls" . }}
+  brokerWebServiceURLTLS: {{ template "pulsar.proxy.web.service.url.tls" . }} 
   tlsEnabledWithBroker: "true"
   tlsCertRefreshCheckDurationSec: "300"
   brokerClientTrustCertsFilePath: "/pulsar/certs/broker/ca.crt"
   {{- end }}
   {{- if not (and .Values.tls.enabled .Values.tls.broker.enabled) }}
-  brokerServiceURL: pulsar://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.pulsar }}
-  brokerWebServiceURL: http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.http }}
+  brokerServiceURL: {{ template "pulsar.proxy.broker.service.url" . }} 
+  brokerWebServiceURL: {{ template "pulsar.proxy.web.service.url" . }}  
   {{- end }}
 
   # Authentication Settings

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -89,7 +89,7 @@ spec:
           - >
             {{- include "pulsar.toolset.zookeeper.tls.settings" . | nindent 12 }}
             bin/pulsar initialize-cluster-metadata \
-              --cluster {{ template "pulsar.fullname" . }} \
+              --cluster {{ template "pulsar.cluster" . }} \
               --zookeeper {{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }} \
               {{- if .Values.pulsar_metadata.configurationStore }}
               --configuration-store {{ .Values.pulsar_metadata.configurationStore }}{{ .Values.pulsar_metadata.configurationStoreMetadataPrefix }} \

--- a/charts/pulsar/templates/zookeeper/gen-zk-conf.yaml
+++ b/charts/pulsar/templates/zookeeper/gen-zk-conf.yaml
@@ -32,6 +32,7 @@ data:
     
     CONF_FILE=$1
     IDX=$2
+    PEER_TYPE=$3
     
     if [ $? != 0 ]; then
         echo "Error: Failed to apply changes to config file"
@@ -45,7 +46,7 @@ data:
     ((IDX++))
     for SERVER in $(echo $ZOOKEEPER_SERVERS | tr "," "\n")
     do
-        echo "server.$IDX=$SERVER.$DOMAIN:2888:3888" >> $CONF_FILE
+        echo "server.$IDX=$SERVER.$DOMAIN:2888:3888:${PEER_TYPE};2181" >> $CONF_FILE
     
         if [ "$HOSTNAME" == "$SERVER" ]; then
             MY_ID=$IDX

--- a/charts/pulsar/templates/zookeeper/zookeeper-configmap.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-configmap.yaml
@@ -42,9 +42,9 @@ data:
   {{- end }}
   {{- if .Values.zookeeper.reconfig.enabled }}
   PULSAR_PREFIX_reconfigEnabled: "true"
-  PULSAR_PREFIX_peerType: {{ .Values.zookeeper.reconfig.peerType }}
   PULSAR_PREFIX_quorumListenOnAllIPs: "true"
   {{- end }}
+  PULSAR_PREFIX_peerType: {{ .Values.zookeeper.peerType }}
 {{ toYaml .Values.zookeeper.configData | indent 2 }}
   # Include log configuration file, If you want to configure the log level and other configuration
   # items, you can modify the configmap, and eventually it will overwrite the log4j2.yaml file under conf

--- a/charts/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
@@ -102,17 +102,15 @@ spec:
 {{ toYaml .Values.zookeeper.resources | indent 10 }}
       {{- end }}
         command: ["sh", "-c"]
-        # PULSAR_EXTRA_OPTS="${PULSAR_EXTRA_OPTS} -Dzookeeper.serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory -Dzookeeper.ssl.keyStore.location=/pulsar/certs/zookeeper/tls.key -Dzookeeper.ssl.trustStore.location=/pulsar/certs/ca/ca.crt"
         args:
         - >
           bin/apply-config-from-env.py conf/zookeeper.conf;
           {{- include "pulsar.zookeeper.tls.settings" . | nindent 10 }}
-          {{- if .Values.zookeeper.reconfig.enabled }}
           {{- range $server := .Values.zookeeper.reconfig.zkServers }}
           echo "{{ $server }}" >> conf/zookeeper.conf;
           {{- end }}
-          {{- end }}
-          bin/gen-zk-conf.sh conf/zookeeper.conf {{ .Values.zookeeper.initialMyId }};
+          bin/gen-zk-conf.sh conf/zookeeper.conf {{ .Values.zookeeper.initialMyId }} {{ .Values.zookeeper.peerType }};
+          cat conf/zookeeper.conf;
           bin/pulsar zookeeper;
         ports:
         - name: metrics

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -115,35 +115,35 @@ monitoring:
 images:
   zookeeper:
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-2
+    tag: 2.6.0-sn-3
     pullPolicy: IfNotPresent
   bookie:
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-2
+    tag: 2.6.0-sn-3
     pullPolicy: IfNotPresent
   presto:
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-2
+    tag: 2.6.0-sn-3
     pullPolicy: IfNotPresent
   autorecovery:
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-2
+    tag: 2.6.0-sn-3
     pullPolicy: IfNotPresent
   broker:
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-2
+    tag: 2.6.0-sn-3
     pullPolicy: IfNotPresent
   proxy:
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-2
+    tag: 2.6.0-sn-3
     pullPolicy: IfNotPresent
   pulsar_detector:
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-2
+    tag: 2.6.0-sn-3
     pullPolicy: IfNotPresent
   functions:
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-2
+    tag: 2.6.0-sn-3
     pullPolicy: IfNotPresent
   prometheus:
     repository: prom/prometheus
@@ -689,7 +689,7 @@ pulsar_metadata:
     # repository: apachepulsar/pulsar-all
     # tag: 2.5.0
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-2
+    tag: 2.6.0-sn-3
     pullPolicy: IfNotPresent
   ## set an existing configuration store
   # configurationStore:

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -115,35 +115,35 @@ monitoring:
 images:
   zookeeper:
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-3
+    tag: 2.6.0-sn-4
     pullPolicy: IfNotPresent
   bookie:
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-3
+    tag: 2.6.0-sn-4
     pullPolicy: IfNotPresent
   presto:
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-3
+    tag: 2.6.0-sn-4
     pullPolicy: IfNotPresent
   autorecovery:
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-3
+    tag: 2.6.0-sn-4
     pullPolicy: IfNotPresent
   broker:
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-3
+    tag: 2.6.0-sn-4
     pullPolicy: IfNotPresent
   proxy:
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-3
+    tag: 2.6.0-sn-4
     pullPolicy: IfNotPresent
   pulsar_detector:
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-3
+    tag: 2.6.0-sn-4
     pullPolicy: IfNotPresent
   functions:
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-3
+    tag: 2.6.0-sn-4
     pullPolicy: IfNotPresent
   prometheus:
     repository: prom/prometheus
@@ -689,7 +689,7 @@ pulsar_metadata:
     # repository: apachepulsar/pulsar-all
     # tag: 2.5.0
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-3
+    tag: 2.6.0-sn-4
     pullPolicy: IfNotPresent
   ## set an existing configuration store
   # configurationStore:

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -115,35 +115,35 @@ monitoring:
 images:
   zookeeper:
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-candidate-2
+    tag: 2.6.0-sn-2
     pullPolicy: IfNotPresent
   bookie:
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-candidate-2
+    tag: 2.6.0-sn-2
     pullPolicy: IfNotPresent
   presto:
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-candidate-2
+    tag: 2.6.0-sn-2
     pullPolicy: IfNotPresent
   autorecovery:
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-candidate-2
+    tag: 2.6.0-sn-2
     pullPolicy: IfNotPresent
   broker:
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-candidate-2
+    tag: 2.6.0-sn-2
     pullPolicy: IfNotPresent
   proxy:
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-candidate-2
+    tag: 2.6.0-sn-2
     pullPolicy: IfNotPresent
   pulsar_detector:
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-candidate-2
+    tag: 2.6.0-sn-2
     pullPolicy: IfNotPresent
   functions:
     repository: streamnative/pulsar-all
-    tag: 2.6.0-sn-candidate-2
+    tag: 2.6.0-sn-2
     pullPolicy: IfNotPresent
   prometheus:
     repository: prom/prometheus
@@ -238,6 +238,8 @@ auth:
     proxy: "proxy-admin"
     # pulsar-admin client to broker/proxy communication
     client: "admin"
+    # pulsar-manager to broker/proxy communication
+    pulsar_manager: "pulsar-manager-admin"
   # Enable vault based authentication
   vault:
     enabled: false
@@ -476,15 +478,12 @@ zookeeper:
   ##
   # The initial myid used for generating myid for each zookeeper pod.
   initialMyId: 0
+  peerType: "participant"
   # reconfig settings
   reconfig:
     enabled: false
-    peerType: "observer"
     # The zookeeper servers to observe/join
-    zkServers:
-    - server.1=platform-pulsar-zookeeper-0.platform-pulsar-zookeeper.pulsar.svc.cluster.local:2888:3888:participant
-    - server.2=platform-pulsar-zookeeper-1.platform-pulsar-zookeeper.pulsar.svc.cluster.local:2888:3888:participant
-    - server.3=platform-pulsar-zookeeper-2.platform-pulsar-zookeeper.pulsar.svc.cluster.local:2888:3888:participant
+    zkServers: []
   # Automtically Roll Deployments when configmap is changed
   autoRollDeployment: true
   configData:
@@ -689,8 +688,8 @@ pulsar_metadata:
     # the image used for running `pulsar-cluster-initialize` job
     # repository: apachepulsar/pulsar-all
     # tag: 2.5.0
-    repository: streamnative/platform
-    tag: v1.0.0
+    repository: streamnative/pulsar-all
+    tag: 2.6.0-sn-2
     pullPolicy: IfNotPresent
   ## set an existing configuration store
   # configurationStore:
@@ -890,6 +889,11 @@ proxy:
   ##
   # Automtically Roll Deployments when configmap is changed
   autoRollDeployment: true
+  # Config proxy to point to an existing broker clusters
+  brokerServiceURL: ""
+  brokerWebServiceURL: ""
+  brokerServiceURLTLS: ""
+  brokerWebServiceURLTLS: ""
   configData:
     PULSAR_MEM: >
       -Xms64m -Xmx64m -XX:MaxDirectMemorySize=64m


### PR DESCRIPTION
*Modifications*

Fixes #113 

- zookeeper: bug fixes to support adding zookeeper pods as observers to an existing zookeeper cluster
- proxy: allow proxy to be configured to use an existing broker cluster
- pulsar-manager: fix pulsar-manager secrets