### PR TITLE
Fix zk configmap namespace

### DIFF
--- a/charts/pulsar/templates/zookeeper/gen-zk-conf.yaml
+++ b/charts/pulsar/templates/zookeeper/gen-zk-conf.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ template "pulsar.fullname" . }}-genzkconf-configmap"
-  namespace: {{ pulsar.namespace }}
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
 data:

--- a/charts/pulsar/templates/zookeeper/gen-zk-conf.yaml
+++ b/charts/pulsar/templates/zookeeper/gen-zk-conf.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: "{{ template "pulsar.fullname" . }}-genzkconf-configmap"
-  namespace: {{ .Values.namespace }}
+  namespace: {{ pulsar.namespace }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
 data:


### PR DESCRIPTION
Rest of zookeeper is placed in namespace pulsar.namespace not .Values.namespace. Thanks.