### PR TITLE
Fixed zookeeper storage size type

### DIFF
--- a/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
@@ -163,7 +163,7 @@ spec:
           {{- if .Values.zookeeper.volumes.useSeparateDiskForTxlog }}
           storage: {{ .Values.zookeeper.volumes.dataLog.size }}
           {{- else }}
-          storage: 0
+          storage: "0"
           {{- end }}
     {{- if and .Values.volumes.local_storage .Values.zookeeper.volumes.data.local_storage }}
       storageClassName: "local-storage"


### PR DESCRIPTION

Exception: 
```
Error: ZooKeeperCluster.zookeeper.streamnative.io "pulsar-sn-platform-zookeeper" is invalid: spec.persistence.dataLog.resources.requests.storage: Invalid value: "integer": spec.persistence.dataLog.resources.requests.storage in body must be of type string: "integer"
```