### PR TITLE
Deploy zk cluster using operator

### DIFF
--- a/.ci/clusters/values_operator_zk.yaml
+++ b/.ci/clusters/values_operator_zk.yaml
@@ -1,0 +1,67 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+components:
+  pulsar_manager: false
+  # disable auto recovery
+  autorecovery: false
+
+monitoring:
+  prometheus: false
+  grafana: false
+  node_exporter: false
+  alert_manager: false
+  loki: false
+
+volumes:
+  local_storage: true
+
+# disabled AntiAffinity
+affinity:
+  anti_affinity: false
+
+zookeeper:
+  replicaCount: 3
+  operator:
+    enabled: true
+
+bookkeeper:
+  replicaCount: 3
+  configData:
+    diskUsageThreshold: "0.999"
+    diskUsageWarnThreshold: "0.999"
+    PULSAR_PREFIX_diskUsageThreshold: "0.999"
+    PULSAR_PREFIX_diskUsageWarnThreshold: "0.999"
+
+broker:
+  replicaCount: 1
+  configData:
+    ## Enable `autoSkipNonRecoverableData` since bookkeeper is running
+    ## without persistence
+    autoSkipNonRecoverableData: "true"
+    # storage settings
+    managedLedgerDefaultEnsembleSize: "1"
+    managedLedgerDefaultWriteQuorum: "1"
+    managedLedgerDefaultAckQuorum: "1"
+
+proxy:
+  replicaCount: 1
+
+toolset:
+  useProxy: false

--- a/.ci/helm.sh
+++ b/.ci/helm.sh
@@ -25,6 +25,7 @@ KIND_BIN=$OUTPUT_BIN/kind
 HELM=${OUTPUT_BIN}/helm
 KUBECTL=${OUTPUT_BIN}/kubectl
 NAMESPACE=pulsar
+OPERATOR_NAMESPACE=sn-system
 CLUSTER=pulsar-ci
 CLUSTER_ID=$(uuidgen)
 
@@ -39,6 +40,46 @@ function ci::delete_cluster() {
     kind delete cluster --name=pulsar-ci-${CLUSTER_ID}
     echo "Successfully delete a kind cluster."
 }
