### PR TITLE
Revert controller related patches

### DIFF
--- a/charts/sn-platform/Chart.yaml
+++ b/charts/sn-platform/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 appVersion: "1.1"
 description: StreamNative Platform Chart
 name: sn-platform
-version: 1.1.6
+version: 1.1.5
 home: https://streamnative.io
 sources:
 - https://github.com/streamnative/charts/tree/master/charts/sn-platform

--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
@@ -242,7 +242,7 @@ spec:
         name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
       updatePolicy:
       {{- if .Values.bookkeeper.operator.adopt_existing }}
-      {{ .Values.bookkeeper.operator.updatePolicy | indent 2 }}
+      {{ .Values.bookkeeper.operator.updatePolicy }}
       {{- else }}
         - all
       {{- end }}
@@ -251,7 +251,7 @@ spec:
         name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
       updatePolicy:
       {{- if .Values.autorecovery.operator.adopt_existing }}
-      {{ .Values.autorecovery.operator.updatePolicy | indent 2 }}
+      {{ .Values.autorecovery.operator.updatePolicy }}
       {{- else }}
         - all
       {{- end }}

--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
@@ -242,7 +242,7 @@ spec:
         name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
       updatePolicy:
       {{- if .Values.bookkeeper.operator.adopt_existing }}
-        {{ .Values.bookkeeper.operator.updatePolicy }}
+      {{ .Values.bookkeeper.operator.updatePolicy | indent 2 }}
       {{- else }}
         - all
       {{- end }}
@@ -251,7 +251,7 @@ spec:
         name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
       updatePolicy:
       {{- if .Values.autorecovery.operator.adopt_existing }}
-        {{ .Values.autorecovery.operator.updatePolicy }}
+      {{ .Values.autorecovery.operator.updatePolicy | indent 2 }}
       {{- else }}
         - all
       {{- end }}

--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -157,7 +157,7 @@ spec:
         name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
       updatePolicy:
       {{- if .Values.broker.operator.adopt_existing }}
-        {{ .Values.broker.operator.updatePolicy }}
+      {{ .Values.broker.operator.updatePolicy | indent 2 }}
       {{- else }}
         - all
       {{- end }}

--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -147,46 +147,17 @@ spec:
       selector:
         istio: {{ quote .Values.broker.istio.gateway.selector.istio }}
   {{- end }}
-  apiObjects:
-    internalService: {}
-    headlessService:
-      metadata:
-        name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
-    statefulSet:
-      metadata:
-        name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
-      updatePolicy:
-      {{- if .Values.broker.operator.adopt_existing }}
-      {{ .Values.broker.operator.updatePolicy | indent 2 }}
-      {{- else }}
-        - all
-      {{- end }}
-    brokerConfigMap:
-      metadata:
-        name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
-    interceptorConfigMap: {}
-    functionWorkerConfigMap:
-      metadata:
-        name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-configfile"
-    functionMeshConfigMap:
-      metadata:
-        name: "builtin-connectors"
-    pdb:
-      metadata:
-        name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
   config:
-    {{- if or .Values.broker.functionmesh.enabled .Values.broker.function.enabled }}
+    {{- if .Values.broker.functionmesh.enabled }}
     function:
       enabled: true
-      {{- if .Values.broker.functionmesh.enabled }}
       mesh:
         builtinConnectorsRef:
           name: builtin-connectors
       type: FunctionMesh
       {{- end }}
-    {{- end }}
     advertisedDomain: {{ quote .Values.broker.advertisedDomain }}
-    {{- if or .Values.broker.kop.enabled .Values.components.kop }}
+    {{- if .Values.broker.kop.enabled }}
     protocolHandlers:
       kop:
         enabled: true
@@ -221,123 +192,15 @@ spec:
       brokerClientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"
       PULSAR_PREFIX_vaultHost: {{ template "pulsar.vault.url" . }}
       PULSAR_PREFIX_OIDCPublicKeyPath: "{{ template "pulsar.vault.url" . }}/v1/identity/oidc/.well-known/keys"
-      superUserRoles: {{ .Values.auth.superUsers.broker }},{{ .Values.auth.superUsers.proxy }},{{ .Values.auth.superUsers.websocket }},{{ .Values.auth.superUsers.client }},{{ .Values.auth.superUsers.streamnative_console }}
+      superUserRoles: "admin"
       {{- end }}
       {{- if .Values.auth.authorization.enabled }}
       authorizationEnabled: "true"
       authorizationProvider: "org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider"
       {{- end }}
