### PR TITLE
Update the metadata tool version

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -574,7 +574,7 @@ zookeeper:
       component: "backup"
       enable: false
       repository: "streamnative/pulsar-metadata-tool"
-      tag: "2.7.1.2"
+      tag: "2.7.0-1"
       pullPolicy: IfNotPresent
       webServerPort: "8088"
     #  secrets:
@@ -592,7 +592,7 @@ zookeeper:
       component: "restore"
       enable: false
       repository: "streamnative/pulsar-metadata-tool"
-      tag: "2.7.1.2"
+      tag: "2.7.0-1"
       pullPolicy: IfNotPresent
       restorePoint: ""
       restoreVersion: "1"


### PR DESCRIPTION
**Motivation**

We have a patch for the pulsar-metadata-tool 2.7.0 and named it `2.7.0-1`.  It will follow the 2.7.1.x release name to release after this release.