### PR TITLE
support use existing external dns and additional cert-manager options

### DIFF
--- a/charts/pulsar/templates/control-center/control-center-ingress.yaml
+++ b/charts/pulsar/templates/control-center/control-center-ingress.yaml
@@ -35,7 +35,11 @@ metadata:
     ingress.kubernetes.io/ssl-redirect: "true"
 {{- if and .Values.certs.public_issuer.enabled }}
     kubernetes.io/tls-acme: "true"
-    cert-manager.io/issuer: "{{ template "pulsar.fullname" . }}-{{ .Values.certs.public_issuer.component }}"
+{{- if eq .Values.certs.public_issuer.issuer_type  "ClusterIssuer" }}
+    cert-manager.io/cluster-issuer: "{{ template "pulsar.tls.public_issuer" . }}"
+{{- else }}
+    cert-manager.io/issuer: "{{ template "pulsar.tls.public_issuer" . }}"
+{{- end }}
 {{- end }}
 {{- else }}
     ingress.kubernetes.io/ssl-redirect: "false"

--- a/charts/pulsar/templates/external-dns/external-dns-rbac.yaml
+++ b/charts/pulsar/templates/external-dns/external-dns-rbac.yaml
@@ -18,6 +18,7 @@
 #
 
 {{- if .Values.external_dns.enabled }}
+{{- if not .Values.external_dns.use_existing }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -63,4 +64,5 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "external_dns.serviceAccount" . }}
   namespace: {{ template "pulsar.namespace" . }}
+{{- end }}
 {{- end }}

--- a/charts/pulsar/templates/external-dns/external-dns.yaml
+++ b/charts/pulsar/templates/external-dns/external-dns.yaml
@@ -18,6 +18,7 @@
 #
 
 {{- if .Values.external_dns.enabled }}
+{{- if not .Values.external_dns.use_existing }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -80,4 +81,5 @@ spec:
       {{- with .Values.external_dns.securityContext }}
       {{ toYaml . | indent 6 }}
       {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/pulsar/templates/tls/_tls.tpl
+++ b/charts/pulsar/templates/tls/_tls.tpl
@@ -1,0 +1,10 @@
+{{/*
+Define the tls issuer
+*/}}
+{{- define "pulsar.tls.public_issuer" -}}
+{{- if and .Values.certs.public_issuer.enabled .Values.certs.public_issuer.issuer_override -}}
+{{ .Values.certs.public_issuer.issuer_override }}
+{{- else -}}
+{{ template "pulsar.fullname" . }}-{{ .Values.certs.public_issuer.component }}
+{{- end -}}
+{{- end -}}

--- a/charts/pulsar/templates/tls/tls-cert-public-issuer.yaml
+++ b/charts/pulsar/templates/tls/tls-cert-public-issuer.yaml
@@ -20,6 +20,7 @@
 {{- if .Values.external_dns.enabled }}
 {{- if .Values.certs.public_issuer.enabled }}
 {{- if eq .Values.certs.public_issuer.type "acme" }}
+{{- if not .Values.certs.public_issuer.issuer_override }}
 apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
@@ -48,6 +49,7 @@ spec:
 {{ toYaml .Values.certs.issuers.acme.solvers.route53 | indent 10 }}
       {{- end }}
       {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/pulsar/templates/tls/tls-certs-public.yaml
+++ b/charts/pulsar/templates/tls/tls-certs-public.yaml
@@ -38,10 +38,10 @@ spec:
     {{- end }}
   # Issuer references are always required.
   issuerRef:
-    name: "{{ template "pulsar.fullname" . }}-{{ .Values.certs.public_issuer.component }}"
+    name: "{{ template "pulsar.tls.public_issuer" . }}"
     # We can reference ClusterIssuers by changing the kind here.
     # The default value is Issuer (i.e. a locally namespaced Issuer)
-    kind: Issuer
+    kind: {{ .Values.certs.public_issuer.issuer_type | default "Issuer" }}
     # This is optional since cert-manager will default to this value however
     # if you are using an external issuer, change this to that issuer group.
     group: cert-manager.io

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -324,6 +324,7 @@ certs:
 ## External DNS is used for synchronizing exposed Ingresses with DNS providers
 external_dns:
   enabled: false
+  use_existing: false
   component: external-dns
   policy: upsert-only
   registry: txt


### PR DESCRIPTION
This commit adds support for using an existing install of external DNS and allowing to override the issuer for certs.

This is part of an effort to refactor to extract out some of the components to be managed outside of these charts