-      # Metadata settings
-      {{- if .Values.pulsar_metadata.configurationStore }}
-      configurationStoreServers: "{{ .Values.pulsar_metadata.configurationStore }}{{ .Values.pulsar_metadata.configurationStoreMetadataPrefix }}"
-      {{- end }}
-      {{- if not .Values.pulsar_metadata.configurationStore }}
-      configurationStoreServers: "{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
-      {{- end }}
-
-      # Broker settings
-      exposeTopicLevelMetricsInPrometheus: "true"
-      numHttpServerThreads: "8"
-      zooKeeperSessionTimeoutMillis: "30000"
-      statusFilePath: "{{ template "pulsar.home" . }}/status"
-
-      ## Offloading settings
-      {{- if .Values.broker.offload.enabled }}
-      offloadersDirectory: "{{ template "pulsar.home" . }}/offloaders"
-
-      {{- if .Values.broker.offload.use }}
-      managedLedgerOffloadDriver: {{ .Values.broker.offload.managedLedgerOffloadDriver }}
-      {{- end }}
-
-      {{- if .Values.broker.offload.gcs.enabled }}
-      # gcs
-      gcsManagedLedgerOffloadRegion: {{ .Values.broker.offload.gcs.gcsManagedLedgerOffloadRegion }}
-      gcsManagedLedgerOffloadBucket: {{ .Values.broker.offload.gcs.gcsManagedLedgerOffloadBucket }}
-      gcsManagedLedgerOffloadMaxBlockSizeInBytes: "{{ .Values.broker.offload.gcs.gcsManagedLedgerOffloadMaxBlockSizeInBytes }}"
-      gcsManagedLedgerOffloadReadBufferSizeInBytes: "{{ .Values.broker.offload.gcs.gcsManagedLedgerOffloadReadBufferSizeInBytes }}"
-      ## Authentication with GCS
-      gcsManagedLedgerOffloadServiceAccountKeyFile: "/pulsar/srvaccts/gcs.json"
-      {{- end }}
-      {{- if .Values.broker.offload.s3.enabled }}
-      # aws-s3
-      s3ManagedLedgerOffloadRegion: {{ .Values.broker.offload.s3.s3ManagedLedgerOffloadRegion }}
-      s3ManagedLedgerOffloadBucket: {{ .Values.broker.offload.s3.s3ManagedLedgerOffloadBucket }}
-      s3ManagedLedgerOffloadServiceEndpoint: {{ .Values.broker.offload.s3.s3ManagedLedgerOffloadServiceEndpoint }}
-      s3ManagedLedgerOffloadMaxBlockSizeInBytes: "{{ .Values.broker.offload.s3.s3ManagedLedgerOffloadMaxBlockSizeInBytes }}"
-      s3ManagedLedgerOffloadReadBufferSizeInBytes: "{{ .Values.broker.offload.s3.s3ManagedLedgerOffloadReadBufferSizeInBytes }}"
-      {{- end }}
-      {{- end }}
-
-      # Function Worker Settings
-      # function worker configuration
-      {{- if .Values.components.functions }}
-      functionsWorkerEnabled: "true"
-      {{- if .Values.functions.enableCustomizerRuntime }}
-      PULSAR_EXTRA_CLASSPATH: "{{ template "pulsar.home" .}}/{{ .Values.functions.pulsarExtraClasspath }}"
-      {{- end }}
-      {{- else }}
-      functionsWorkerEnabled: "false"
-      {{- end }}
-
-      # prometheus needs to access /metrics endpoint
-      webServicePort: "{{ .Values.broker.ports.http }}"
-      {{- if or (not .Values.tls.enabled) (not .Values.tls.broker.enabled) }}
-      brokerServicePort: "{{ .Values.broker.ports.pulsar }}"
-      {{- end }}
-      {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
-      brokerServicePortTls: "{{ .Values.broker.ports.pulsarssl }}"
-      webServicePortTls: "{{ .Values.broker.ports.https }}"
-      # TLS Settings
-      tlsCertificateFilePath: "/pulsar/certs/broker/tls.crt"
-      tlsKeyFilePath: "/pulsar/certs/broker/tls.key"
-      tlsTrustCertsFilePath: "/pulsar/certs/ca/ca.crt"
-      {{- end }}
-
-      # Authentication Settings
-      {{- if .Values.auth.authentication.enabled }}
-      authenticateOriginalAuthData: "true"
-      {{- if .Values.auth.authorization.enabled }}
-      proxyRoles: {{ .Values.auth.superUsers.proxy }}
-      {{- end }}
-      {{- if and (eq .Values.auth.authentication.provider "jwt") (not .Values.auth.vault.enabled) }}
-      # token authentication configuration
-      brokerClientAuthenticationParameters: "file:///pulsar/tokens/broker/token"
-      {{- if .Values.auth.authentication.jwt.usingSecretKey }}
-      tokenSecretKey: "file:///pulsar/keys/token/secret.key"
-      {{- else }}
-      tokenPublicKey: "file:///pulsar/keys/token/public.key"
-      {{- end }}
-      {{- end }}
-      {{- end }}
-
-      {{- if and .Values.tls.enabled .Values.tls.bookie.enabled }}
-      # bookkeeper tls settings
-      bookkeeperTLSClientAuthentication: "true"
-      bookkeeperTLSKeyFileType: "PEM"
-      bookkeeperTLSKeyFilePath: "/pulsar/certs/broker/tls.key"
-      bookkeeperTLSCertificateFilePath: "/pulsar/certs/broker/tls.crt"
-      bookkeeperTLSTrustCertsFilePath: "/pulsar/certs/ca/ca.crt"
-      bookkeeperTLSTrustCertTypes: "PEM"
-      PULSAR_PREFIX_bookkeeperTLSClientAuthentication: "true"
-      PULSAR_PREFIX_bookkeeperTLSKeyFileType: "PEM"
-      PULSAR_PREFIX_bookkeeperTLSKeyFilePath: "/pulsar/certs/broker/tls.key"
-      PULSAR_PREFIX_bookkeeperTLSCertificateFilePath: "/pulsar/certs/broker/tls.crt"
-      PULSAR_PREFIX_bookkeeperTLSTrustCertsFilePath: "/pulsar/certs/ca/ca.crt"
-      PULSAR_PREFIX_bookkeeperTLSTrustCertTypes: "PEM"
-      # https://github.com/apache/bookkeeper/pull/2300
-      bookkeeperUseV2WireProtocol: "false"
-      {{- end }}
-      {{- if eq .Values.auth.authentication.provider "jwt" }}
+      {{- if .Values.broker.kop.enabled }}
       PULSAR_PREFIX_saslAllowedMechanisms: "PLAIN"
       {{- end }}
-      {{- end }}
-      {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
-      PULSAR_PREFIX_kopSslKeystoreLocation: /pulsar/broker.keystore.jks
-      PULSAR_PREFIX_kopSslTruststoreLocation: /pulsar/broker.truststore.jks
-      {{- end }}
-      # Include log configuration file, If you want to configure the log level and other configuration
-      # items, you can modify the configmap, and eventually it will overwrite the log4j2.yaml file under conf
-    {{ (.Files.Glob "conf/broker/log4j2.yaml").AsConfig | indent 2 }}
   {{- if .Values.zookeeper.customTools.restore.enable }}
   initJobPod:
     initContainers:
@@ -360,3 +223,4 @@ spec:
           name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.customTools.restore.component }}"
   {{- end }}
 {{ (.Files.Glob "conf/broker/log4j2.yaml").AsConfig | indent 2 }}
