### PR TITLE
add storageClassNames to values and all stateful components

### DIFF
--- a/charts/pulsar/templates/bookkeeper/_bookkeeper.tpl
+++ b/charts/pulsar/templates/bookkeeper/_bookkeeper.tpl
@@ -31,20 +31,26 @@ Define bookie zookeeper client tls settings
 {{- end }}
 
 {{- define "pulsar.bookkeeper.journal.storage.class" -}}
-{{- if and (not (and .Values.volumes.local_storage .Values.bookkeeper.volumes.journal.local_storage)) .Values.bookkeeper.volumes.journal.storageClass }}
-{{ template "pulsar.bookkeeper.journal.pvc.name" . }}
-{{- end }}
 {{- if and .Values.volumes.local_storage .Values.bookkeeper.volumes.journal.local_storage }}
-{{- print "local-storage" -}}
+  {{- print "local-storage" -}}
+{{- else }}
+  {{- if  .Values.bookkeeper.volumes.journal.storageClass }}
+    {{ template "pulsar.bookkeeper.journal.pvc.name" . }}
+  {{- else if .Values.bookkeeper.volumes.journal.storageClassName }}
+    {{- print .Values.bookkeeper.volumes.journal.storageClassName }}
+  {{- end -}}
 {{- end }}
 {{- end }}
 
 {{- define "pulsar.bookkeeper.ledgers.storage.class" -}}
-{{- if and (not (and .Values.volumes.local_storage .Values.bookkeeper.volumes.ledgers.local_storage)) .Values.bookkeeper.volumes.ledgers.storageClass }}
-{{ template "pulsar.bookkeeper.ledgers.pvc.name" . }}
-{{- end -}}
 {{- if and .Values.volumes.local_storage .Values.bookkeeper.volumes.ledgers.local_storage }}
-{{- print "local-storage" -}}
+  {{- print "local-storage" -}}
+{{- else }}
+  {{- if  .Values.bookkeeper.volumes.ledgers.storageClass }}
+    {{ template "pulsar.bookkeeper.ledgers.pvc.name" . }}
+  {{- else if .Values.bookkeeper.volumes.ledgers.storageClassName }}
+    {{- print .Values.bookkeeper.volumes.ledgers.storageClassName }}
+  {{- end -}}
 {{- end }}
 {{- end }}
 

--- a/charts/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
@@ -205,11 +205,14 @@ spec:
       resources:
         requests:
           storage: {{ .Values.bookkeeper.volumes.journal.size }}
-    {{- if and (not (and .Values.volumes.local_storage .Values.bookkeeper.volumes.journal.local_storage)) .Values.bookkeeper.volumes.journal.storageClass }}
-      storageClassName: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.journal.name }}"
-    {{- end }}
     {{- if and .Values.volumes.local_storage .Values.bookkeeper.volumes.journal.local_storage }}
       storageClassName: "local-storage"
+    {{- else }}
+      {{- if  .Values.bookkeeper.volumes.journal.storageClass }}
+      storageClassName: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.journal.name }}"
+      {{- else if .Values.bookkeeper.volumes.journal.storageClassName }}
+      storageClassName: {{ .Values.bookkeeper.volumes.journal.storageClassName }}
+      {{- end -}}
     {{- end }}
   - metadata:
       name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.ledgers.name }}"
@@ -218,11 +221,14 @@ spec:
       resources:
         requests:
           storage: {{ .Values.bookkeeper.volumes.ledgers.size }}
-    {{- if and (not (and .Values.volumes.local_storage .Values.bookkeeper.volumes.ledgers.local_storage)) .Values.bookkeeper.volumes.ledgers.storageClass }}
-      storageClassName: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.ledgers.name }}"
-    {{- end }}
-    {{- if and .Values.volumes.local_storage .Values.bookkeeper.volumes.ledgers.local_storage }}
+    {{- if and .Values.volumes.local_storage .Values.bookkeeper.volumes.journal.local_storage }}
       storageClassName: "local-storage"
