### PR TITLE
Fix rbac/config for namespace only prom

### DIFF
--- a/charts/pulsar/templates/prometheus/prometheus-configmap.yaml
+++ b/charts/pulsar/templates/prometheus/prometheus-configmap.yaml
@@ -58,6 +58,11 @@ data:
 {{- end }}
       kubernetes_sd_configs:
       - role: pod
+{{- if eq .Values.prometheus.serviceAccount.clusterRole false }}
+        namespaces:
+          names:
+            - {{ .Values.namespace }}
+{{- end }}
       relabel_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
@@ -88,6 +93,7 @@ data:
 {{ toYaml . | indent 6 }}
 {{- end }}
 {{- end }}
+{{- if eq .Values.prometheus.serviceAccount.clusterRole true }}
     - job_name: 'kubernetes-nodes'
       scheme: https
       kubernetes_sd_configs:
@@ -124,6 +130,7 @@ data:
           regex: (.+)
           target_label: __metrics_path__
           replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+{{- end }}
   rules.yml: |
 {{- if .Values.monitoring.alert_manager -}}
 {{- with .Values.alert_manager.rules }}

--- a/charts/pulsar/templates/prometheus/pulsar-operators-rbac.yaml
+++ b/charts/pulsar/templates/prometheus/pulsar-operators-rbac.yaml
@@ -109,6 +109,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.rbac.roleName }}"
+  namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
 rules:
@@ -118,8 +119,6 @@ rules:
   - endpoints
   - pods
   verbs: ["get", "list", "watch"]
-- nonResourceURLs: ["/metrics"]
-  verbs: ["get"]
 - apiGroups: ["", "extensions", "apps"]
   resources:
     - pods
@@ -162,6 +161,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.rbac.roleBindingName }}"
+  namespace: {{ template "pulsar.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
In the event of using a prometheus that can't read a whole cluster and
only a subset of data, we need to set some different rbac and config
policies.

This was started before, but now fixes a few issues with that