### PR TITLE
Make service account configurable

### DIFF
--- a/.ci/clusters/values-service-account.yaml
+++ b/.ci/clusters/values-service-account.yaml
@@ -1,0 +1,71 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+components:
+  pulsar_manager: false
+  # disable auto recovery
+  autorecovery: false
+
+monitoring:
+  prometheus: false
+  grafana: false
+  node_exporter: false
+  alert_manager: false
+  loki: false
+
+volumes:
+  persistence: false
+
+# disabled AntiAffinity
+affinity:
+  anti_affinity: false
+
+zookeeper:
+  replicaCount: 1
+
+bookkeeper:
+  replicaCount: 3
+  configData:
+    diskUsageThreshold: "0.999"
+    diskUsageWarnThreshold: "0.999"
+    PULSAR_PREFIX_diskUsageThreshold: "0.999"
+    PULSAR_PREFIX_diskUsageWarnThreshold: "0.999"
+  serviceAccount:
+    name: "test-bookie-sa"
+
+broker:
+  replicaCount: 1
+  configData:
+    ## Enable `autoSkipNonRecoverableData` since bookkeeper is running
+    ## without persistence
+    autoSkipNonRecoverableData: "true"
+    # storage settings
+    managedLedgerDefaultEnsembleSize: "1"
+    managedLedgerDefaultWriteQuorum: "1"
+    managedLedgerDefaultAckQuorum: "1"
+  serviceAccount:
+    name: "test-broker-sa"
+
+proxy:
+  replicaCount: 1
+  serviceAccount:
+    name: "test-proxy-sa"
+
+toolset:
+  useProxy: false

--- a/.github/workflows/pulsar_service_account.yml
+++ b/.github/workflows/pulsar_service_account.yml
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Precommit - Pulsar Helm Chart (Service Account)
+on:
+  pull_request:
+    branches:
+      - '*'
+    paths:
+      - 'charts/local-storage-provisioner/**'
+      - 'charts/pulsar/**'
+      - '.github/workflows/**'
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Run chart-testing (lint)
+        id: lint
+        uses: helm/chart-testing-action@master
+        with:
+          command: lint
+
+      - name: Run chart-testing (install)
+        run: |
+          .ci/chart_test.sh .ci/clusters/values-service-account.yaml
+        # Only build a kind cluster if there are chart changes to test.
+        if: steps.lint.outputs.changed == 'true'

--- a/charts/pulsar/templates/bookkeeper/_bookkeeper.tpl
+++ b/charts/pulsar/templates/bookkeeper/_bookkeeper.tpl
@@ -169,6 +169,7 @@ Define bookkeeper log volumes
   configMap:
     name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
 {{- end }}
+
 {{/*Define bookkeeper datadog annotation*/}}
 {{- define  "pulsar.bookkeeper.datadog.annotation" -}}
 {{- if .Values.datadog.components.bookkeeper.enabled }}
@@ -212,3 +213,16 @@ ad.datadoghq.com/{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.compon
   ]
 {{- end }}
 {{- end }}
