### PR TITLE
Fix empty storageClassName issue

### DIFF
--- a/charts/pulsar/templates/bookkeeper/_bookkeeper.tpl
+++ b/charts/pulsar/templates/bookkeeper/_bookkeeper.tpl
@@ -32,24 +32,24 @@ Define bookie zookeeper client tls settings
 
 {{- define "pulsar.bookkeeper.journal.storage.class" -}}
 {{- if and .Values.volumes.local_storage .Values.bookkeeper.volumes.journal.local_storage }}
-  {{- print "local-storage" -}}
+storageClassName: "local-storage"
 {{- else }}
   {{- if  .Values.bookkeeper.volumes.journal.storageClass }}
-    {{- template "pulsar.bookkeeper.journal.pvc.name" . }}
+storageClassName: "{{ template "pulsar.bookkeeper.journal.pvc.name" . }}"
   {{- else if .Values.bookkeeper.volumes.journal.storageClassName }}
-    {{- print .Values.bookkeeper.volumes.journal.storageClassName }}
+storageClassName: "{{ .Values.bookkeeper.volumes.journal.storageClassName }}"
   {{- end -}}
 {{- end }}
 {{- end }}
 
 {{- define "pulsar.bookkeeper.ledgers.storage.class" -}}
 {{- if and .Values.volumes.local_storage .Values.bookkeeper.volumes.ledgers.local_storage }}
-  {{- print "local-storage" -}}
+storageClassName: "local-storage"
 {{- else }}
   {{- if  .Values.bookkeeper.volumes.ledgers.storageClass }}
-    {{- template "pulsar.bookkeeper.ledgers.pvc.name" . }}
+storageClassName: "{{ template "pulsar.bookkeeper.ledgers.pvc.name" . }}"
   {{- else if .Values.bookkeeper.volumes.ledgers.storageClassName }}
-    {{- print .Values.bookkeeper.volumes.ledgers.storageClassName }}
+storageClassName: "{{ .Values.bookkeeper.volumes.ledgers.storageClassName }}"
   {{- end -}}
 {{- end }}
 {{- end }}

--- a/charts/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
+++ b/charts/pulsar/templates/bookkeeper/bookkeeper-statefulset.yaml
@@ -227,7 +227,7 @@ spec:
       resources:
         requests:
           storage: {{ .Values.bookkeeper.volumes.journal.size }}
-      storageClassName: "{{ template "pulsar.bookkeeper.journal.storage.class" . }}"
+      {{- include "pulsar.bookkeeper.journal.storage.class" . | nindent 6 }}
   - metadata:
       name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.ledgers.name }}"
     spec:
@@ -235,6 +235,6 @@ spec:
       resources:
         requests:
           storage: {{ .Values.bookkeeper.volumes.ledgers.size }}
-      storageClassName: "{{ template "pulsar.bookkeeper.ledgers.storage.class" . }}"
+      {{- include "pulsar.bookkeeper.ledgers.storage.class" . | nindent 6 }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
*Motivation*

If no storage class name is specified, the bookkeeper statefulset will be using an empty storage class name.
It will cause pvc pending in creating pv. Because no storage class name is found.

```
storageClassName: ""
```

This change fixes the issue.