### PR TITLE
Upgrade cert-manager and external-dns + tweaks

### DIFF
--- a/charts/pulsar/templates/external-dns/external-dns-rbac.yaml
+++ b/charts/pulsar/templates/external-dns/external-dns-rbac.yaml
@@ -39,17 +39,14 @@ metadata:
     release: {{ .Release.Name }}
 rules:
 - apiGroups: [""]
-  resources: ["services"]
+  resources: ["services","endpoints","pods"]
   verbs: ["get","watch","list"]
-- apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["get","watch","list"]
-- apiGroups: ["extensions"] 
-  resources: ["ingresses"] 
+- apiGroups: ["extensions","networking.k8s.io"]
+  resources: ["ingresses"]
   verbs: ["get","watch","list"]
 - apiGroups: [""]
   resources: ["nodes"]
-  verbs: ["get", "watch", "list"]
+  verbs: ["list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/charts/pulsar/templates/external-dns/external-dns.yaml
+++ b/charts/pulsar/templates/external-dns/external-dns.yaml
@@ -18,7 +18,7 @@
 #
 
 {{- if .Values.external_dns.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.external_dns.component }}"
@@ -26,15 +26,25 @@ metadata:
 spec:
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      {{- include "pulsar.template.labels" . | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "pulsar.template.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "pulsar.fullname" . }}-{{ .Values.external_dns.component }}
+      volumes:
+        {{- range .Values.external_dns.extraMounts }}
+        - name: {{ .mountName }}
+          {{ .type }}:
+            {{ toYaml .mountOpts }}
+        {{- end }}
+
       containers:
       - name: external-dns
-        image: registry.opensource.zalan.do/teapot/external-dns:latest
+        image: k8s.gcr.io/external-dns/external-dns:v0.7.3
         args:
         - --source=service
         - --source=ingress
@@ -54,6 +64,16 @@ spec:
         - --policy={{ .Values.external_dns.policy }}
         - --registry={{ .Values.external_dns.registry }}
         - --txt-owner-id={{ .Values.external_dns.owner_id }}
+        volumeMounts:
+          {{- range .Values.external_dns.extraMounts }}
+          - name: {{ .mountName }}
+            mountPath: {{ .mountPath }}
+          {{- end }}
+        env:
+          {{- range .Values.external_dns.extraEnv }}
+          - name: {{ .name }}
+            value: {{ .value }}
+          {{- end }}
       securityContext:
       {{- with .Values.external_dns.securityContext }}
       {{ toYaml . | indent 6 }}

--- a/charts/pulsar/templates/proxy/_proxy.tpl
+++ b/charts/pulsar/templates/proxy/_proxy.tpl
@@ -70,9 +70,11 @@ Define proxy certs mounts
 - mountPath: "/pulsar/certs/proxy"
   name: proxy-certs
   readOnly: true
+{{- if .Values.tls.proxy.untrustedCa }}
 - mountPath: "/pulsar/certs/ca"
   name: proxy-ca
   readOnly: true
+{{- end }}
 {{- end }}
 {{- if .Values.tls.broker.enabled }}
 - mountPath: "/pulsar/certs/broker"
@@ -87,6 +89,7 @@ Define proxy certs volumes
 */}}
 {{- define "pulsar.proxy.certs.volumes" -}}
 {{- if and .Values.tls.enabled .Values.tls.proxy.enabled }}
+{{- if .Values.tls.proxy.untrustedCa }}
 - name: proxy-ca
   secret:
   {{- if and .Values.certs.public_issuer.enabled (eq .Values.certs.public_issuer.type "acme") }}
@@ -99,6 +102,7 @@ Define proxy certs volumes
     items:
       - key: ca.crt
         path: ca.crt
+  {{- end }}
   {{- end }}
 - name: proxy-certs
   secret:

--- a/charts/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/charts/pulsar/templates/proxy/proxy-configmap.yaml
@@ -34,8 +34,8 @@ data:
   webServicePort: "{{ .Values.proxy.ports.http }}"
   {{- if or (not .Values.tls.enabled) (not .Values.tls.proxy.enabled) }}
   servicePort: "{{ .Values.proxy.ports.pulsar }}"
-  brokerServiceURL: {{ template "pulsar.proxy.broker.service.url" . }} 
-  brokerWebServiceURL: {{ template "pulsar.proxy.web.service.url" . }}  
+  brokerServiceURL: {{ template "pulsar.proxy.broker.service.url" . }}
+  brokerWebServiceURL: {{ template "pulsar.proxy.web.service.url" . }}
   {{- end }}
   {{- if and .Values.tls.enabled .Values.tls.proxy.enabled }}
   tlsEnabledInProxy: "true"
@@ -43,19 +43,21 @@ data:
   webServicePortTls: "{{ .Values.proxy.ports.https }}"
   tlsCertificateFilePath: "/pulsar/certs/proxy/tls.crt"
   tlsKeyFilePath: "/pulsar/certs/proxy/tls.key"
+  {{- if .Values.tls.proxy.untrustedCa }}
   tlsTrustCertsFilePath: "/pulsar/certs/ca/ca.crt"
+  {{- end }}
   {{- end }}
   {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
   # if broker enables TLS, configure proxy to talk to broker using TLS
   brokerServiceURLTLS: {{ template "pulsar.proxy.broker.service.url.tls" . }}
-  brokerWebServiceURLTLS: {{ template "pulsar.proxy.web.service.url.tls" . }} 
+  brokerWebServiceURLTLS: {{ template "pulsar.proxy.web.service.url.tls" . }}
   tlsEnabledWithBroker: "true"
   tlsCertRefreshCheckDurationSec: "300"
   brokerClientTrustCertsFilePath: "/pulsar/certs/broker/ca.crt"
   {{- end }}
   {{- if not (and .Values.tls.enabled .Values.tls.broker.enabled) }}
-  brokerServiceURL: {{ template "pulsar.proxy.broker.service.url" . }} 
-  brokerWebServiceURL: {{ template "pulsar.proxy.web.service.url" . }}  
+  brokerServiceURL: {{ template "pulsar.proxy.broker.service.url" . }}
+  brokerWebServiceURL: {{ template "pulsar.proxy.web.service.url" . }}
   {{- end }}
 
   # Authentication Settings

--- a/charts/pulsar/templates/toolset/_toolset.tpl
+++ b/charts/pulsar/templates/toolset/_toolset.tpl
@@ -83,9 +83,11 @@ Define toolset tls certs mounts
 {{- end }}
 {{- end }}
 {{- if and .Values.tls.enabled (or .Values.tls.broker.enabled .Values.tls.proxy.enabled) }}
+{{- if .Values.tls.proxy.untrustedCa }}
 - mountPath: "/pulsar/certs/proxy-ca"
   name: proxy-ca
   readOnly: true
+{{- end }}
 {{- end }}
 {{- end }}
 
@@ -116,6 +118,7 @@ Define toolset tls certs volumes
 {{- end }}
 {{- end }}
 {{- if and .Values.tls.enabled (or .Values.tls.broker.enabled .Values.tls.proxy.enabled) }}
+{{- if .Values.tls.proxy.untrustedCa }}
 - name: proxy-ca
   secret:
   {{- if and .Values.certs.public_issuer.enabled (eq .Values.certs.public_issuer.type "acme") }}
@@ -129,6 +132,7 @@ Define toolset tls certs volumes
       - key: ca.crt
         path: ca.crt
   {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/pulsar/templates/toolset/toolset-configmap.yaml
+++ b/charts/pulsar/templates/toolset/toolset-configmap.yaml
@@ -50,7 +50,9 @@ data:
   brokerServiceUrl: "pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:{{ .Values.proxy.ports.pulsarssl }}/"
   useTls: "true"
   tlsAllowInsecureConnection: "false"
+  {{- if .Values.tls.proxy.untrustedCa }}
   tlsTrustCertsFilePath: "/pulsar/certs/proxy-ca/ca.crt"
+  {{- end }}
   tlsEnableHostnameVerification: "false"
   {{- end }}
   {{- if not (and .Values.tls.enabled .Values.tls.proxy.enabled) }}
@@ -63,8 +65,8 @@ data:
   {{- if eq .Values.auth.authentication.provider "jwt" }}
   authParams: "file:///pulsar/tokens/client/token"
   authPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"
-  {{- end }} 
-  {{- end }} 
+  {{- end }}
+  {{- end }}
 {{ toYaml .Values.toolset.configData | indent 2 }}
   # Include log configuration file, If you want to configure the log level and other configuration
   # items, you can modify the configmap, and eventually it will overwrite the log4j2.yaml file under conf

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -196,6 +196,7 @@ tls:
   proxy:
     enabled: false
     cert_name: tls-proxy
+    untrustedCa: true
   # settings for generating certs for proxy
   pulsar_detector:
     enabled: false
@@ -317,6 +318,9 @@ external_dns:
   serviceAcct:
     annotations: {}
   securityContext: {}
+  extraMounts: []
+  extraEnv: []
+
 
 ## Domain requested from External DNS
 domain:

--- a/scripts/cert-manager/install-cert-manager.sh
+++ b/scripts/cert-manager/install-cert-manager.sh
@@ -21,13 +21,13 @@
 
 NAMESPACE=cert-manager
 NAME=cert-manager
-VERSION=v0.13.0
+VERSION=v1.0.4
 
 # Install cert-manager CustomResourceDefinition resources
 echo "Installing cert-manager CRD resources ..."
-kubectl apply --validate=false -f https://raw.githubusercontent.com/jetstack/cert-manager/${VERSION}/deploy/manifests/00-crds.yaml
+kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/${VERSION}/cert-manager.crds.yaml
 
-# Create the namespace 
+# Create the namespace
 kubectl get ns ${NAMESPACE}
 if [ $? == 0 ]; then
     echo "Namespace '${NAMESPACE}' already exists."


### PR DESCRIPTION
This commit does a few main things:
1. Updates cert-manager to a more modern version
2. Updates external-dns to a more modern version
3. Fixes that if we are using lets encrypt we don't try and mount CA if
we have trusted cert