### PR TITLE
Add support for datadog prom federation, minor tweaks

### DIFF
--- a/charts/pulsar/templates/prometheus/_prometheus.tpl
+++ b/charts/pulsar/templates/prometheus/_prometheus.tpl
@@ -39,3 +39,91 @@ Define toolset token volumes
 {{ .Values.prometheus.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*Define federation datadog annotation*/}}
+{{- define "pulsar.prometheus.datadog.annotation" -}}
+{{- if .Values.datadog.components.prometheus.enabled }}
+ad.datadoghq.com/{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}.check_names: |
+  ["openmetrics"]
+ad.datadoghq.com/{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}.init_configs: |
+  [{}]
+ad.datadoghq.com/{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}.instances: |
+  [
+    {
+      "prometheus_url": "http://%%host%%:{{ .Values.prometheus.port }}/federate?match[]=%7B__name__%3D~%22pulsar_.%2B%7Cjvm_.%2B%7Ctopic_.%2B%22%7D",
+      "namespace": "{{ .Values.datadog.namespace }}",
+      "metrics": {{ .Values.datadog.components.prometheus.metrics }},
+      "health_service_check": true,
+      "prometheus_timeout": 1000,
+      "max_returned_metrics": 1000000,
+      "type_overrides": {
+        "pulsar_topics_count": "gauge",
+        "pulsar_rate_in": "gauge",
+        "pulsar_rate_out": "gauge",
+        "pulsar_subscriptions_count": "gauge",
+        "pulsar_producers_count": "gauge",
+        "pulsar_consumers_count": "gauge",
+        "pulsar_throughput_in": "gauge",
+        "pulsar_throughput_out": "gauge",
+        "pulsar_storage_size": "gauge",
+        "pulsar_msg_backlog": "gauge",
+        "pulsar_storage_backlog_size": "gauge",
+        "pulsar_storage_offloaded_size": "gauge",
+        "pulsar_storage_write_latency_le_0_5": "gauge",
+        "pulsar_storage_write_latency_le_1": "gauge",
+        "pulsar_storage_write_latency_le_5": "gauge",
+        "pulsar_storage_write_latency_le_10": "gauge",
+        "pulsar_storage_write_latency_le_20": "gauge",
+        "pulsar_storage_write_latency_le_50": "gauge",
+        "pulsar_storage_write_latency_le_100": "gauge",
+        "pulsar_storage_write_latency_le_200": "gauge",
+        "pulsar_storage_write_latency_le_1000": "gauge",
+        "pulsar_storage_write_latency_overflow": "gauge",
+        "pulsar_entry_size_le_128": "gauge",
+        "pulsar_entry_size_le_512": "gauge",
+        "pulsar_entry_size_le_1_kb": "gauge",
+        "pulsar_entry_size_le_2_kb": "gauge",
+        "pulsar_entry_size_le_4_kb": "gauge",
+        "pulsar_entry_size_le_16_kb": "gauge",
+        "pulsar_entry_size_le_100_kb": "gauge",
+        "pulsar_entry_size_le_1_mb": "gauge",
+        "pulsar_entry_size_le_overflow": "gauge",
+        "pulsar_subscription_back_log": "gauge",
+        "pulsar_subscription_back_log_no_delayed": "gauge",
+        "pulsar_subscription_delayed": "gauge",
+        "pulsar_subscription_msg_rate_redeliver": "gauge",
+        "pulsar_subscription_unacked_messages": "gauge",
+        "pulsar_subscription_blocked_on_unacked_messages": "gauge",
+        "pulsar_subscription_msg_rate_out": "gauge",
+        "pulsar_subscription_msg_throughput_out": "gauge",
+        "pulsar_in_bytes_total": "counter",
+        "pulsar_in_messages_total": "counter",
+        "topic_load_times": "counter",
+        "jvm_memory_bytes_used": "gauge",
+        "jvm_memory_bytes_committed": "gauge",
+        "jvm_memory_bytes_max": "gauge",
+        "jvm_memory_bytes_init": "gauge",
+        "jvm_memory_pool_bytes_used": "gauge",
+        "jvm_memory_pool_bytes_committed": "gauge",
+        "jvm_memory_pool_bytes_max": "gauge",
+        "jvm_memory_pool_bytes_init": "gauge",
+        "jvm_classes_loaded": "gauge",
+        "jvm_classes_loaded_total": "counter",
+        "jvm_classes_unloaded_total": "counter",
+        "jvm_buffer_pool_used_bytes": "gauge",
+        "jvm_buffer_pool_capacity_bytes": "gauge",
+        "jvm_buffer_pool_used_buffers": "gauge",
+        "jvm_threads_current": "gauge",
+        "jvm_threads_daemon": "gauge",
+        "jvm_threads_peak": "gauge",
+        "jvm_threads_started_total": "counter",
+        "jvm_threads_deadlocked": "gauge",
+        "jvm_threads_deadlocked_monitor": "gauge",
+        "jvm_gc_collection_seconds_count": "gauge",
+        "jvm_gc_collection_seconds_sum": "gauge",
+        "jvm_memory_direct_bytes_max": "gauge"
+      }
+    }
+  ]
+{{- end }}
+{{- end }}