+    {{- else }}
+      {{- if  .Values.bookkeeper.volumes.journal.storageClass }}
+      storageClassName: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.journal.name }}"
+      {{- else if .Values.bookkeeper.volumes.journal.storageClassName }}
+      storageClassName: {{ .Values.bookkeeper.volumes.journal.storageClassName }}
+      {{- end -}}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/pulsar/templates/prometheus/prometheus-pvc.yaml
+++ b/charts/pulsar/templates/prometheus/prometheus-pvc.yaml
@@ -29,11 +29,14 @@ spec:
     requests:
       storage: {{ .Values.prometheus.volumes.data.size }}
   accessModes: [ "ReadWriteOnce" ]
-{{- if and (not (and .Values.volumes.local_storage .Values.prometheus.volumes.data.local_storage)) .Values.prometheus.volumes.data.storageClass }}
-  storageClassName: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}-{{ .Values.prometheus.volumes.data.name }}"
-{{- end }}
 {{- if and .Values.volumes.local_storage .Values.prometheus.volumes.data.local_storage }}
   storageClassName: "local-storage"
+{{- else }}
+  {{- if  .Values.prometheus.volumes.data.storageClass }}
+  storageClassName: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}-{{ .Values.prometheus.volumes.data.name }}"
+  {{- else if .Values.prometheus.volumes.data.storageClassName }}
+  storageClassName: {{ .Values.prometheus.volumes.data.storageClassName }}
+  {{- end -}}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/pulsar/templates/pulsar-manager/pulsar-manager-pvc.yaml
+++ b/charts/pulsar/templates/pulsar-manager/pulsar-manager-pvc.yaml
@@ -29,11 +29,14 @@ spec:
     requests:
       storage: {{ .Values.pulsar_manager.volumes.data.size }}
   accessModes: [ "ReadWriteOnce" ]
-{{- if and (not (and .Values.volumes.local_storage .Values.pulsar_manager.volumes.data.local_storage)) .Values.pulsar_manager.volumes.data.storageClass }}
-  storageClassName: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-{{ .Values.pulsar_manager.volumes.data.name }}"
-{{- end }}
 {{- if and .Values.volumes.local_storage .Values.pulsar_manager.volumes.data.local_storage }}
   storageClassName: "local-storage"
+{{- else }}
+  {{- if  .Values.pulsar_manager.volumes.data.storageClass }}
+  storageClassName: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-{{ .Values.pulsar_manager.volumes.data.name }}"
+  {{- else if .Values.pulsar_manager.volumes.data.storageClassName }}
+  storageClassName: {{ .Values.pulsar_manager.volumes.data.storageClassName }}
+  {{- end -}}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/pulsar/templates/zookeeper/_zookeeper.tpl
+++ b/charts/pulsar/templates/zookeeper/_zookeeper.tpl
@@ -190,11 +190,14 @@ Define zookeeper data volumes
     resources:
       requests:
         storage: {{ .Values.zookeeper.volumes.data.size }}
-  {{- if and (not (and .Values.volumes.local_storage .Values.zookeeper.volumes.data.local_storage)) .Values.zookeeper.volumes.data.storageClass }}
-    storageClassName: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.data.name }}"
-  {{- end }}
   {{- if and .Values.volumes.local_storage .Values.zookeeper.volumes.data.local_storage }}
     storageClassName: "local-storage"
+  {{- else }}
+    {{- if  .Values.zookeeper.volumes.data.storageClass }}
+    storageClassName: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.data.name }}"
+    {{- else if .Values.zookeeper.volumes.data.storageClassName }}
+    storageClassName: {{ .Values.zookeeper.volumes.data.storageClassName }}
+    {{- end -}}
   {{- end }}
 {{- if .Values.zookeeper.volumes.useSeparateDiskForTxlog }}
 - metadata:
@@ -204,11 +207,14 @@ Define zookeeper data volumes
     resources:
       requests:
         storage: {{ .Values.zookeeper.volumes.dataLog.size }}
-  {{- if and (not (and .Values.volumes.local_storage .Values.zookeeper.volumes.dataLog.local_storage)) .Values.zookeeper.volumes.dataLog.storageClass }}
-    storageClassName: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.dataLog.name }}"
-  {{- end }}
-  {{- if and .Values.volumes.local_storage .Values.zookeeper.volumes.dataLog.local_storage }}
+  {{- if and .Values.volumes.local_storage .Values.zookeeper.volumes.data.local_storage }}
     storageClassName: "local-storage"