+{{- end }}

--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -327,22 +327,17 @@ spec:
       # https://github.com/apache/bookkeeper/pull/2300
       bookkeeperUseV2WireProtocol: "false"
       {{- end }}
-      {{- if .Values.components.kop }}
-      {{- if .Values.auth.authentication.enabled }}
       {{- if eq .Values.auth.authentication.provider "jwt" }}
       PULSAR_PREFIX_saslAllowedMechanisms: "PLAIN"
       {{- end }}
       {{- end }}
-      {{- if and .Values.tls.enabled .Values.tls.kop.enabled }}
-      PULSAR_PREFIX_kopSslKeystoreLocation: /pulsar/certs/kop/keystore.jks
-      {{- if not .Values.certs.public_issuer.enabled }}
-      PULSAR_PREFIX_kopSslTruststoreLocation: /pulsar/certs/kop/truststore.jks
-      {{- end }}
-      {{- end }}
+      {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
+      PULSAR_PREFIX_kopSslKeystoreLocation: /pulsar/broker.keystore.jks
+      PULSAR_PREFIX_kopSslTruststoreLocation: /pulsar/broker.truststore.jks
       {{- end }}
       # Include log configuration file, If you want to configure the log level and other configuration
       # items, you can modify the configmap, and eventually it will overwrite the log4j2.yaml file under conf
-{{ (.Files.Glob "conf/broker/log4j2.yaml").AsConfig | indent 6 }}
+    {{ (.Files.Glob "conf/broker/log4j2.yaml").AsConfig | indent 2 }}
   {{- if .Values.zookeeper.customTools.restore.enable }}
   initJobPod:
     initContainers:
@@ -364,4 +359,4 @@ spec:
         configMap:
           name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.customTools.restore.component }}"
   {{- end }}
