### PR TITLE
Restore presto service to match service name

### DIFF
--- a/charts/pulsar/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/pulsar/templates/presto/presto-coordinator-statefulset.yaml
@@ -27,7 +27,7 @@ metadata:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: {{ .Values.presto.coordinator.component }}
 spec:
-  serviceName: {{ template "presto.coordinator" . }}
+  serviceName: {{ template "presto.service" . }}
   replicas: {{ .Values.presto.coordinator.replicaCount }}
   selector:
     matchLabels:
@@ -89,7 +89,7 @@ spec:
                       operator: In
                       values:
                       - {{ .Release.Name }}
-                    - key: "component" 
+                    - key: "component"
                       operator: In
                       values:
                       - {{ .Values.presto.coordinator.component }}

--- a/charts/sn-platform/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/sn-platform/templates/presto/presto-coordinator-statefulset.yaml
@@ -89,7 +89,7 @@ spec:
                       operator: In
                       values:
                       - {{ .Release.Name }}
-                    - key: "component" 
+                    - key: "component"
                       operator: In
                       values:
                       - {{ .Values.presto.coordinator.component }}


### PR DESCRIPTION
Previously, this was changed to be a seperate service, however, this
seems incorrect.

The serviceName should match the name of K8S service which is used for
internal communication.

This effectively reverts #271

@zymap Can you provide some context on why this change was made in the first place?