+
+function ci::install_operator_chart() {
+    echo "Installing the pulsar-operators chart ... "
+    ${HELM} plugin install https://github.com/aslafy-z/helm-git --version 0.10.0
+    WC=$(${HELM} plugin list | grep helm-git | wc -l)
+    while [[ ${WC} -lt 1 ]]; do
+      echo ${WC};
+      sleep 15
+      ${HELM} plugin list
+      WC=$(${HELM} plugin list | grep helm-git | wc -l)
+    done
+
+    git config --global url."https://${ACCESS_TOKEN}:@github.com/".insteadOf "https://github.com/"
+
+    ${HELM} repo add sn-operator git+https://github.com/streamnative/pulsar-operators@charts?ref=v0.6.3
+    WC=$(${HELM} repo list | grep sn-operator | wc -l)
+    while [[ ${WC} -lt 1 ]]; do
+      echo ${WC};
+      sleep 15
+      ${HELM} repo list
+      WC=$(${HELM} repo list | grep sn-operator | wc -l)
+    done
+
+    ${KUBECTL} create namespace ${OPERATOR_NAMESPACE}
+    ${KUBECTL} apply -f ${CHARTS_HOME}/charts/pulsar/crds
+
+    ${HELM} install pulsar-operators sn-operator/pulsar --version 0.5.20 -n ${OPERATOR_NAMESPACE}
+
+    WC=$(${KUBECTL} get pods -n ${OPERATOR_NAMESPACE} --field-selector=status.phase=Running | wc -l)
+    while [[ ${WC} -lt 3 ]]; do
+      echo ${WC};
+      sleep 15
+      ${KUBECTL} get pods -n ${OPERATOR_NAMESPACE}
+      WC=$(${KUBECTL} get pods -n ${OPERATOR_NAMESPACE} --field-selector=status.phase=Running | wc -l)
+    done
+
+    echo "Successfully installed the pulsar-operators chart."
+}
+
+
 
 function ci::install_storage_provisioner() {
     echo "Installing the local storage provisioner ..."

--- a/.ci/helm.sh
+++ b/.ci/helm.sh
@@ -52,8 +52,6 @@ function ci::install_operator_chart() {
       WC=$(${HELM} plugin list | grep helm-git | wc -l)
     done
 
-    git config --global url."https://${ACCESS_TOKEN}:@github.com/".insteadOf "https://github.com/"
-
     ${HELM} repo add sn-operator git+https://github.com/streamnative/pulsar-operators@charts?ref=v0.6.3
     WC=$(${HELM} repo list | grep sn-operator | wc -l)
     while [[ ${WC} -lt 1 ]]; do

--- a/.ci/operator_test.sh
+++ b/.ci/operator_test.sh
@@ -7,7 +7,6 @@ VALUES_FILE=$1
 TLS=${TLS:-"false"}
 SYMMETRIC=${SYMMETRIC:-"false"}
 FUNCTION=${FUNCTION:-"false"}
-OPERATOR_NAMESPACE=sn-system
 
 source ${CHARTS_HOME}/.ci/helm.sh
 
@@ -21,6 +20,9 @@ extra_opts=""
 if [[ "x${SYMMETRIC}" == "xtrue" ]]; then
     extra_opts="-s"
 fi
+
+# install pulsar-operators
+ci::install_pulsar_chart
 
 # install pulsar chart
 ci::install_pulsar_chart ${CHARTS_HOME}/${VALUES_FILE} ${extra_opts}

--- a/.github/workflows/pulsar_operator.yml
+++ b/.github/workflows/pulsar_operator.yml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-name: Precommit - Pulsar Helm Chart (Basic Installation)
+name: Precommit - Pulsar Helm Chart (Operator)
 on:
   pull_request:
     branches:

--- a/.github/workflows/pulsar_operator.yml
+++ b/.github/workflows/pulsar_operator.yml
@@ -19,16 +19,14 @@
 
 name: Precommit - Pulsar Helm Chart (Operator)
 on:
-  pull_request:
-    branches:
-      - '*'
-    paths:
-      - 'charts/local-storage-provisioner/**'
-      - 'charts/pulsar/**'
-      - '.github/workflows/**'
+  workflow_dispatch:
+
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    env:
+      GOPRIVATE: github.com/streamnative
+      ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -36,14 +34,25 @@ jobs:
       - name: Fetch history
         run: git fetch --prune --unshallow
 
+      - name: Set up Git token
+        run: |
+          git config --global url."https://${ACCESS_TOKEN}:@github.com/".insteadOf "https://github.com/"
+
       - name: Lint chart
         id: lint
         uses: helm/chart-testing-action@v1.0.0
         with:
           command: lint
 
+      - name: Setup Google Cloud SDK
+          uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+          with:
+            version: '276.0.0'
+            service_account_email: ${{ secrets.GCP_SA_EMAIL }}
+            service_account_key: ${{ secrets.GCP_SA_KEY }}
+
       - name: Install chart
         run: |
-          .ci/operator_test.sh .ci/clusters/values-local-pv.yaml
+          .ci/operator_test.sh .ci/clusters/values_operator_zk.yaml
         # Only build a kind cluster if there are chart changes to test.
         if: steps.lint.outputs.changed == 'true'

--- a/.github/workflows/pulsar_operator.yml
+++ b/.github/workflows/pulsar_operator.yml
@@ -45,11 +45,11 @@ jobs:
           command: lint
 
       - name: Setup Google Cloud SDK
-          uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
-          with:
-            version: '276.0.0'
-            service_account_email: ${{ secrets.GCP_SA_EMAIL }}
-            service_account_key: ${{ secrets.GCP_SA_KEY }}
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          version: '276.0.0'
+          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
 
       - name: Install chart
         run: |

--- a/.github/workflows/pulsar_operator.yml
+++ b/.github/workflows/pulsar_operator.yml
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Precommit - Pulsar Helm Chart (Basic Installation)
+on:
+  pull_request:
+    branches:
+      - '*'
+    paths:
+      - 'charts/local-storage-provisioner/**'
+      - 'charts/pulsar/**'
+      - '.github/workflows/**'
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+
+      - name: Lint chart
+        id: lint
+        uses: helm/chart-testing-action@v1.0.0
+        with:
+          command: lint
+
+      - name: Install chart
+        run: |
+          .ci/operator_test.sh .ci/clusters/values-local-pv.yaml
+        # Only build a kind cluster if there are chart changes to test.
+        if: steps.lint.outputs.changed == 'true'

--- a/.github/workflows/pulsar_operator.yml
+++ b/.github/workflows/pulsar_operator.yml
@@ -20,7 +20,6 @@
 name: Precommit - Pulsar Helm Chart (Operator)
 on:
   workflow_dispatch:
-
 jobs:
   lint-test:
     runs-on: ubuntu-latest

--- a/charts/pulsar/crds/zookeeper.streamnative.io_zookeeperclusters.yaml
+++ b/charts/pulsar/crds/zookeeper.streamnative.io_zookeeperclusters.yaml
@@ -1,0 +1,1561 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.3.0
+  creationTimestamp: null
+  name: zookeeperclusters.zookeeper.streamnative.io
+spec:
+  group: zookeeper.streamnative.io
+  names:
+    kind: ZooKeeperCluster
+    listKind: ZooKeeperClusterList
+    plural: zookeeperclusters
+    singular: zookeepercluster
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ZooKeeperCluster is the Schema for the zookeeperclusters API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ZooKeeperClusterSpec defines the desired state of ZooKeeperCluster
+          properties:
+            apiObjects:
+              description: APIObjects allows precise control over how components (services,
+                statefulset and so on) should be managed
+              properties:
+                clientService:
+                  description: ClientService defines the client service resource template
+                    used for adopting existing client service.
+                  properties:
+                    metadata:
+                      description: 'Standard object''s metadata used to customize
+                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                      type: object
+                    updatePolicy:
+                      description: UpdatePolicy defines which field to update.
+                      items:
+                        description: UpdateMode defines how to update resource.
+                        type: string
+                      type: array
+                  type: object
+                configMap:
+                  description: ConfigMap defines the configmap resource template.
+                  properties:
+                    metadata:
+                      description: 'Standard object''s metadata used to customize
+                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                      type: object
+                    updatePolicy:
+                      description: UpdatePolicy defines which field to update.
+                      items:
+                        description: UpdateMode defines how to update resource.
+                        type: string
+                      type: array
+                  type: object
+                headlessService:
+                  description: HeadlessService defines the headless service resource
+                    template used for adopting existing headless service.
+                  properties:
+                    metadata:
+                      description: 'Standard object''s metadata used to customize
+                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                      type: object
+                    updatePolicy:
+                      description: UpdatePolicy defines which field to update.
+                      items:
+                        description: UpdateMode defines how to update resource.
+                        type: string
+                      type: array
+                  type: object
+                pdb:
+                  description: PDB defines the podDisruptionBudget resource template.
+                  properties:
+                    metadata:
+                      description: 'Standard object''s metadata used to customize
+                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                      type: object
+                    updatePolicy:
+                      description: UpdatePolicy defines which field to update.
+                      items:
+                        description: UpdateMode defines how to update resource.
+                        type: string
+                      type: array
+                  type: object
+                statefulSet:
+                  description: StatefulSet defines the statefulset resource template
+                    for adopting existing headless service.
+                  properties:
+                    metadata:
+                      description: 'Standard object''s metadata used to customize
+                        the name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                      type: object
+                    updatePolicy:
+                      description: UpdatePolicy defines which field to update.
+                      items:
+                        description: UpdateMode defines how to update resource.
+                        type: string
+                      type: array
+                  type: object
+              type: object
+            conf:
+              description: 'Conf defines the zookeeper configuration. It will be used
+                for generating the configuration file used by zookeeper process. Deprecated:
+                use `config`'
+              properties:
+                custom:
+                  additionalProperties:
+                    type: string
+                  description: Custom accepts other configurations
+                  type: object
+                globalOutstandingLimit:
+                  description: "GlobalOutstandingLimit limits the number of queued
+                    outstanding requests \n The default value is 100000"
+                  type: integer
+                initLimit:
+                  description: "InitLimit is the number of ticks that the initial
+                    synchronization phase can take. \n The default value is 10."
+                  type: integer
+                maxClientCnxns:
+                  description: "MaxClientCnxns limits the maximum number of client
+                    connections. \n The default value is 1000"
+                  type: integer
+                serverCnxnFactory:
+                  description: "ServerCnxnFactory is the ServerCnxnFactory implementation.
+                    \n The default value is org.apache.zookeeper.server.NettyServerCnxnFactory"
+                  type: string
+                snapCount:
+                  description: "SnapCount is the number of transactions recorded in
+                    the transaction log before a snapshot can be taken. \n The default
+                    value is 1000000"
+                  type: integer
+                syncLimit:
+                  description: "SyncLimit is the number of ticks that can pass between
+                    sending a request and getting an acknowledgement \n The default
+                    value is 5."
+                  type: integer
+                tickTime:
+                  description: "TickTime is the number of milliseconds of each tick.
+                    A tick is the basic time unit used by ZooKeeper, as measured in
+                    milliseconds \n The default value is 2000."
+                  type: integer
+              type: object
+            config:
+              description: Config defines the zookeeper configuration
+              properties:
+                custom:
+                  additionalProperties:
+                    type: string
+                  description: Custom accepts other configurations
+                  type: object
+                globalOutstandingLimit:
+                  description: "GlobalOutstandingLimit limits the number of queued
+                    outstanding requests \n The default value is 100000"
+                  type: integer
+                initLimit:
+                  description: "InitLimit is the number of ticks that the initial
+                    synchronization phase can take. \n The default value is 10."
+                  type: integer
+                maxClientCnxns:
+                  description: "MaxClientCnxns limits the maximum number of client
+                    connections. \n The default value is 1000"
+                  type: integer
+                serverCnxnFactory:
+                  description: "ServerCnxnFactory is the ServerCnxnFactory implementation.
+                    \n The default value is org.apache.zookeeper.server.NettyServerCnxnFactory"
+                  type: string
+                snapCount:
+                  description: "SnapCount is the number of transactions recorded in
+                    the transaction log before a snapshot can be taken. \n The default
+                    value is 1000000"
+                  type: integer
+                syncLimit:
+                  description: "SyncLimit is the number of ticks that can pass between
+                    sending a request and getting an acknowledgement \n The default
+                    value is 5."
+                  type: integer
+                tickTime:
+                  description: "TickTime is the number of milliseconds of each tick.
+                    A tick is the basic time unit used by ZooKeeper, as measured in
+                    milliseconds \n The default value is 2000."
+                  type: integer
+              type: object
+            image:
+              description: Image is the container image used to run zookeeper pods.
+                default is apachepulsar/pulsar:latest
+              type: string
+            imagePullPolicy:
+              description: Image pull policy, one of Always, Never, IfNotPresent,
+                default to Always.
+              type: string
+            labels:
+              additionalProperties:
+                type: string
+              description: Labels specifies the labels to attach to the stateful set
+                the operator creates for the zookeeper cluster.
+              type: object
+            persistence:
+              description: Persistence defines the persistent volume used for the
+                zookeeper pod
+              properties:
+                data:
+                  description: Data is the spec to define the data PVC for the container
+                  properties:
+                    accessModes:
+                      description: 'AccessModes contains the desired access modes
+                        the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                      items:
+                        type: string
+                      type: array
+                    dataSource:
+                      description: 'This field can be used to specify either: * An
+                        existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                        - Beta) * An existing PVC (PersistentVolumeClaim) * An existing
+                        custom resource/object that implements data population (Alpha)
+                        In order to use VolumeSnapshot object types, the appropriate
+                        feature gate must be enabled (VolumeSnapshotDataSource or
+                        AnyVolumeDataSource) If the provisioner or an external controller
+                        can support the specified data source, it will create a new
+                        volume based on the contents of the specified data source.
+                        If the specified data source is not supported, the volume
+                        will not be created and the failure will be reported as an
+                        event. In the future, we plan to support more data source
+                        types and the behavior of the provisioner may change.'
+                      properties:
+                        apiGroup:
+                          description: APIGroup is the group for the resource being
+                            referenced. If APIGroup is not specified, the specified
+                            Kind must be in the core API group. For any other third-party
+                            types, APIGroup is required.
+                          type: string
+                        kind:
+                          description: Kind is the type of resource being referenced
+                          type: string
+                        name:
+                          description: Name is the name of resource being referenced
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    resources:
+                      description: 'Resources represents the minimum resources the
+                        volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    selector:
+                      description: A label query over volumes to consider for binding.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    storageClassName:
+                      description: 'Name of the StorageClass required by the claim.
+                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                      type: string
+                    volumeMode:
+                      description: volumeMode defines what type of volume is required
+                        by the claim. Value of Filesystem is implied when not included
+                        in claim spec.
+                      type: string
+                    volumeName:
+                      description: VolumeName is the binding reference to the PersistentVolume
+                        backing this claim.
+                      type: string
+                  type: object
+                dataLog:
+                  description: DataLog is the spec to define the data-log PVC for
+                    the container
+                  properties:
+                    accessModes:
+                      description: 'AccessModes contains the desired access modes
+                        the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                      items:
+                        type: string
+                      type: array
+                    dataSource:
+                      description: 'This field can be used to specify either: * An
+                        existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                        - Beta) * An existing PVC (PersistentVolumeClaim) * An existing
+                        custom resource/object that implements data population (Alpha)
+                        In order to use VolumeSnapshot object types, the appropriate
+                        feature gate must be enabled (VolumeSnapshotDataSource or
+                        AnyVolumeDataSource) If the provisioner or an external controller
+                        can support the specified data source, it will create a new
+                        volume based on the contents of the specified data source.
+                        If the specified data source is not supported, the volume
+                        will not be created and the failure will be reported as an
+                        event. In the future, we plan to support more data source
+                        types and the behavior of the provisioner may change.'
+                      properties:
+                        apiGroup:
+                          description: APIGroup is the group for the resource being
+                            referenced. If APIGroup is not specified, the specified
+                            Kind must be in the core API group. For any other third-party
+                            types, APIGroup is required.
+                          type: string
+                        kind:
+                          description: Kind is the type of resource being referenced
+                          type: string
+                        name:
+                          description: Name is the name of resource being referenced
+                          type: string
+                      required:
+                      - kind
+                      - name
+                      type: object
+                    resources:
+                      description: 'Resources represents the minimum resources the
+                        volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                            resources required. If Requests is omitted for a container,
+                            it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. More info:
+                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          type: object
+                      type: object
+                    selector:
+                      description: A label query over volumes to consider for binding.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector
+                            requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector
+                              that contains values, a key, and an operator that relates
+                              the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector
+                                  applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship
+                                  to a set of values. Valid operators are In, NotIn,
+                                  Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values.
+                                  If the operator is In or NotIn, the values array
+                                  must be non-empty. If the operator is Exists or
+                                  DoesNotExist, the values array must be empty. This
+                                  array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                            - key
+                            - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs.
+                            A single {key,value} in the matchLabels map is equivalent
+                            to an element of matchExpressions, whose key field is
+                            "key", the operator is "In", and the values array contains
+                            only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    storageClassName:
+                      description: 'Name of the StorageClass required by the claim.
+                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                      type: string
+                    volumeMode:
+                      description: volumeMode defines what type of volume is required
+                        by the claim. Value of Filesystem is implied when not included
+                        in claim spec.
+                      type: string
+                    volumeName:
+                      description: VolumeName is the binding reference to the PersistentVolume
+                        backing this claim.
+                      type: string
+                  type: object
+                reclaimPolicy:
+                  description: VolumeReclaimPolicy defines how to reclaim PV.
+                  type: string
+              type: object
+            pod:
+              description: Pod defines the policy for creating a zookeeper pod for
+                the cluster
+              properties:
+                affinity:
+                  description: Affinity specifies the scheduling constraints of a
+                    pod
+                  properties:
+                    nodeAffinity:
+                      description: Describes node affinity scheduling rules for the
+                        pod.
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods
+                            to nodes that satisfy the affinity expressions specified
+                            by this field, but it may choose a node that violates
+                            one or more of the expressions. The node that is most
+                            preferred is the one with the greatest sum of weights,
+                            i.e. for each node that meets all of the scheduling requirements
+                            (resource request, requiredDuringScheduling affinity expressions,
+                            etc.), compute a sum by iterating through the elements
+                            of this field and adding "weight" to the sum if the node
+                            matches the corresponding matchExpressions; the node(s)
+                            with the highest sum are the most preferred.
+                          items:
+                            description: An empty preferred scheduling term matches
+                              all objects with implicit weight 0 (i.e. it's a no-op).
+                              A null preferred scheduling term matches no objects
+                              (i.e. is also a no-op).
+                            properties:
+                              preference:
+                                description: A node selector term, associated with
+                                  the corresponding weight.
+                                properties:
+                                  matchExpressions:
+                                    description: A list of node selector requirements
+                                      by node's labels.
+                                    items:
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    description: A list of node selector requirements
+                                      by node's fields.
+                                    items:
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              weight:
+                                description: Weight associated with matching the corresponding
+                                  nodeSelectorTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                            - preference
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the affinity requirements specified by this
+                            field are not met at scheduling time, the pod will not
+                            be scheduled onto the node. If the affinity requirements
+                            specified by this field cease to be met at some point
+                            during pod execution (e.g. due to an update), the system
+                            may or may not try to eventually evict the pod from its
+                            node.
+                          properties:
+                            nodeSelectorTerms:
+                              description: Required. A list of node selector terms.
+                                The terms are ORed.
+                              items:
+                                description: A null or empty node selector term matches
+                                  no objects. The requirements of them are ANDed.
+                                  The TopologySelectorTerm type implements a subset
+                                  of the NodeSelectorTerm.
+                                properties:
+                                  matchExpressions:
+                                    description: A list of node selector requirements
+                                      by node's labels.
+                                    items:
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchFields:
+                                    description: A list of node selector requirements
+                                      by node's fields.
+                                    items:
+                                      description: A node selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: The label key that the selector
+                                            applies to.
+                                          type: string
+                                        operator:
+                                          description: Represents a key's relationship
+                                            to a set of values. Valid operators are
+                                            In, NotIn, Exists, DoesNotExist. Gt, and
+                                            Lt.
+                                          type: string
+                                        values:
+                                          description: An array of string values.
+                                            If the operator is In or NotIn, the values
+                                            array must be non-empty. If the operator
+                                            is Exists or DoesNotExist, the values
+                                            array must be empty. If the operator is
+                                            Gt or Lt, the values array must have a
+                                            single element, which will be interpreted
+                                            as an integer. This array is replaced
+                                            during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                          required:
+                          - nodeSelectorTerms
+                          type: object
+                      type: object
+                    podAffinity:
+                      description: Describes pod affinity scheduling rules (e.g. co-locate
+                        this pod in the same node, zone, etc. as some other pod(s)).
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods
+                            to nodes that satisfy the affinity expressions specified
+                            by this field, but it may choose a node that violates
+                            one or more of the expressions. The node that is most
+                            preferred is the one with the greatest sum of weights,
+                            i.e. for each node that meets all of the scheduling requirements
+                            (resource request, requiredDuringScheduling affinity expressions,
+                            etc.), compute a sum by iterating through the elements
+                            of this field and adding "weight" to the sum if the node
+                            has pods which matches the corresponding podAffinityTerm;
+                            the node(s) with the highest sum are the most preferred.
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm
+                              fields are added per-node to find the most preferred
+                              node(s)
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated
+                                  with the corresponding weight.
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                description: weight associated with matching the corresponding
+                                  podAffinityTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the affinity requirements specified by this
+                            field are not met at scheduling time, the pod will not
+                            be scheduled onto the node. If the affinity requirements
+                            specified by this field cease to be met at some point
+                            during pod execution (e.g. due to a pod label update),
+                            the system may or may not try to eventually evict the
+                            pod from its node. When there are multiple elements, the
+                            lists of nodes corresponding to each podAffinityTerm are
+                            intersected, i.e. all terms must be satisfied.
+                          items:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                    podAntiAffinity:
+                      description: Describes pod anti-affinity scheduling rules (e.g.
+                        avoid putting this pod in the same node, zone, etc. as some
+                        other pod(s)).
+                      properties:
+                        preferredDuringSchedulingIgnoredDuringExecution:
+                          description: The scheduler will prefer to schedule pods
+                            to nodes that satisfy the anti-affinity expressions specified
+                            by this field, but it may choose a node that violates
+                            one or more of the expressions. The node that is most
+                            preferred is the one with the greatest sum of weights,
+                            i.e. for each node that meets all of the scheduling requirements
+                            (resource request, requiredDuringScheduling anti-affinity
+                            expressions, etc.), compute a sum by iterating through
+                            the elements of this field and adding "weight" to the
+                            sum if the node has pods which matches the corresponding
+                            podAffinityTerm; the node(s) with the highest sum are
+                            the most preferred.
+                          items:
+                            description: The weights of all of the matched WeightedPodAffinityTerm
+                              fields are added per-node to find the most preferred
+                              node(s)
+                            properties:
+                              podAffinityTerm:
+                                description: Required. A pod affinity term, associated
+                                  with the corresponding weight.
+                                properties:
+                                  labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of
+                                          label selector requirements. The requirements
+                                          are ANDed.
+                                        items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a
+                                            key, and an operator that relates the
+                                            key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                          - key
+                                          - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only
+                                          "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified
+                                      namespaces, where co-located is defined as running
+                                      on a node whose value of the label with key
+                                      topologyKey matches that of any node on which
+                                      any of the selected pods is running. Empty topologyKey
+                                      is not allowed.
+                                    type: string
+                                required:
+                                - topologyKey
+                                type: object
+                              weight:
+                                description: weight associated with matching the corresponding
+                                  podAffinityTerm, in the range 1-100.
+                                format: int32
+                                type: integer
+                            required:
+                            - podAffinityTerm
+                            - weight
+                            type: object
+                          type: array
+                        requiredDuringSchedulingIgnoredDuringExecution:
+                          description: If the anti-affinity requirements specified
+                            by this field are not met at scheduling time, the pod
+                            will not be scheduled onto the node. If the anti-affinity
+                            requirements specified by this field cease to be met at
+                            some point during pod execution (e.g. due to a pod label
+                            update), the system may or may not try to eventually evict
+                            the pod from its node. When there are multiple elements,
+                            the lists of nodes corresponding to each podAffinityTerm
+                            are intersected, i.e. all terms must be satisfied.
+                          items:
+                            description: Defines a set of pods (namely those matching
+                              the labelSelector relative to the given namespace(s))
+                              that this pod should be co-located (affinity) or not
+                              co-located (anti-affinity) with, where co-located is
+                              defined as running on a node whose value of the label
+                              with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
+                            properties:
+                              labelSelector:
+                                description: A label query over a set of resources,
+                                  in this case pods.
+                                properties:
+                                  matchExpressions:
+                                    description: matchExpressions is a list of label
+                                      selector requirements. The requirements are
+                                      ANDed.
+                                    items:
+                                      description: A label selector requirement is
+                                        a selector that contains values, a key, and
+                                        an operator that relates the key and values.
+                                      properties:
+                                        key:
+                                          description: key is the label key that the
+                                            selector applies to.
+                                          type: string
+                                        operator:
+                                          description: operator represents a key's
+                                            relationship to a set of values. Valid
+                                            operators are In, NotIn, Exists and DoesNotExist.
+                                          type: string
+                                        values:
+                                          description: values is an array of string
+                                            values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If
+                                            the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array
+                                            is replaced during a strategic merge patch.
+                                          items:
+                                            type: string
+                                          type: array
+                                      required:
+                                      - key
+                                      - operator
+                                      type: object
+                                    type: array
+                                  matchLabels:
+                                    additionalProperties:
+                                      type: string
+                                    description: matchLabels is a map of {key,value}
+                                      pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions,
+                                      whose key field is "key", the operator is "In",
+                                      and the values array contains only "value".
+                                      The requirements are ANDed.
+                                    type: object
+                                type: object
+                              namespaces:
+                                description: namespaces specifies which namespaces
+                                  the labelSelector applies to (matches against);
+                                  null or empty list means "this pod's namespace"
+                                items:
+                                  type: string
+                                type: array
+                              topologyKey:
+                                description: This pod should be co-located (affinity)
+                                  or not co-located (anti-affinity) with the pods
+                                  matching the labelSelector in the specified namespaces,
+                                  where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches
+                                  that of any node on which any of the selected pods
+                                  is running. Empty topologyKey is not allowed.
+                                type: string
+                            required:
+                            - topologyKey
+                            type: object
+                          type: array
+                      type: object
+                  type: object
+                annotations:
+                  additionalProperties:
+                    type: string
+                  description: Annotations specifies the annotations to attach to
+                    pods the operator creates
+                  type: object
+                jvmOptions:
+                  description: JVMOptions defines JVM parameters
+                  properties:
+                    extraOptions:
+                      items:
+                        type: string
+                      type: array
+                    gcLoggingOptions:
+                      items:
+                        type: string
+                      type: array
+                    gcOptions:
+                      items:
+                        type: string
+                      type: array
+                    memoryOptions:
+                      items:
+                        type: string
+                      type: array
+                  type: object
+                labels:
+                  additionalProperties:
+                    type: string
+                  description: Labels specifies the labels to attach to pod the operator
+                    creates for the zookeeper cluster.
+                  type: object
+                nodeSelector:
+                  additionalProperties:
+                    type: string
+                  description: NodeSelector specifies a map of key-value pairs. For
+                    a pod to be eligible to run on a node, the node must have each
+                    of the indicated key-value pairs as labels.
+                  type: object
+                resources:
+                  description: Resources specifies the resource requirements of a
+                    pod to run in the cluster
+                  properties:
+                    limits:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Limits describes the maximum amount of compute
+                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                    requests:
+                      additionalProperties:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      description: 'Requests describes the minimum amount of compute
+                        resources required. If Requests is omitted for a container,
+                        it defaults to Limits if that is explicitly specified, otherwise
+                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                      type: object
+                  type: object
+                securityContext:
+                  description: 'SecurityContext specifies the security context for
+                    the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
+                  properties:
+                    fsGroup:
+                      description: "A special supplemental group that applies to all
+                        containers in a pod. Some volume types allow the Kubelet to
+                        change the ownership of that volume to be owned by the pod:
+                        \n 1. The owning GID will be the FSGroup 2. The setgid bit
+                        is set (new files created in the volume will be owned by FSGroup)
+                        3. The permission bits are OR'd with rw-rw---- \n If unset,
+                        the Kubelet will not modify the ownership and permissions
+                        of any volume."
+                      format: int64
+                      type: integer
+                    fsGroupChangePolicy:
+                      description: 'fsGroupChangePolicy defines behavior of changing
+                        ownership and permission of the volume before being exposed
+                        inside Pod. This field will only apply to volume types which
+                        support fsGroup based ownership(and permissions). It will
+                        have no effect on ephemeral volume types such as: secret,
+                        configmaps and emptydir. Valid values are "OnRootMismatch"
+                        and "Always". If not specified defaults to "Always".'
+                      type: string
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container
+                        process. Uses runtime default if unset. May also be set in
+                        SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence for
+                        that container.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to
+                        start the container if it does. If unset or false, no such
+                        validation will be performed. May also be set in SecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container
+                        process. Defaults to user specified in image metadata if unspecified.
+                        May also be set in SecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence for that container.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: The SELinux context to be applied to all containers.
+                        If unspecified, the container runtime will allocate a random
+                        SELinux context for each container.  May also be set in SecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence for that container.
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    seccompProfile:
+                      description: The seccomp options to use by the containers in
+                        this pod.
+                      properties:
+                        localhostProfile:
+                          description: localhostProfile indicates a profile defined
+                            in a file on the node should be used. The profile must
+                            be preconfigured on the node to work. Must be a descending
+                            path, relative to the kubelet's configured seccomp profile
+                            location. Must only be set if type is "Localhost".
+                          type: string
+                        type:
+                          description: "type indicates which kind of seccomp profile
+                            will be applied. Valid options are: \n Localhost - a profile
+                            defined in a file on the node should be used. RuntimeDefault
+                            - the container runtime default profile should be used.
+                            Unconfined - no profile should be applied."
+                          type: string
+                      required:
+                      - type
+                      type: object
+                    supplementalGroups:
+                      description: A list of groups applied to the first process run
+                        in each container, in addition to the container's primary
+                        GID.  If unspecified, no groups will be added to any container.
+                      items:
+                        format: int64
+                        type: integer
+                      type: array
+                    sysctls:
+                      description: Sysctls hold a list of namespaced sysctls used
+                        for the pod. Pods with unsupported sysctls (by the container
+                        runtime) might fail to launch.
+                      items:
+                        description: Sysctl defines a kernel parameter to be set
+                        properties:
+                          name:
+                            description: Name of a property to set
+                            type: string
+                          value:
+                            description: Value of a property to set
+                            type: string
+                        required:
+                        - name
+                        - value
+                        type: object
+                      type: array
+                    windowsOptions:
+                      description: The Windows specific settings applied to all containers.
+                        If unspecified, the options within a container's SecurityContext
+                        will be used. If set in both SecurityContext and PodSecurityContext,
+                        the value specified in SecurityContext takes precedence.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named
+                            by the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
+                terminationGracePeriodSeconds:
+                  description: TerminationGracePeriodSeconds is the amount of time
+                    that kubernetes will give for a pod before terminating it.
+                  format: int64
+                  type: integer
+                tolerations:
+                  description: Tolerations specifies the tolerations of a Pod
+                  items:
+                    description: The pod this Toleration is attached to tolerates
+                      any taint that matches the triple <key,value,effect> using the
+                      matching operator <operator>.
+                    properties:
+                      effect:
+                        description: Effect indicates the taint effect to match. Empty
+                          means match all taint effects. When specified, allowed values
+                          are NoSchedule, PreferNoSchedule and NoExecute.
+                        type: string
+                      key:
+                        description: Key is the taint key that the toleration applies
+                          to. Empty means match all taint keys. If the key is empty,
+                          operator must be Exists; this combination means to match
+                          all values and all keys.
+                        type: string
+                      operator:
+                        description: Operator represents a key's relationship to the
+                          value. Valid operators are Exists and Equal. Defaults to
+                          Equal. Exists is equivalent to wildcard for value, so that
+                          a pod can tolerate all taints of a particular category.
+                        type: string
+                      tolerationSeconds:
+                        description: TolerationSeconds represents the period of time
+                          the toleration (which must be of effect NoExecute, otherwise
+                          this field is ignored) tolerates the taint. By default,
+                          it is not set, which means tolerate the taint forever (do
+                          not evict). Zero and negative values will be treated as
+                          0 (evict immediately) by the system.
+                        format: int64
+                        type: integer
+                      value:
+                        description: Value is the taint value the toleration matches
+                          to. If the operator is Exists, the value should be empty,
+                          otherwise just a regular string.
+                        type: string
+                    type: object
+                  type: array
+                vars:
+                  description: Vars specifies the environment variables of a Pod
+                  items:
+                    description: EnvVar represents an environment variable present
+                      in a Container.
+                    properties:
+                      name:
+                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        type: string
+                      value:
+                        description: 'Variable references $(VAR_NAME) are expanded
+                          using the previous defined environment variables in the
+                          container and any service environment variables. If a variable
+                          cannot be resolved, the reference in the input string will
+                          be unchanged. The $(VAR_NAME) syntax can be escaped with
+                          a double $$, ie: $$(VAR_NAME). Escaped references will never
+                          be expanded, regardless of whether the variable exists or
+                          not. Defaults to "".'
+                        type: string
+                      valueFrom:
+                        description: Source for the environment variable's value.
+                          Cannot be used if value is not empty.
+                        properties:
+                          configMapKeyRef:
+                            description: Selects a key of a ConfigMap.
+                            properties:
+                              key:
+                                description: The key to select.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the ConfigMap or its
+                                  key must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                          fieldRef:
+                            description: 'Selects a field of the pod: supports metadata.name,
+                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP,
+                              status.podIP, status.podIPs.'
+                            properties:
+                              apiVersion:
+                                description: Version of the schema the FieldPath is
+                                  written in terms of, defaults to "v1".
+                                type: string
+                              fieldPath:
+                                description: Path of the field to select in the specified
+                                  API version.
+                                type: string
+                            required:
+                            - fieldPath
+                            type: object
+                          resourceFieldRef:
+                            description: 'Selects a resource of the container: only
+                              resources limits and requests (limits.cpu, limits.memory,
+                              limits.ephemeral-storage, requests.cpu, requests.memory
+                              and requests.ephemeral-storage) are currently supported.'
+                            properties:
+                              containerName:
+                                description: 'Container name: required for volumes,
+                                  optional for env vars'
+                                type: string
+                              divisor:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Specifies the output format of the exposed
+                                  resources, defaults to "1"
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              resource:
+                                description: 'Required: resource to select'
+                                type: string
+                            required:
+                            - resource
+                            type: object
+                          secretKeyRef:
+                            description: Selects a key of a secret in the pod's namespace
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  type: array
+              type: object
+            replicas:
+              description: Replicas is the expected size of the zookeeper cluster.
+                The zookeeper operator will eventually make the size of the running
+                cluster equal to the expected size.
+              format: int32
+              type: integer
+          type: object
+        status:
+          description: ZooKeeperClusterStatus defines the observed state of ZooKeeperCluster
+          properties:
+            conditions:
+              description: Conditions represent observations of the ZookeeperCluster's
+                state
+              items:
+                description: "Condition represents an observation of an object's state.
+                  Conditions are an extension mechanism intended to be used when the
+                  details of an observation are not a priori known or would not apply
+                  to all instances of a given Kind. \n Conditions should be added
+                  to explicitly convey properties that users and components care about
+                  rather than requiring those properties to be inferred from other
+                  observations. Once defined, the meaning of a Condition can not be
+                  changed arbitrarily - it becomes part of the API, and has the same
+                  backwards- and forwards-compatibility concerns of any other part
+                  of the API."
+                properties:
+                  lastTransitionTime:
+                    format: date-time
+                    type: string
+                  message:
+                    type: string
+                  reason:
+                    description: ConditionReason is intended to be a one-word, CamelCase
+                      representation of the category of cause of the current status.
+                      It is intended to be used in concise output, such as one-line
+                      kubectl get output, and in summarizing occurrences of causes.
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    description: "ConditionType is the type of the condition and is
+                      typically a CamelCased word or short phrase. \n Condition types
+                      should indicate state in the \"abnormal-true\" polarity. For
+                      example, if the condition indicates when a policy is invalid,
+                      the \"is valid\" case is probably the norm, so the condition
+                      should be called \"Invalid\"."
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            externalServiceEndpoint:
+              description: ExternalServiceEndpoint is the external service endpoint
+                (ip:port)
+              type: string
+            internalServiceEndpoint:
+              description: InternalServiceEndpoint is the internal service endpoint
+                (ip:port)
+              type: string
+            numReadyServers:
+              description: NumReadyServers is the number of zookeeper servers in the
+                cluster that are in ready status
+              format: int32
+              type: integer
+            replicas:
+              description: Replicas is the number of desired zookeeper servers in
+                the cluster
+              format: int32
+              type: integer
+            servers:
+              description: Servers is the list of servers in the zookeeper cluster
+              properties:
+                notReady:
+                  items:
+                    type: string
+                  type: array
+                ready:
+                  items:
+                    type: string
+                  type: array
+              required:
+              - notReady
+              - ready
+              type: object
+          required:
+          - conditions
+          - externalServiceEndpoint
+          - internalServiceEndpoint
+          - numReadyServers
+          - replicas
+          - servers
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/pulsar/templates/zookeeper/gen-zk-conf.yaml
+++ b/charts/pulsar/templates/zookeeper/gen-zk-conf.yaml
@@ -25,7 +25,9 @@ metadata:
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
   annotations:
+    {{- if .Values.zookeeper.resourcePolicy.keep }}
     "helm.sh/resource-policy": keep
+    {{- end }}
 data:
   gen-zk-conf.sh: |
     #!/bin/bash

--- a/charts/pulsar/templates/zookeeper/gen-zk-conf.yaml
+++ b/charts/pulsar/templates/zookeeper/gen-zk-conf.yaml
@@ -24,6 +24,8 @@ metadata:
   namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
+  annotations:
+    "helm.sh/resource-policy": keep
 data:
   gen-zk-conf.sh: |
     #!/bin/bash

--- a/charts/pulsar/templates/zookeeper/zookeeper-cluster.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-cluster.yaml
@@ -168,8 +168,6 @@ spec:
     headlessService:
       metadata:
         name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
-      updatePolicy:
-        - all
     statefulSet:
       metadata:
         name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
@@ -182,12 +180,8 @@ spec:
     configMap:
       metadata:
         name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
-      updatePolicy:
-        - all
     pdb:
       metadata:
         name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
-      updatePolicy:
-        - all
 {{- end }}
 {{- end }}

--- a/charts/pulsar/templates/zookeeper/zookeeper-cluster.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-cluster.yaml
@@ -1,0 +1,189 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# deploy zookeeper only when `components.zookeeper` is true
+{{- if .Values.components.zookeeper }}
+{{- if or .Values.zookeeper.operator.enabled .Values.zookeeper.operator.adopt_existing }}
+apiVersion: zookeeper.streamnative.io/v1alpha1
+kind: ZooKeeperCluster
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
+  namespace: {{ template "pulsar.namespace" . }}
+  annotations:
+    "cloud.streamnative.io/ignore-leader-check": "true"
+    "cloud.streamnative.io/cluster-force-update": "true"
+  labels:
+    {{- include "pulsar.standardLabels" . | nindent 4 }}
+    component: {{ .Values.zookeeper.component }}
+spec:
+  replicas: {{ .Values.zookeeper.replicaCount }}
+  image: "{{ .Values.images.zookeeper.repository }}:{{ .Values.images.zookeeper.tag }}"
+  pod:
+    labels:
+      {{- include "pulsar.template.labels" . | nindent 6 }}
+      component: {{ .Values.zookeeper.component }}
+    annotations:
+      {{- if .Values.monitoring.datadog }}
+      {{- include "pulsar.zookeeper.datadog.annotation" . | nindent 6 }}
+      {{- end }}
+{{- with .Values.zookeeper.annotations }}
+{{ toYaml . | indent 6 }}
+{{- end }}
+    affinity:
+      {{- if and .Values.affinity.anti_affinity .Values.zookeeper.affinity.anti_affinity }}
+      podAntiAffinity:
+        {{ .Values.zookeeper.affinity.type }}:
+          {{ if eq .Values.zookeeper.affinity.type "requiredDuringSchedulingIgnoredDuringExecution" }}
+          - labelSelector:
+              matchExpressions:
+                - key: "app"
+                  operator: In
+                  values:
+                    - "{{ template "pulsar.name" . }}"
+                - key: "release"
+                  operator: In
+                  values:
+                    - {{ .Release.Name }}
+                - key: "component"
+                  operator: In
+                  values:
+                    - {{ .Values.zookeeper.component }}
+            topologyKey: "kubernetes.io/hostname"
+          {{ else }}
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: "app"
+                    operator: In
+                    values:
+                      - "{{ template "pulsar.name" . }}"
+                  - key: "release"
+                    operator: In
+                    values:
+                      - {{ .Release.Name }}
+                  - key: "component"
+                    operator: In
+                    values:
+                      - {{ .Values.zookeeper.component }}
+              topologyKey: "kubernetes.io/hostname"
+          {{ end }}
+        {{- end }}
+    {{- if .Values.zookeeper.resources }}
+    resources:
+      requests:
+        memory: "{{ .Values.zookeeper.resources.requests.memory }}"
+        cpu: "{{ .Values.zookeeper.resources.requests.cpu }}"
+    {{- end }}
+    {{- if .Values.zookeeper.securityContext }}
+    securityContext: {{ .Values.zookeeper.securityContext }}
+    {{- end }}
+    {{- if .Values.zookeeper.tolerations }}
+    tolerations:
+{{ toYaml .Values.zookeeper.tolerations | indent 6 }}
+    {{- end }}
+    terminationGracePeriodSeconds: {{ .Values.zookeeper.gracePeriod }}
+    jvmOptions:
+      memoryOptions:
+        - {{ .Values.zookeeper.configData.PULSAR_MEM }}
+      gcOptions:
+        - {{ .Values.zookeeper.configData.PULSAR_GC }}
+  {{- if and .Values.volumes.persistence .Values.zookeeper.volumes.persistence }}
+  persistence:
+    data:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: {{ .Values.zookeeper.volumes.data.size }}
+    {{- if and .Values.volumes.local_storage .Values.zookeeper.volumes.data.local_storage }}
+      storageClassName: "local-storage"
+    {{- else }}
+      {{- if  .Values.zookeeper.volumes.data.storageClass }}
+      storageClassName: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.data.name }}"
+      {{- else if .Values.zookeeper.volumes.data.storageClassName }}
+      storageClassName: {{ .Values.zookeeper.volumes.data.storageClassName }}
+      {{- end -}}
+    {{- end }}
+    {{- if .Values.zookeeper.volumes.useSeparateDiskForTxlog }}
+    dataLog:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: {{ .Values.zookeeper.volumes.dataLog.size }}
+    {{- if and .Values.volumes.local_storage .Values.zookeeper.volumes.data.local_storage }}
+      storageClassName: "local-storage"
+    {{- else }}
+      {{- if  .Values.zookeeper.volumes.data.storageClass }}
+      storageClassName: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}-{{ .Values.zookeeper.volumes.data.name }}"
+      {{- else if .Values.zookeeper.volumes.data.storageClassName }}
+      storageClassName: {{ .Values.zookeeper.volumes.data.storageClassName }}
+      {{- end -}}
+    {{- end }}
+    {{- end }}
+    reclaimPolicy: Delete
+  {{- end }}
+  config:
+    serverCnxnFactory: org.apache.zookeeper.server.NettyServerCnxnFactory
+    # copy from configmap
+    custom:
+      dataDir: /pulsar/data/zookeeper
+      {{- if .Values.zookeeper.volumes.useSeparateDiskForTxlog }}
+      # use a seperate disk for tx log
+      PULSAR_PREFIX_dataLogDir: /pulsar/data/zookeeper-datalog
+      {{- end }}
+      PULSAR_PREFIX_serverCnxnFactory: org.apache.zookeeper.server.NettyServerCnxnFactory
+      # enable zookeeper tls
+      {{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
+      secureClientPort: "{{ .Values.zookeeper.ports.clientTls }}"
+      PULSAR_PREFIX_secureClientPort: "{{ .Values.zookeeper.ports.clientTls }}"
+      {{- end }}
+      {{- if .Values.zookeeper.reconfig.enabled }}
+      PULSAR_PREFIX_reconfigEnabled: "true"
+      PULSAR_PREFIX_quorumListenOnAllIPs: "true"
+      {{- end }}
+      PULSAR_PREFIX_peerType: {{ .Values.zookeeper.peerType }}
+{{ toYaml .Values.zookeeper.configData | indent 6 }}
+      # Include log configuration file, If you want to configure the log level and other configuration
+      # items, you can modify the configmap, and eventually it will overwrite the log4j2.yaml file under conf
+{{ (.Files.Glob "conf/zookeeper/log4j2.yaml").AsConfig | indent 6 }}
+  apiObjects:
+    clientService: {}
+    headlessService:
+      metadata:
+        name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
+      updatePolicy:
+      - all
+    statefulSet:
+      metadata:
+        name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
+      updatePolicy:
+      - default
+    configMap:
+      metadata:
+        name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
+      updatePolicy:
+      - all
+    pdb:
+      metadata:
+        name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
+      updatePolicy:
+      - all
+{{- end }}
+{{- end }}

--- a/charts/pulsar/templates/zookeeper/zookeeper-cluster.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-cluster.yaml
@@ -17,8 +17,7 @@
 # under the License.
 #
 # deploy zookeeper only when `components.zookeeper` is true
-{{- if .Values.components.zookeeper }}
-{{- if .Values.zookeeper.operator.enabled }}
+{{- if and .Values.components.zookeeper .Values.zookeeper.operator.enabled }}
 apiVersion: zookeeper.streamnative.io/v1alpha1
 kind: ZooKeeperCluster
 metadata:
@@ -183,5 +182,4 @@ spec:
     pdb:
       metadata:
         name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
-{{- end }}
 {{- end }}

--- a/charts/pulsar/templates/zookeeper/zookeeper-cluster.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-cluster.yaml
@@ -18,7 +18,7 @@
 #
 # deploy zookeeper only when `components.zookeeper` is true
 {{- if .Values.components.zookeeper }}
-{{- if or .Values.zookeeper.operator.enabled }}
+{{- if .Values.zookeeper.operator.enabled }}
 apiVersion: zookeeper.streamnative.io/v1alpha1
 kind: ZooKeeperCluster
 metadata:

--- a/charts/pulsar/templates/zookeeper/zookeeper-cluster.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-cluster.yaml
@@ -18,7 +18,7 @@
 #
 # deploy zookeeper only when `components.zookeeper` is true
 {{- if .Values.components.zookeeper }}
-{{- if or .Values.zookeeper.operator.enabled .Values.zookeeper.operator.adopt_existing }}
+{{- if or .Values.zookeeper.operator.enabled }}
 apiVersion: zookeeper.streamnative.io/v1alpha1
 kind: ZooKeeperCluster
 metadata:
@@ -169,21 +169,25 @@ spec:
       metadata:
         name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
       updatePolicy:
-      - all
+        - all
     statefulSet:
       metadata:
         name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
       updatePolicy:
-      - default
+      {{- if .Values.zookeeper.operator.adopt_existing }}
+      {{ .Values.zookeeper.operator.updatePolicy }}
+      {{- else }}
+        - all
+      {{- end }}
     configMap:
       metadata:
         name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
       updatePolicy:
-      - all
+        - all
     pdb:
       metadata:
         name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
       updatePolicy:
-      - all
+        - all
 {{- end }}
 {{- end }}

--- a/charts/pulsar/templates/zookeeper/zookeeper-configmap.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-configmap.yaml
@@ -18,7 +18,7 @@
 #
 
 # deploy zookeeper only when `components.zookeeper` is true
-{{- if .Values.components.zookeeper }}
+{{- if and .Values.components.zookeeper (not .Values.zookeeper.operator.enabled) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/pulsar/templates/zookeeper/zookeeper-configmap.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-configmap.yaml
@@ -27,6 +27,8 @@ metadata:
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.zookeeper.component }}
+  annotations:
+    "helm.sh/resource-policy": keep
 data:
   dataDir: /pulsar/data/zookeeper
   {{- if .Values.zookeeper.volumes.useSeparateDiskForTxlog }}

--- a/charts/pulsar/templates/zookeeper/zookeeper-configmap.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-configmap.yaml
@@ -28,7 +28,9 @@ metadata:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.zookeeper.component }}
   annotations:
+    {{- if .Values.zookeeper.resourcePolicy.keep }}
     "helm.sh/resource-policy": keep
+    {{- end }}
 data:
   dataDir: /pulsar/data/zookeeper
   {{- if .Values.zookeeper.volumes.useSeparateDiskForTxlog }}

--- a/charts/pulsar/templates/zookeeper/zookeeper-pdb.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-pdb.yaml
@@ -18,7 +18,7 @@
 #
 
 # deploy zookeeper only when `components.zookeeper` is true
-{{- if .Values.components.zookeeper }}
+{{- if and .Values.components.zookeeper (not .Values.zookeeper.operator.enabled) }}
 {{- if .Values.zookeeper.pdb.usePolicy }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget

--- a/charts/pulsar/templates/zookeeper/zookeeper-pdb.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-pdb.yaml
@@ -28,6 +28,8 @@ metadata:
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.zookeeper.component }}
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   selector:
     matchLabels:

--- a/charts/pulsar/templates/zookeeper/zookeeper-pdb.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-pdb.yaml
@@ -29,7 +29,9 @@ metadata:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.zookeeper.component }}
   annotations:
+    {{- if .Values.zookeeper.resourcePolicy.keep }}
     "helm.sh/resource-policy": keep
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/charts/pulsar/templates/zookeeper/zookeeper-service.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-service.yaml
@@ -18,7 +18,7 @@
 #
 
 # deploy zookeeper only when `components.zookeeper` is true