+
+{{/*Define bookkeeper service account*/}}
+{{- define "pulsar.bookkeeper.serviceAccount" -}}
+{{- if .Values.bookkeeper.serviceAccount.create -}}
+    {{- if .Values.bookkeeper.serviceAccount.name -}}
+{{ .Values.bookkeeper.serviceAccount.name }}
+    {{- else -}}
+{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-acct
+    {{- end -}}
+{{- else -}}
+{{ .Values.bookkeeper.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/pulsar/templates/bookkeeper/bookkeeper-cluster-role-binding.yaml
+++ b/charts/pulsar/templates/bookkeeper/bookkeeper-cluster-role-binding.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-{{- if .Values.components.bookkeeper }}
+{{- if and .Values.components.bookkeeper .Values.bookkeeper.serviceAccount.create }}
 ## TODO create our own cluster role with less privledges than admin
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -31,7 +31,7 @@ roleRef:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-clusterrole"
 subjects:
 - kind: ServiceAccount
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-acct"
+  name: {{ template "pulsar.bookkeeper.serviceAccount" . }}
   namespace: {{ template "pulsar.namespace" . }}
 ---
 

--- a/charts/pulsar/templates/bookkeeper/bookkeeper-service-account.yaml
+++ b/charts/pulsar/templates/bookkeeper/bookkeeper-service-account.yaml
@@ -17,13 +17,17 @@
 # under the License.
 #
 
-{{- if .Values.components.bookkeeper }}
+{{- if and .Values.components.bookkeeper .Values.bookkeeper.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-acct"
+  name: {{ template "pulsar.bookkeeper.serviceAccount" . }}
   namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.bookkeeper.component }}
+  annotations:
+{{- with .Values.bookkeeper.serviceAccount.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
 {{- with .Values.bookkeeper.securityContext }}
 {{ toYaml . | indent 8 }}
 {{- end }}
-      serviceAccountName: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-acct"
+      serviceAccountName: {{ template "pulsar.bookkeeper.serviceAccount" . }}
     {{- if .Values.bookkeeper.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.bookkeeper.nodeSelector | indent 8 }}

--- a/charts/pulsar/templates/broker/_broker.tpl
+++ b/charts/pulsar/templates/broker/_broker.tpl
@@ -342,3 +342,15 @@ Define gcs offload options mounts
 {{- end }}
 {{- end }}
 
+{{/*Define broker service account*/}}
+{{- define "pulsar.broker.serviceAccount" -}}
+{{- if .Values.broker.serviceAccount.create -}}
+    {{- if .Values.broker.serviceAccount.name -}}
+{{ .Values.broker.serviceAccount.name }}
+    {{- else -}}
+{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-acct
+    {{- end -}}
+{{- else -}}
+{{ .Values.broker.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/pulsar/templates/broker/broker-cluster-role-binding.yaml
+++ b/charts/pulsar/templates/broker/broker-cluster-role-binding.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-{{- if .Values.components.broker }}
+{{- if and .Values.components.broker .Values.broker.serviceAccount.create }}
 ## TODO create our own cluster role with less privledges than admin
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -31,7 +31,7 @@ roleRef:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-clusterrole"
 subjects:
 - kind: ServiceAccount
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-acct"
+  name: {{ template "pulsar.broker.serviceAccount" . }}
   namespace: {{ template "pulsar.namespace" . }}
 ---
 

--- a/charts/pulsar/templates/broker/broker-service-account.yaml
+++ b/charts/pulsar/templates/broker/broker-service-account.yaml
@@ -17,17 +17,20 @@
 # under the License.
 #
 
-{{- if .Values.components.broker }}
+{{- if and .Values.components.broker .Values.broker.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-acct"
+  name: {{ template "pulsar.broker.serviceAccount" . }}
   namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.broker.component }}
   annotations:
 {{- with .Values.broker.service_account.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.broker.serviceAccount.annotations }}
 {{ toYaml . | indent 4 }}
 {{- end }}
 {{- end }}

--- a/charts/pulsar/templates/broker/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker/broker-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
 {{- with .Values.broker.securityContext }}
 {{ toYaml . | indent 8 }}
 {{- end }}
-      serviceAccountName: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}-acct"
+      serviceAccountName: {{ template "pulsar.broker.serviceAccount" . }}
     {{- if .Values.broker.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.broker.nodeSelector | indent 8 }}

--- a/charts/pulsar/templates/detector/_detector.tpl
+++ b/charts/pulsar/templates/detector/_detector.tpl
@@ -1,0 +1,13 @@
+
+{{/*Define pulsar detector service account*/}}
+{{- define "pulsar.detector.serviceAccount" -}}
+{{- if .Values.pulsar_detector.serviceAccount.create -}}
+    {{- if .Values.pulsar_detector.serviceAccount.name -}}
+{{ .Values.pulsar_detector.serviceAccount.name }}
+    {{- else -}}
+{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_detector.component }}-acct
+    {{- end -}}
+{{- else -}}
+{{ .Values.pulsar_detector.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/pulsar/templates/detector/pulsar-detector-service-account.yaml
+++ b/charts/pulsar/templates/detector/pulsar-detector-service-account.yaml
@@ -17,13 +17,17 @@
 # under the License.
 #
 
-{{- if .Values.components.pulsar_detector }}
+{{- if and .Values.components.pulsar_detector .Values.pulsar_detector.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_detector.component }}-acct"
+  name: {{ template "pulsar.detector.serviceAccount" . }}
   namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.pulsar_detector.component }}
+  annotations:
+{{- with .Values.pulsar_detector.serviceAccount.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/pulsar/templates/detector/pulsar-detector-statefulset.yaml
+++ b/charts/pulsar/templates/detector/pulsar-detector-statefulset.yaml
@@ -42,7 +42,7 @@ spec:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.pulsar_detector.component }}
     spec:
-      {{/*serviceAccountName: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_detector.component }}-acct"*/}}
+      serviceAccountName: {{ template "pulsar.detector.serviceAccount" . }}
       terminationGracePeriodSeconds: {{ .Values.pulsar_detector.gracePeriod }}
       initContainers:
       # This init container will wait for zookeeper to be ready before

--- a/charts/pulsar/templates/prometheus/_prometheus.tpl
+++ b/charts/pulsar/templates/prometheus/_prometheus.tpl
@@ -26,3 +26,16 @@ Define toolset token volumes
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*Define prometheus service account*/}}
+{{- define "pulsar.prometheus.serviceAccount" -}}
+{{- if .Values.prometheus.serviceAccount.create -}}
+    {{- if .Values.prometheus.serviceAccount.name -}}
+{{ .Values.prometheus.serviceAccount.name }}
+    {{- else -}}
+{{ template "pulsar.fullname" . }}-{{ .Values.rbac.roleName }}
+    {{- end -}}
+{{- else -}}
+{{ .Values.prometheus.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/pulsar/templates/prometheus/prometheus-statefulset.yaml
+++ b/charts/pulsar/templates/prometheus/prometheus-statefulset.yaml
@@ -55,7 +55,7 @@ spec:
 {{ toYaml .Values.prometheus.tolerations | indent 8 }}
     {{- end }}
     {{- if .Values.rbac.enable }}
-      serviceAccount: "{{ template "pulsar.fullname" . }}-{{ .Values.rbac.roleName }}"
+      serviceAccount: {{ template "pulsar.prometheus.serviceAccount" . }}
     {{- end }}
       terminationGracePeriodSeconds: {{ .Values.prometheus.gracePeriod }}
       {{- if .Values.prometheus.securityContext }}

--- a/charts/pulsar/templates/prometheus/pulsar-operators-rbac.yaml
+++ b/charts/pulsar/templates/prometheus/pulsar-operators-rbac.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-{{- if .Values.rbac.enable }}
+{{- if and .Values.rbac.enable .Values.prometheus.serviceAccount.create }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
@@ -86,7 +86,7 @@ rules:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.rbac.roleName }}"
+  name: {{ template "pulsar.prometheus.serviceAccount" . }}
   namespace: {{ template "pulsar.namespace" . }}
 ---
 
@@ -100,7 +100,7 @@ roleRef:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.rbac.roleName }}"
 subjects:
 - kind: ServiceAccount
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.rbac.roleName }}"
+  name: {{ template "pulsar.prometheus.serviceAccount" . }}
   namespace: {{ template "pulsar.namespace" . }}
 
 {{- end }}

--- a/charts/pulsar/templates/proxy/_proxy.tpl
+++ b/charts/pulsar/templates/proxy/_proxy.tpl
@@ -9,7 +9,6 @@ pulsar service domain
 {{- end -}}
 {{- end -}}
 
-
 {{/*
 Define proxy token mounts
 */}}
@@ -233,5 +232,18 @@ Pulsar Web Service URL
 {{- .Values.proxy.brokerWebServiceURLTLS -}}
 {{- else -}}
 https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Values.broker.ports.https }}