--- a/charts/pulsar/templates/prometheus/prometheus-configmap.yaml
+++ b/charts/pulsar/templates/prometheus/prometheus-configmap.yaml
@@ -82,6 +82,12 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: kubernetes_pod_name
+      metric_relabel_configs:
+{{- if .Values.prometheus.customRelabelConfigs -}}
+{{- with .Values.prometheus.customRelabelConfigs }}
+{{ toYaml . | indent 6 }}
+{{- end }}
+{{- end }}
     - job_name: 'kubernetes-nodes'
       scheme: https
       kubernetes_sd_configs:

--- a/charts/pulsar/templates/prometheus/prometheus-statefulset.yaml
+++ b/charts/pulsar/templates/prometheus/prometheus-statefulset.yaml
@@ -42,9 +42,12 @@ spec:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.prometheus.component }}
       annotations:
-{{- with .Values.prometheus.annotations }}
-{{ toYaml . | indent 8 }}
-{{- end }}
+        {{- if .Values.monitoring.datadog }}
+        {{- include "pulsar.prometheus.datadog.annotation" . | nindent 8 }}
+        {{- end }}
+        {{- with .Values.prometheus.annotations }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
     spec:
     {{- if .Values.prometheus.nodeSelector }}
       nodeSelector:
@@ -88,7 +91,7 @@ spec:
             subPath: {{ .subPath }}
             readOnly: {{ .readOnly }}
         {{- end }}
-      {{- end }} 
+      {{- end }}
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}"
         image: "{{ .Values.images.prometheus.repository }}:{{ .Values.images.prometheus.tag }}"
         imagePullPolicy: {{ .Values.images.prometheus.pullPolicy }}

--- a/charts/pulsar/templates/proxy/websocket-configmap.yaml
+++ b/charts/pulsar/templates/proxy/websocket-configmap.yaml
@@ -42,18 +42,20 @@ data:
   webServicePortTls: "{{ .Values.proxy.ports.websockettls }}"
   tlsCertificateFilePath: "/pulsar/certs/proxy/tls.crt"
   tlsKeyFilePath: "/pulsar/certs/proxy/tls.key"
+  {{- if .Values.tls.proxy.untrustedCa }}
   tlsTrustCertsFilePath: "/pulsar/certs/ca/ca.crt"
+  {{- end }}
   {{- end }}
   {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
   # if broker enables TLS, configure proxy to talk to broker using TLS
   brokerServiceUrlTls: {{ template "pulsar.proxy.broker.service.url.tls" . }}
-  serviceUrlTls: {{ template "pulsar.proxy.web.service.url.tls" . }} 
+  serviceUrlTls: {{ template "pulsar.proxy.web.service.url.tls" . }}
   tlsCertRefreshCheckDurationSec: "300"
   brokerClientTlsEnabled: "true"
   brokerClientTrustCertsFilePath: "/pulsar/certs/broker/ca.crt"
   {{- else }}
-  brokerServiceUrl: {{ template "pulsar.proxy.broker.service.url" . }} 
-  serviceUrl: {{ template "pulsar.proxy.web.service.url" . }}  
+  brokerServiceUrl: {{ template "pulsar.proxy.broker.service.url" . }}
+  serviceUrl: {{ template "pulsar.proxy.web.service.url" . }}
   {{- end }}
 
   # Authentication Settings

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1260,6 +1260,7 @@ prometheus:
       failureThreshold: 10
       initialDelaySeconds: 30
       periodSeconds: 10
+  customRelabelConfigs: []
 
   ## Prometheus service
   ## templates/prometheus-service.yaml


### PR DESCRIPTION
The main change of this commit is to support having datadog scrape from
the prometheus federation endpoint. This is useful along with the small
change for adding in custom relabel configs, allow for custom handling
of labels and then getting those modified labels values into datadog.

There is also a small fix here for making the websocket work with a
trusted CA