### PR TITLE
Add Superset as a dependency to allow pulsar-sql to connect

### DIFF
--- a/charts/pulsar/requirements.yaml
+++ b/charts/pulsar/requirements.yaml
@@ -22,3 +22,7 @@ dependencies:
   version: 0.36.1
   repository: https://grafana.github.io/loki/charts
   condition: monitoring.loki
+- name: superset
+  version: 0.1.1
+  repository:  https://apache.github.io/superset
+  condition: components.superset

--- a/charts/pulsar/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/pulsar/templates/presto/presto-coordinator-statefulset.yaml
@@ -108,7 +108,7 @@ spec:
           {{- if .Values.presto.coordinator.probe.liveness.enabled }}
           livenessProbe:
             httpGet:
-              path: /v1/cluster
+              path: /v1/status
               port: {{ .Values.presto.coordinator.ports.http }}
             initialDelaySeconds: {{ .Values.presto.coordinator.probe.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.presto.coordinator.probe.liveness.periodSeconds }}
@@ -117,7 +117,7 @@ spec:
           {{- if .Values.presto.coordinator.probe.readiness.enabled }}
           readinessProbe:
             httpGet:
-              path: /v1/cluster
+              path: /v1/status
               port: {{ .Values.presto.coordinator.ports.http }}
             initialDelaySeconds: {{ .Values.presto.coordinator.probe.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.presto.coordinator.probe.readiness.periodSeconds }}

--- a/charts/pulsar/templates/presto/presto-worker-configmap.yaml
+++ b/charts/pulsar/templates/presto/presto-worker-configmap.yaml
@@ -229,6 +229,6 @@ data:
     pulsar.managed-ledger-num-scheduler-threads = {{ .Values.presto.catalog.pulsar.mlNumSchedulerThreads }}
   health_check.sh: |
     #!/bin/bash 
-    curl --silent {{ template "presto.service" . }}:{{ .Values.presto.coordinator.ports.http }}/v1/node | tr "," "\n" | grep --silent $(hostname -i)
+    curl --silent {{ template "presto.service" . }}:{{ .Values.presto.coordinator.ports.http }}/v1/node | tr "," "\n" | grep --silent $(hostname)
 {{- end }}
 {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -94,6 +94,8 @@ components:
   kop: false
   # pulsar detector
   pulsar_detector: false
+  # superset
+  superset: false
 
 ## Monitoring Components
 ##


### PR DESCRIPTION
**Motivation**

Add [Superset](https://github.com/apache/superset) as a dependency to allow pulsar-sql to connect.

**Modification**

- Change pulsar-sql status check endpoint. The `/v1/cluster` already removed in trino. https://github.com/trinodb/trino/issues/3661
- `hostname -i` will return the host IP, not the hostname. `/v1/node` will return an FQDN