+{{- end -}}
+{{- end -}}
+
+{{/*Define proxy service account*/}}
+{{- define "pulsar.proxy.serviceAccount" -}}
+{{- if .Values.proxy.serviceAccount.create -}}
+    {{- if .Values.proxy.serviceAccount.name -}}
+{{ .Values.proxy.serviceAccount.name }}
+    {{- else -}}
+{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}-acct
+    {{- end -}}
+{{- else -}}
+{{ .Values.proxy.serviceAccount.name }}
 {{- end -}}
 {{- end -}}

--- a/charts/pulsar/templates/proxy/proxy-service-account.yaml
+++ b/charts/pulsar/templates/proxy/proxy-service-account.yaml
@@ -17,13 +17,17 @@
 # under the License.
 #
 
-{{- if .Values.components.proxy }}
+{{- if and .Values.components.proxy .Values.proxy.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}-acct"
+  name: {{ template "pulsar.proxy.serviceAccount" . }}
   namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.proxy.component }}
+  annotations:
+{{- with .Values.proxy.serviceAccount.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/pulsar/templates/proxy/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy/proxy-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
 {{- with .Values.proxy.securityContext }}
 {{ toYaml . | indent 8 }}
 {{- end }}
-      serviceAccountName: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}-acct"
+      serviceAccountName: {{ template "pulsar.proxy.serviceAccount" . }}
     {{- if .Values.proxy.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.proxy.nodeSelector | indent 8 }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -586,6 +586,17 @@ bookkeeper:
     requests:
       memory: 512Mi
       cpu: 0.2
+  # Definition of the serviceAccount used to run bookies.
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+    # Extra annotations for the serviceAccount definition. This can either be
+    # YAML or a YAML-formatted multi-line templated string map of the
+    # annotations to apply to the serviceAccount.
+    annotations: {}
   volumes:
     # use a persistent volume or emptyDir
     persistence: true
@@ -798,6 +809,17 @@ broker:
       memory: 512Mi
       cpu: 0.2
   extraInitContainers: {}
+  # Definition of the serviceAccount used to run brokers.
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+    # Extra annotations for the serviceAccount definition. This can either be
+    # YAML or a YAML-formatted multi-line templated string map of the
+    # annotations to apply to the serviceAccount.
+    annotations: {}
   ## Broker configmap
   ## templates/broker-configmap.yaml
   ##
@@ -840,6 +862,7 @@ broker:
     maxUnavailable: 1
   ### Broker service account
   ## templates/broker-service-account.yaml
+  # deprecated: use `serviceAccount` section to configure service account.
   service_account:
     annotations: {}
   offload:
@@ -902,6 +925,19 @@ pulsar_detector:
 
   gracePeriod: 30
   port: 9000
+
+  # Definition of the serviceAccount used to run brokers.
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+    # Extra annotations for the serviceAccount definition. This can either be
+    # YAML or a YAML-formatted multi-line templated string map of the
+    # annotations to apply to the serviceAccount.
+    annotations: {}
+
   ## Proxy service
   ## templates/pulsar-detector-service.yaml
   ##
@@ -957,6 +993,17 @@ proxy:
       memory: 128Mi
       cpu: 0.2
   extraInitContainers: {}
+  # Definition of the serviceAccount used to run proxies.
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+    # Extra annotations for the serviceAccount definition. This can either be
+    # YAML or a YAML-formatted multi-line templated string map of the
+    # annotations to apply to the serviceAccount.
+    annotations: {}
   ## Proxy configmap
   ## templates/proxy-configmap.yaml
   ##
@@ -1124,6 +1171,17 @@ prometheus:
     requests:
       memory: 256Mi
       cpu: 0.1
+  # Definition of the serviceAccount used to run brokers.
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+    # Extra annotations for the serviceAccount definition. This can either be
+    # YAML or a YAML-formatted multi-line templated string map of the
+    # annotations to apply to the serviceAccount.
+    annotations: {}
   volumes:
     # use a persistent volume or emptyDir
     persistence: true


### PR DESCRIPTION
*Motivation*

In certain deployment, people would like to deploy Pulsar using existing service accounts.

This change is to make sure creating service accounts is optional and user can configure to use existing service accounts.