### PR TITLE
Run the cleanup in the bookie init job

### DIFF
--- a/charts/pulsar/templates/bookkeeper/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper/bookkeeper-cluster-initialize.yaml
@@ -46,6 +46,28 @@ spec:
               sleep 3;
             done;
             {{- end}}
+        {{- if .Values.zookeeper.customTools.restore.enable }}
+      - name: pulsar-metadata-cleanup
+        image: "{{ .Values.zookeeper.customTools.restore.repository }}:{{ .Values.zookeeper.customTools.restore.tag }}"
+        imagePullPolicy: "{{ .Values.zookeeper.customTools.restore.pullPolicy }}"
+        command: ["sh", "-c"]
+        args:
+          - >
+            {{- include "pulsar.toolset.zookeeper.tls.settings" . | nindent 12 }}
+            {{ if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
+            export "$(cat conf/pulsar_env.sh | xargs)";
+            export "OPTS=${PULSAR_EXTRA_OPTS}";
+            env;
+            {{- end }}
+            bin/pulsar-metadata-tool cleanup
+        env:
+          - name: METADATA_TOOL_CONF
+            value: "/pulsar-metadata-tool/conf/pulsar-metadata-tool/pulsar-metadata-tool.properties"
+        volumeMounts:
+          - name: cleanup-config
+            mountPath: /pulsar-metadata-tool/conf/pulsar-metadata-tool
+      {{- include "pulsar.toolset.certs.volumeMounts" . | nindent 10 }}
+      {{- end }}
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-init"
         image: "{{ .Values.images.bookie.repository }}:{{ .Values.images.bookie.tag }}"
@@ -74,6 +96,11 @@ spec:
         {{- include "pulsar.toolset.certs.volumeMounts" . | nindent 8 }}
       volumes:
       {{- include "pulsar.toolset.certs.volumes" . | nindent 6 }}
+      {{- if .Values.zookeeper.customTools.restore.enable }}
+        - name: cleanup-config
+          configMap:
+            name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.customTools.restore.component }}"
+      {{- end }}
       restartPolicy: Never
 {{- end }}
 {{- end }}

--- a/charts/pulsar/templates/pulsar-cluster-initialize.yaml
+++ b/charts/pulsar/templates/pulsar-cluster-initialize.yaml
@@ -58,28 +58,6 @@ spec:
               sleep 3;
             done;
             {{- end}}
-      {{- if .Values.zookeeper.customTools.restore.enable }}
-      - name: pulsar-metadata-cleanup
-        image: "{{ .Values.zookeeper.customTools.restore.repository }}:{{ .Values.zookeeper.customTools.restore.tag }}"
-        imagePullPolicy: "{{ .Values.zookeeper.customTools.restore.pullPolicy }}"
-        command: ["sh", "-c"]
-        args:
-          - >
-            {{- include "pulsar.toolset.zookeeper.tls.settings" . | nindent 12 }}
-            {{ if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
-            export "$(cat conf/pulsar_env.sh | xargs)";
-            export "OPTS=${PULSAR_EXTRA_OPTS}";
-            env;
-            {{- end }}
-            bin/pulsar-metadata-tool cleanup
-        env:
-          - name: METADATA_TOOL_CONF
-            value: "/pulsar-metadata-tool/conf/pulsar-metadata-tool/pulsar-metadata-tool.properties"
-        volumeMounts:
-          - name: cleanup-config
-            mountPath: /pulsar-metadata-tool/conf/pulsar-metadata-tool
-          {{- include "pulsar.toolset.certs.volumeMounts" . | nindent 10 }}
-      {{- end }}
       # This initContainer will wait for bookkeeper initnewcluster to complete
       # before initializing pulsar metadata
       - name: pulsar-bookkeeper-verify-clusterid
@@ -127,11 +105,6 @@ spec:
         {{- include "pulsar.toolset.certs.volumeMounts" . | nindent 8 }}
       volumes:
       {{- include "pulsar.toolset.certs.volumes" . | nindent 6 }}
-      {{- if .Values.zookeeper.customTools.restore.enable }}
-      - name: cleanup-config
-        configMap:
-          name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.customTools.restore.component }}"
-      {{- end }}
       restartPolicy: Never
 {{- end }}
 {{- end }}

--- a/charts/pulsar/templates/zookeeper/zookeeper-restore-configmap.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-restore-configmap.yaml
@@ -36,5 +36,7 @@ data:
     managedLedgerPath={{ .Values.zookeeper.customTools.restore.managedLedgerPath }}
     webServerPort=8088
     restoreVersion={{ .Values.zookeeper.customTools.restore.restoreVersion }}
+    cleanupBookieMeta={{ .Values.zookeeper.customTools.restore.cleanupBookieMeta }}
+    cleanupClusterMeta={{ .Values.zookeeper.customTools.restore.cleanupClusterMeta }}
 {{ toYaml .Values.zookeeper.customTools.restore.configData | indent 2 }}
 {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -614,6 +614,8 @@ zookeeper:
       restoreVersion: "1"
       managedLedgerPath: "/managed-ledgers"
       bucket: "s3a://bucket"
+      cleanupBookieMeta: false
+      cleanupClusterMeta: false
       configData:
         OPTS: ""
       secrets:


### PR DESCRIPTION
---

*Motivation*

The pulsar cluster init job will run after the bookie init.
If we restore a cluster with the same name of the old cluster,
it will fail to start bookie with mismatch cookie error.
So we allow to cleanup /ledgers path to cleanup the bookie metadata.
So we can initialize the cluster with the restore point successfully.