### PR TITLE
Fix the wrong start scripts when enable restoring

### DIFF
--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -66,9 +66,11 @@ spec:
         args:
           - >
             {{- include "pulsar.toolset.zookeeper.tls.settings" . | nindent 12 }}
+            {{ if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
             export "$(cat conf/pulsar_env.sh | xargs)";
             export "OPTS=${PULSAR_EXTRA_OPTS}";
             env;
+            {{- end }}
             bin/pulsar-metadata-tool cleanup
         env:
           - name: METADATA_TOOL_CONF

--- a/charts/sn-pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/sn-pulsar/templates/pulsar-cluster-initialize.yaml
@@ -66,6 +66,11 @@ spec:
         args:
           - >
             {{- include "pulsar.toolset.zookeeper.tls.settings" . | nindent 12 }}
+            {{ if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
+            export "$(cat conf/pulsar_env.sh | xargs)";
+            export "OPTS=${PULSAR_EXTRA_OPTS}";
+            env;
+            {{- end }}
             bin/pulsar-metadata-tool cleanup
         env:
           - name: METADATA_TOOL_CONF


### PR DESCRIPTION
---

*Motivation*

The OPTS only used when enable the tls on zookeeper, if we disable
the TLS and doing restoration, the cleanup job in the pulsar init job
will failed to get the TLS related files.