### PR TITLE
Allow configure the presto probe path

### DIFF
--- a/charts/pulsar/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/pulsar/templates/presto/presto-coordinator-statefulset.yaml
@@ -108,7 +108,7 @@ spec:
           {{- if .Values.presto.coordinator.probe.liveness.enabled }}
           livenessProbe:
             httpGet:
-              path: /v1/status
+              path: {{ .Values.presto.coordinator.probe.liveness.path }}
               port: {{ .Values.presto.coordinator.ports.http }}
             initialDelaySeconds: {{ .Values.presto.coordinator.probe.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.presto.coordinator.probe.liveness.periodSeconds }}
@@ -117,7 +117,7 @@ spec:
           {{- if .Values.presto.coordinator.probe.readiness.enabled }}
           readinessProbe:
             httpGet:
-              path: /v1/status
+              path: {{ .Values.presto.coordinator.probe.readiness.path }}
               port: {{ .Values.presto.coordinator.ports.http }}
             initialDelaySeconds: {{ .Values.presto.coordinator.probe.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.presto.coordinator.probe.readiness.periodSeconds }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1671,11 +1671,13 @@ presto:
         failureThreshold: 10
         initialDelaySeconds: 10
         periodSeconds: 30
+        path: "/v1/status"
       readiness:
         enabled: true
         failureThreshold: 10
         initialDelaySeconds: 10
         periodSeconds: 30
+        path: "/v1/status"
       startup:
         enabled: false
         failureThreshold: 30


### PR DESCRIPTION
---

*Motivation*

Different pulsar version is with different presto version. Presto
status check path is changed when upgrading pulsar version. Allow
configure the probe path for starting up different pulsar version.