### PR TITLE
k8s/helm pulsar-manager fix missing CSRF_TOKEN

### DIFF
--- a/charts/pulsar/templates/pulsar-manager/pulsar-manager-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-manager/pulsar-manager-initialize.yaml
@@ -54,7 +54,10 @@ spec:
         args:
           - >
             apk add curl;
+            export CSRF_TOKEN=$(curl http://{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-backend:{{ .Values.pulsar_manager.ports.backend }}/pulsar-manager/csrf-token);
             curl -H "Content-Type: application/json" \
+                 -H "X-XSRF-TOKEN: $CSRF_TOKEN" \
+                 -H "Cookie: XSRF-TOKEN=$CSRF_TOKEN;" \
                  -X PUT \
                  http://{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}-backend:{{ .Values.pulsar_manager.ports.backend }}/pulsar-manager/users/superuser \
                  -d '{"name": "{{ .Values.pulsar_manager.superuser.user }}", "password": "{{ .Values.pulsar_manager.superuser.password }}", "description": "{{ .Values.pulsar_manager.superuser.description }}", "email": "{{ .Values.pulsar_manager.superuser.email }}"}' 


### PR DESCRIPTION
In the helm chart template for pulsar-manager initialization,
if token auth is enabled, the initial superuser creation shell
script won't work with pulsar-manager >= 0.2.0 because of a missing
CSRF_TOKEN.

Add this to the curl command so it works.