-{{- end }}
+{{ (.Files.Glob "conf/broker/log4j2.yaml").AsConfig | indent 2 }}

--- a/charts/sn-platform/templates/broker/broker-service.yaml
+++ b/charts/sn-platform/templates/broker/broker-service.yaml
@@ -30,9 +30,7 @@ metadata:
     {{- if .Values.broker.resourcePolicy.keep }}
     "helm.sh/resource-policy": keep
     {{- end }}
-    {{- if .Values.broker.service.annotations}}
 {{ toYaml .Values.broker.service.annotations | indent 4 }}
-    {{- end}}
 spec:
   ports:
   # prometheus needs to access /metrics endpoint

--- a/charts/sn-platform/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-cluster.yaml
@@ -127,26 +127,6 @@ spec:
       gcOptions:
         - {{ .Values.proxy.configData.PULSAR_GC }}
       gcLoggingOptions: []
-  apiObjects:
-    externalService: {}
-    headlessService:
-      metadata:
-        name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
-    statefulSet:
-      metadata:
-        name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
-      updatePolicy:
-      {{- if .Values.proxy.operator.adopt_existing }}
-      {{ .Values.proxy.operator.updatePolicy | indent 2 }}
-      {{- else }}
-        - all
-      {{- end }}
-    proxyConfigMap:
-      metadata:
-        name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
-    websocketConfigMap:
-      metadata:
-        name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.websocket.component }}"
   config:
     tls:
       enabled: {{ and (.Values.tls.enabled) (.Values.tls.proxy.enabled) }}
@@ -178,61 +158,6 @@ spec:
       {{- end }}
       {{- end }}
 {{ (.Files.Glob "conf/proxy/log4j2.yaml").AsConfig | indent 4 }}
