### PR TITLE
Update kafkaPlainText label to DNS-1123 compliant label

### DIFF
--- a/charts/pulsar/templates/broker/broker-service-ingress.yaml
+++ b/charts/pulsar/templates/broker/broker-service-ingress.yaml
@@ -49,7 +49,7 @@ spec:
   - name: pulsar
     port: {{ .Values.broker.ports.pulsar }}
   {{- if .Values.components.kop }}
-  - name: kafkaPlainText
+  - name: kafkaplaintext
     port: {{ .Values.kop.ports.plaintext }}
   {{- end }}
   {{- end }}

--- a/charts/pulsar/templates/broker/broker-service.yaml
+++ b/charts/pulsar/templates/broker/broker-service.yaml
@@ -46,7 +46,7 @@ spec:
   - name: pulsar
     port: {{ .Values.broker.ports.pulsar }}
   {{- if .Values.components.kop }}
-  - name: kafkaPlainText
+  - name: kafkaplaintext
     port: {{ .Values.kop.ports.plaintext }}
   {{- end }}
   {{- end }}

--- a/charts/pulsar/templates/broker/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker/broker-statefulset.yaml
@@ -252,7 +252,7 @@ spec:
         - name: kafkassl
           containerPort: {{ .Values.kop.ports.ssl }}
         {{- else }}
-        - name: kafkaPlainText
+        - name: kafkaplaintext
           containerPort: {{ .Values.kop.ports.plaintext }}
         {{- end }}
         {{- end }}


### PR DESCRIPTION
Currently there are uppercase characters in the label which causes invalid value errors, I have converted them all to lowercase which should resolve this issue. Thanks.