### PR TITLE
Update grafana dashboard image version to 0.0.9

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -155,7 +155,7 @@ images:
     pullPolicy: IfNotPresent
   grafana:
     repository: streamnative/apache-pulsar-grafana-dashboard-k8s
-    tag: 0.0.8
+    tag: 0.0.9
     pullPolicy: IfNotPresent
   pulsar_manager:
     repository: streamnative/pulsar-manager


### PR DESCRIPTION
Signed-off-by: xiaolong.ran <rxl@apache.org>

- Update grafana dashboard image version to 0.0.9