### PR TITLE
Don't apply environment variables to function worker yaml file

### DIFF
--- a/charts/pulsar/templates/broker/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker/broker-statefulset.yaml
@@ -201,7 +201,6 @@ spec:
         - >
           {{- include "pulsar.broker.kop.settings" . | nindent 10 }}
           bin/apply-config-from-env.py conf/broker.conf;
-          bin/gen-yml-from-env.py conf/functions_worker.yml;
           echo "OK" > status;
           {{- include "pulsar.broker.zookeeper.tls.settings" . | nindent 10 }}
           bin/pulsar zookeeper-shell -server {{ template "pulsar.zookeeper.connect" . }} get {{ template "pulsar.broker.znode" . }};


### PR DESCRIPTION
*Motivation*

In #130, we changed the helm chart to load the function worker config file from a configmap.
Hence the mounted config file is readonly. We don't need to apply the environment variables to function worker config file anymore.