### PR TITLE
correct the command of uninstalling pulsar charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,10 +215,10 @@ For more detailed information, see our [Upgrading](https://streamnative.io/docs/
 To uninstall the Pulsar Chart, run the following command:
 
 ```bash
-helm delete <pulsar-release-name>
+helm uninstall <pulsar-release-name>
 ```
 
-For the purposes of continuity, these charts have some Kubernetes objects that are not removed when performing `helm delete`.
+For the purposes of continuity, these charts have some Kubernetes objects that are not removed when performing `helm uninstall`.
 These items we require you to *conciously* remove them, as they affect re-deployment should you choose to.
 
 * PVCs for stateful data, which you must *consciously* remove


### PR DESCRIPTION
In helm3+, we uninstall charts by using command 'helm uninstall <release-name>' instead of 'helm delete <release-name>'.