### PR TITLE
pulsarRootDir was configured twice

### DIFF
--- a/charts/pulsar/templates/broker/function-worker-configfile-configmap.yaml
+++ b/charts/pulsar/templates/broker/function-worker-configfile-configmap.yaml
@@ -44,7 +44,9 @@ data:
       changeConfigMapNamespace: {{ template "pulsar.namespace" . }}
       submittingInsidePod: true
       installUserCodeDependencies: true
-{{ toYaml .Values.functions.functionRuntimeFactoryConfigs | indent 6 }}
+{{- with .Values.functions.functionRuntimeFactoryConfigs }}
+{{ toYaml . | indent 6 }}
+{{- end }}
     # runtime customizer
     {{- if .Values.functions.enableCustomizerRuntime }}
     runtimeCustomizerClassName: {{ .Values.functions.runtimeCustomizerClassName }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -892,7 +892,6 @@ functions:
     functionsDirectory: ./functions
     narExtractionDirectory: ""
   functionRuntimeFactoryConfigs:
-    pulsarRootDir: /pulsar
 
 ## Pulsar: pulsar detector
 ## templates/pulsar-detector-statefulset.yaml


### PR DESCRIPTION
*Motivation*

The pulsarRootDir is configured twice in the function worker configfile. This can result in function worker using a wrong root dir.

This change remove the duplicated setting.