### PR TITLE
Allow authentication to be disabled in pulsar

### DIFF
--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -92,6 +92,7 @@ spec:
           {{ end }}
     {{- end }}
     vars:
+    {{- if .Values.auth.authentication.enabled }}
     - name: PULSAR_PREFIX_OIDCTokenAudienceID
       valueFrom:
           secretKeyRef:
@@ -102,6 +103,7 @@ spec:
           secretKeyRef:
             name: {{ template "pulsar.vault-secret-key-name" . }}
             key: brokerClientAuthenticationParameters
+    {{- end }}
     {{- if not ( and .Values.broker.kop.enabled .Values.broker.advertisedDomain ) }}
     - name: POD_NAME
       valueFrom:

--- a/charts/sn-platform/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-cluster.yaml
@@ -89,6 +89,7 @@ spec:
           {{ end }}
     {{- end }}
     vars:
+    {{- if .Values.auth.authentication.enabled }}
     - name: PULSAR_PREFIX_OIDCTokenAudienceID
       valueFrom:
           secretKeyRef:
@@ -99,6 +100,7 @@ spec:
           secretKeyRef:
             name: {{ template "pulsar.vault-secret-key-name" . }}
             key: brokerClientAuthenticationParameters
+    {{- end }}
     #envFrom:
     #- secretRef:
     #    name: {{ template "pulsar.vault-secret-key-name" . }}

--- a/charts/sn-platform/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-cluster.yaml
@@ -88,8 +88,8 @@ spec:
               topologyKey: "kubernetes.io/hostname"
           {{ end }}
     {{- end }}
-    vars:
     {{- if .Values.auth.authentication.enabled }}
+    vars:
     - name: PULSAR_PREFIX_OIDCTokenAudienceID
       valueFrom:
           secretKeyRef:


### PR DESCRIPTION
Only reference the secret for credentials on broker and proxy when the authentication is enabled. Otherwise the broker and proxy cannot run properly without authentication.