-{{- if .Values.components.zookeeper }}
+{{- if and .Values.components.zookeeper (not .Values.zookeeper.operator.enabled) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/pulsar/templates/zookeeper/zookeeper-service.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-service.yaml
@@ -28,7 +28,9 @@ metadata:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.zookeeper.component }}
   annotations:
+    {{- if .Values.zookeeper.resourcePolicy.keep }}
     "helm.sh/resource-policy": keep
+    {{- end }}
 {{ toYaml .Values.zookeeper.service.annotations | indent 4 }}
 spec:
   ports:

--- a/charts/pulsar/templates/zookeeper/zookeeper-service.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-service.yaml
@@ -28,6 +28,7 @@ metadata:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.zookeeper.component }}
   annotations:
+    "helm.sh/resource-policy": keep
 {{ toYaml .Values.zookeeper.service.annotations | indent 4 }}
 spec:
   ports:

--- a/charts/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
@@ -18,7 +18,7 @@
 #
 
 # deploy zookeeper only when `components.zookeeper` is true
-{{- if .Values.components.zookeeper }}
+{{- if and .Values.components.zookeeper (not .Values.zookeeper.operator.enabled) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
@@ -50,7 +50,7 @@ spec:
         {{- if .Values.monitoring.datadog }}
         {{- include "pulsar.zookeeper.datadog.annotation" . | nindent 8 }}
         {{- end }}
-        {{- if .Values.zookeeper.autoRollDeployment }}
+        {{- if and .Values.zookeeper.autoRollDeployment }}
         checksum/config: {{ include (print $.Template.BasePath "/zookeeper/zookeeper-configmap.yaml") . | sha256sum }}
         {{- end }}
 {{- with .Values.zookeeper.annotations }}

--- a/charts/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
@@ -50,7 +50,7 @@ spec:
         {{- if .Values.monitoring.datadog }}
         {{- include "pulsar.zookeeper.datadog.annotation" . | nindent 8 }}
         {{- end }}
-        {{- if and .Values.zookeeper.autoRollDeployment }}
+        {{- if .Values.zookeeper.autoRollDeployment }}
         checksum/config: {{ include (print $.Template.BasePath "/zookeeper/zookeeper-configmap.yaml") . | sha256sum }}
         {{- end }}
 {{- with .Values.zookeeper.annotations }}

--- a/charts/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
@@ -27,6 +27,8 @@ metadata:
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.zookeeper.component }}
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
   replicas: {{ .Values.zookeeper.replicaCount }}