-
-      # Proxy settings
-      clusterName: { { template "pulsar.cluster" . } }
-      httpNumThreads: "8"
-      statusFilePath: "{{ template "pulsar.home" . }}/status"
-      # prometheus needs to access /metrics endpoint
-      webServicePort: "{{ .Values.proxy.ports.http }}"
-      { { - if or (not .Values.tls.enabled) (not .Values.tls.proxy.enabled) } }
-      servicePort: "{{ .Values.proxy.ports.pulsar }}"
-      { { - end } }
-      { { - if and .Values.tls.enabled .Values.tls.proxy.enabled } }
-      tlsEnabledInProxy: "true"
-      servicePortTls: "{{ .Values.proxy.ports.pulsarssl }}"
-      webServicePortTls: "{{ .Values.proxy.ports.https }}"
-      tlsCertificateFilePath: "/pulsar/certs/proxy/tls.crt"
-      tlsKeyFilePath: "/pulsar/certs/proxy/tls.key"
-      { { - if .Values.tls.proxy.untrustedCa } }
-      tlsTrustCertsFilePath: "/pulsar/certs/ca/ca.crt"
-      { { - end } }
-      { { - end } }
-      { { - if and .Values.tls.enabled .Values.tls.broker.enabled } }
-      # if broker enables TLS, configure proxy to talk to broker using TLS
-      brokerServiceURLTLS: { { template "pulsar.proxy.broker.service.url.tls" . } }
-      brokerWebServiceURLTLS: { { template "pulsar.proxy.web.service.url.tls" . } }
-      tlsEnabledWithBroker: "true"
-      tlsCertRefreshCheckDurationSec: "300"
-      brokerClientTrustCertsFilePath: "/pulsar/certs/broker/ca.crt"
-      { { - end } }
-      { { - if not (and .Values.tls.enabled .Values.tls.broker.enabled) } }
-      brokerServiceURL: { { template "pulsar.proxy.broker.service.url" . } }
-      brokerWebServiceURL: { { template "pulsar.proxy.web.service.url" . } }
-      { { - end } }
-
-        # Authentication Settings
-      { { - if .Values.auth.authentication.enabled } }
-      authenticationEnabled: "true"
-      forwardAuthorizationCredentials: "true"
-      { { - if .Values.auth.authorization.enabled } }
-      # disable authorization on proxy and forward authorization credentials to broker
-      authorizationEnabled: "false"
-      forwardAuthorizationCredentials: "true"
-      # superUserRoles: {{ .Values.auth.superUsers.broker }},{{ .Values.auth.superUsers.proxy }},{{ .Values.auth.superUsers.websocket }},{{ .Values.auth.superUsers.client }},{{ .Values.auth.superUsers.streamnative_console }}
-      { { - end } }
-      { { - if and (eq .Values.auth.authentication.provider "jwt") (not .Values.auth.vault.enabled) } }
-      # token authentication configuration
-      authenticationProviders: "org.apache.pulsar.broker.authentication.AuthenticationProviderToken"
-      brokerClientAuthenticationParameters: "file:///pulsar/tokens/proxy/token"
-      brokerClientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"
-      { { - if .Values.auth.authentication.jwt.usingSecretKey } }
-      tokenSecretKey: "file:///pulsar/keys/token/secret.key"
-      { { - else } }
-      tokenPublicKey: "file:///pulsar/keys/token/public.key"
-      { { - end } }
-      { { - end } }
-      { { - end } }
   dnsNames: []
   issuerRef:
     name: ""

--- a/charts/sn-platform/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-cluster.yaml
@@ -137,7 +137,7 @@ spec:
         name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
       updatePolicy:
       {{- if .Values.proxy.operator.adopt_existing }}
-        {{ .Values.proxy.operator.updatePolicy }}
+      {{ .Values.proxy.operator.updatePolicy | indent 2 }}
       {{- else }}
         - all
       {{- end }}

--- a/charts/sn-platform/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-cluster.yaml
@@ -177,61 +177,62 @@ spec:
       tlsTrustCertsFilePath: "/etc/tls/pulsar-proxy-tls/ca.crt"
       {{- end }}
       {{- end }}
-{{ (.Files.Glob "conf/proxy/log4j2.yaml").AsConfig | indent 6 }}
+{{ (.Files.Glob "conf/proxy/log4j2.yaml").AsConfig | indent 4 }}
+
       # Proxy settings
-      clusterName: {{ template "pulsar.cluster" . }}
+      clusterName: { { template "pulsar.cluster" . } }
       httpNumThreads: "8"
       statusFilePath: "{{ template "pulsar.home" . }}/status"
       # prometheus needs to access /metrics endpoint
       webServicePort: "{{ .Values.proxy.ports.http }}"
-      {{- if or (not .Values.tls.enabled) (not .Values.tls.proxy.enabled) }}
+      { { - if or (not .Values.tls.enabled) (not .Values.tls.proxy.enabled) } }
       servicePort: "{{ .Values.proxy.ports.pulsar }}"
-      {{- end }}
-      {{- if and .Values.tls.enabled .Values.tls.proxy.enabled }}
+      { { - end } }
+      { { - if and .Values.tls.enabled .Values.tls.proxy.enabled } }
       tlsEnabledInProxy: "true"
       servicePortTls: "{{ .Values.proxy.ports.pulsarssl }}"
       webServicePortTls: "{{ .Values.proxy.ports.https }}"
       tlsCertificateFilePath: "/pulsar/certs/proxy/tls.crt"
       tlsKeyFilePath: "/pulsar/certs/proxy/tls.key"
-      {{- if .Values.tls.proxy.untrustedCa }}
+      { { - if .Values.tls.proxy.untrustedCa } }
       tlsTrustCertsFilePath: "/pulsar/certs/ca/ca.crt"