+  {{- else }}
+    {{- if  .Values.zookeeper.volumes.dataLog.storageClass }}
+    storageClassName: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.dataLog.name }}"
+    {{- else if .Values.zookeeper.volumes.dataLog.storageClassName }}
+    storageClassName: {{ .Values.zookeeper.volumes.dataLog.storageClassName }}
+    {{- end -}}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -454,38 +454,40 @@ zookeeper:
       name: data
       size: 50Gi
       local_storage: true
+      # storageClassName: ""
       ## If the storage class is left undefined when using persistence
       ## the default storage class for the cluster will be used.
       ##
       # storageClass:
-        # type: pd-ssd
-        # fsType: xfs
-        # provisioner: kubernetes.io/gce-pd
-        # allowVolumeExpansion: false
-        # volumeBindingMode: Immediate
-        # reclaimPolicy: Retain
-        # allowedTopologies:
-        # mountOptions:
-        # extraParameters:
-        #   iopsPerGB: "50"
+      #   type: pd-ssd
+      #   fsType: xfs
+      #   provisioner: kubernetes.io/gce-pd
+      #   allowVolumeExpansion: false
+      #   volumeBindingMode: Immediate
+      #   reclaimPolicy: Retain
+      #   allowedTopologies:
+      #   mountOptions:
+      #   extraParameters:
+      #     iopsPerGB: "50"
     dataLog:
       name: datalog
       size: 10Gi
       local_storage: true
+      # storageClassName: ""
       ## If the storage class is left undefined when using persistence
       ## the default storage class for the cluster will be used.
       ##
       # storageClass:
-        # type: pd-ssd
-        # fsType: xfs
-        # provisioner: kubernetes.io/gce-pd
-        # allowVolumeExpansion: false
-        # volumeBindingMode: Immediate
-        # reclaimPolicy: Retain
-        # allowedTopologies:
-        # mountOptions:
-        # extraParameters:
-        #   iopsPerGB: "50"
+      #   type: pd-ssd
+      #   fsType: xfs
+      #   provisioner: kubernetes.io/gce-pd
+      #   allowVolumeExpansion: false
+      #   volumeBindingMode: Immediate
+      #   reclaimPolicy: Retain
+      #   allowedTopologies:
+      #   mountOptions:
+      #   extraParameters:
+      #     iopsPerGB: "50"
   extraInitContainers: {}
   ## Zookeeper configmap
   ## templates/zookeeper-configmap.yaml
@@ -583,24 +585,26 @@ bookkeeper:
       name: journal
       size: 10Gi
       local_storage: true
+      # storageClassName: ""
       ## If the storage class is left undefined when using persistence
       ## the default storage class for the cluster will be used.
       ##
       # storageClass:
-        # type: pd-ssd
-        # fsType: xfs
-        # provisioner: kubernetes.io/gce-pd
-        # allowVolumeExpansion: false
-        # volumeBindingMode: Immediate
-        # reclaimPolicy: Retain
-        # allowedTopologies:
-        # mountOptions:
-        # extraParameters:
-        #   iopsPerGB: "50"
+      #   type: pd-ssd
+      #   fsType: xfs
+      #   provisioner: kubernetes.io/gce-pd
+      #   allowVolumeExpansion: false
+      #   volumeBindingMode: Immediate
+      #   reclaimPolicy: Retain
+      #   allowedTopologies:
+      #   mountOptions:
+      #   extraParameters:
+      #     iopsPerGB: "50"
     ledgers:
       name: ledgers
       size: 50Gi
       local_storage: true
+      # storageClassName: ""
       ## If the storage class is left undefined when using persistence
       ## the default storage class for the cluster will be used.
       ##
@@ -1083,6 +1087,7 @@ prometheus:
       name: data
       size: 10Gi
       local_storage: true
+      # storageClassName: ""
       ## If the storage class is left undefined when using persistence
       ## the default storage class for the cluster will be used.
       ##
@@ -1268,6 +1273,7 @@ pulsar_manager:
       name: data
       size: 10Gi
       local_storage: true
+      # storageClassName: ""
       ## If the storage class is left undefined when using persistence
       ## the default storage class for the cluster will be used.
       ##


### PR DESCRIPTION
In reference to #126 this PR adds `storageClassName` values to all stateful components.

This lets you use previously defined storage classes for these components instead of relying on the default or creating new ones for every component.