--- a/charts/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-statefulset.yaml
@@ -28,7 +28,9 @@ metadata:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.zookeeper.component }}
   annotations:
+    {{- if .Values.zookeeper.resourcePolicy.keep }}
     "helm.sh/resource-policy": keep
+    {{- end }}
 spec:
   serviceName: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
   replicas: {{ .Values.zookeeper.replicaCount }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -573,7 +573,6 @@ zookeeper:
   ## templates/zookeeper-cluster.yaml
   operator:
     enabled: false
-    adopt_existing: false
 
 ## Pulsar: Bookkeeper cluster
 ## templates/bookkeeper-statefulset.yaml

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -569,6 +569,11 @@ zookeeper:
   pdb:
     usePolicy: true
     maxUnavailable: 1
+  ## Operator Controller
+  ## templates/zookeeper-cluster.yaml
+  operator:
+    enabled: false
+    adopt_existing: false
 
 ## Pulsar: Bookkeeper cluster
 ## templates/bookkeeper-statefulset.yaml

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -573,6 +573,12 @@ zookeeper:
   ## templates/zookeeper-cluster.yaml
   operator:
     enabled: false
+    adopt_existing: false
+    updatePolicy: >
+      - default
+  ## Retention Policy
+  resourcePolicy:
+    keep: false
 
 ## Pulsar: Bookkeeper cluster
 ## templates/bookkeeper-statefulset.yaml

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -574,8 +574,7 @@ zookeeper:
   operator:
     enabled: false
     adopt_existing: false
-    updatePolicy: >
-      - default
+    updatePolicy: []
   ## Retention Policy
   resourcePolicy:
     keep: false

--- a/examples/pulsar/values-operator.yaml
+++ b/examples/pulsar/values-operator.yaml
@@ -48,5 +48,5 @@ zookeeper:
   volumes:
     useSeparateDiskForTxlog: true
   operator:
-    enabled: true
+    enabled: false
   

--- a/examples/pulsar/values-operator.yaml
+++ b/examples/pulsar/values-operator.yaml
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+metadataPrefix: "/configuration-store"
+
+## start
+components:
+  # zookeeper
+  zookeeper: true
+  # bookkeeper
+  bookkeeper: false
+  # bookkeeper - autorecovery
+  autorecovery: false
+  # broker
+  broker: false
+  # proxy
+  proxy: false
+  # toolset
+  toolset: false
+  # pulsar manager
+  pulsar_manager: false
+
+monitoring:
+  # monitoring - prometheus
+  prometheus: false
+  # monitoring - grafana
+  grafana: false
+  # monitoring - node_exporter
+  node_exporter: false
+
+zookeeper:
+  volumes:
+    useSeparateDiskForTxlog: true
+  operator:
+    enabled: true
+  


### PR DESCRIPTION
## A demo for deploying cluster using operator

### Motivation
To taking over zk cluster using our operator.

### Modifications
```yaml
## Operator Controller
## templates/zookeeper-cluster.yaml
  operator:
    enabled: false
    adopt_existing: false
    updatePolicy: []
## Retention Policy
  resourcePolicy:
    keep: false
```
#### update policy
##### commons 
```golang
const (
	// UpdateAll defines to update all fields.
	UpdateAll UpdateMode = "all"
	// UpdateNone defines that the API Object refuses to be updated.
	UpdateNone UpdateMode = "none"
)
```
##### pod template
```golang
const (
	UpdateFinalizers UpdateMode = "finalizers"
	UpdateReplicas   UpdateMode = "replicas"
	UpdateCmd        UpdateMode = "cmd"
	UpdateEnv        UpdateMode = "env"
	UpdatePorts      UpdateMode = "ports"
	UpdateProbes     UpdateMode = "probes"
)
```
**enabled** represent we want to use operator to deploy a ZK cluster whenever you create a new cluster or take over an existing cluster.
**adopt_existing** means we want to take over an existing cluster using operator and it can use updatePolicy, otherwise it will use all Policy.

When taking over cluster by operator, we set up an annotation `"helm.sh/resource-policy": keep` to skip deleting these resource when a helm operation and these resource becomes orphaned. Finally our operator can control cluster by helm without original interference.

### Compatibility

We already compat the most configuration between operator and helm in CRD instance yaml.
That means we don't need to do extra work to taking over cluster and we can create a new ZK cluster using Helm 
by our operator.

### How to adopt an existing cluster

1. update streamnative repo
    `helm repo update`
2. upgrade and add `helm.sh/resource-policy": keep `annotation
  ```shell
  helm get values helm-mgr  > pulsar.yaml
  helm upgrade -f pulsar.yaml --set zookeeper.resourcePolicy.keep=true helm-mgr streamnative/pulsar
  ```
  Waiting for all of the zk pod upgrading completed.
3. start up opeator and adopt cluster
```shell
helm get values helm-mgr  > pulsar.yaml
# change value.yaml  and set enabled: true adopt_existing: true

cat pulsar.yaml
  ...
  operator:
      enabled: true
      adopt_existing: true
  resourcePolicy:
      keep: true
  ...

helm upgrade -f pulsar.yaml helm-mgr streamnative/pulsar
```
 Waiting for upgrading process completed.

### How to create a new cluster using Helm
To start up operator and set operator.enabled = true is a very simply way to create a new cluster using operator.
```shell
cat values.yaml
 ...
  operator:
      enabled: true
  ..
```