-      {{- end }}
-      {{- end }}
-      {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
+      { { - end } }
+      { { - end } }
+      { { - if and .Values.tls.enabled .Values.tls.broker.enabled } }
       # if broker enables TLS, configure proxy to talk to broker using TLS
-      brokerServiceURLTLS: {{ template "pulsar.proxy.broker.service.url.tls" . }}
-      brokerWebServiceURLTLS: {{ template "pulsar.proxy.web.service.url.tls" . }}
+      brokerServiceURLTLS: { { template "pulsar.proxy.broker.service.url.tls" . } }
+      brokerWebServiceURLTLS: { { template "pulsar.proxy.web.service.url.tls" . } }
       tlsEnabledWithBroker: "true"
       tlsCertRefreshCheckDurationSec: "300"
       brokerClientTrustCertsFilePath: "/pulsar/certs/broker/ca.crt"
-      {{- end }}
-      {{- if not (and .Values.tls.enabled .Values.tls.broker.enabled) }}
-      brokerServiceURL: {{ template "pulsar.proxy.broker.service.url" . }}
-      brokerWebServiceURL: {{ template "pulsar.proxy.web.service.url" . }}
-      {{- end }}
+      { { - end } }
+      { { - if not (and .Values.tls.enabled .Values.tls.broker.enabled) } }
+      brokerServiceURL: { { template "pulsar.proxy.broker.service.url" . } }
+      brokerWebServiceURL: { { template "pulsar.proxy.web.service.url" . } }
+      { { - end } }
 
         # Authentication Settings
-      {{- if .Values.auth.authentication.enabled }}
+      { { - if .Values.auth.authentication.enabled } }
       authenticationEnabled: "true"
       forwardAuthorizationCredentials: "true"
-      {{- if .Values.auth.authorization.enabled }}
+      { { - if .Values.auth.authorization.enabled } }
       # disable authorization on proxy and forward authorization credentials to broker
       authorizationEnabled: "false"
       forwardAuthorizationCredentials: "true"
       # superUserRoles: {{ .Values.auth.superUsers.broker }},{{ .Values.auth.superUsers.proxy }},{{ .Values.auth.superUsers.websocket }},{{ .Values.auth.superUsers.client }},{{ .Values.auth.superUsers.streamnative_console }}
-      {{- end }}
-      {{- if and (eq .Values.auth.authentication.provider "jwt") (not .Values.auth.vault.enabled) }}
+      { { - end } }
+      { { - if and (eq .Values.auth.authentication.provider "jwt") (not .Values.auth.vault.enabled) } }
       # token authentication configuration
       authenticationProviders: "org.apache.pulsar.broker.authentication.AuthenticationProviderToken"
       brokerClientAuthenticationParameters: "file:///pulsar/tokens/proxy/token"
       brokerClientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"
-      {{- if .Values.auth.authentication.jwt.usingSecretKey }}
+      { { - if .Values.auth.authentication.jwt.usingSecretKey } }
       tokenSecretKey: "file:///pulsar/keys/token/secret.key"
-      {{- else }}
+      { { - else } }
       tokenPublicKey: "file:///pulsar/keys/token/public.key"
-      {{- end }}
-      {{- end }}
-      {{- end }}
+      { { - end } }
+      { { - end } }
+      { { - end } }
   dnsNames: []
   issuerRef:
     name: ""

--- a/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
@@ -210,7 +210,7 @@ spec:
         name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
       updatePolicy:
       {{- if .Values.zookeeper.operator.adopt_existing }}
-      {{ .Values.zookeeper.operator.updatePolicy | indent 2 }}
+      {{ .Values.zookeeper.operator.updatePolicy }}
       {{- else }}
         - all
       {{- end }}

--- a/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
@@ -210,7 +210,7 @@ spec:
         name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
       updatePolicy:
       {{- if .Values.zookeeper.operator.adopt_existing }}
-        {{ .Values.zookeeper.operator.updatePolicy }}
+      {{ .Values.zookeeper.operator.updatePolicy | indent 2 }}
       {{- else }}
         - all
       {{- end }}

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -951,8 +951,6 @@ broker:
         istio: "ingressgateway"
   functionmesh:
     enabled: true
-  function:
-    enabled: true
   resources:
     requests:
       memory: 512Mi


### PR DESCRIPTION
Revert controller related patches as chart's broker headless service name clash with operator generated broker service's internal service name so the headless service won't be created, revert for now to unblock customer.