### PR TITLE
Fixed grafana root url

### DIFF
--- a/charts/sn-platform/templates/grafana/grafana-deployment.yaml
+++ b/charts/sn-platform/templates/grafana/grafana-deployment.yaml
@@ -97,7 +97,7 @@ spec:
         - name: GRAFANA_DOMAIN
           value: {{ template "pulsar.control_center_domain" . }}
         - name: GRAFANA_ROOT_URL
-          value: https://{{ template "pulsar.control_center_domain" . }}:3000{{ template "pulsar.control_center_url" . }}{{ template "pulsar.control_center_path.grafana" . }}/
+          value: https://{{ template "pulsar.control_center_domain" . }}{{ template "pulsar.control_center_url" . }}{{ template "pulsar.control_center_path.grafana" . }}/
         - name: GRAFANA_SERVE_FROM_SUB_PATH
           value: "true"
 {{- else }}

--- a/charts/sn-platform/templates/grafana/grafana-deployment.yaml
+++ b/charts/sn-platform/templates/grafana/grafana-deployment.yaml
@@ -97,7 +97,7 @@ spec:
         - name: GRAFANA_DOMAIN
           value: {{ template "pulsar.control_center_domain" . }}
         - name: GRAFANA_ROOT_URL
-          value: {{ template "pulsar.control_center_url" . }}{{ template "pulsar.control_center_path.grafana" . }}/
+          value: https://{{ template "pulsar.control_center_domain" . }}:3000{{ template "pulsar.control_center_url" . }}{{ template "pulsar.control_center_path.grafana" . }}/
         - name: GRAFANA_SERVE_FROM_SUB_PATH
           value: "true"
 {{- else }}

--- a/charts/sn-platform/templates/grafana/grafana-statefulset.yaml
+++ b/charts/sn-platform/templates/grafana/grafana-statefulset.yaml
@@ -109,7 +109,7 @@ spec:
         - name: GRAFANA_DOMAIN
           value: {{ template "pulsar.control_center_domain" . }}
         - name: GRAFANA_ROOT_URL
-          value: https://{{ template "pulsar.control_center_domain" . }}:3000{{ template "pulsar.control_center_url" . }}{{ template "pulsar.control_center_path.grafana" . }}/
+          value: https://{{ template "pulsar.control_center_domain" . }}{{ template "pulsar.control_center_url" . }}{{ template "pulsar.control_center_path.grafana" . }}/
         - name: GRAFANA_SERVE_FROM_SUB_PATH
           value: "true"
 {{- else }}

--- a/charts/sn-platform/templates/grafana/grafana-statefulset.yaml
+++ b/charts/sn-platform/templates/grafana/grafana-statefulset.yaml
@@ -109,7 +109,7 @@ spec:
         - name: GRAFANA_DOMAIN
           value: {{ template "pulsar.control_center_domain" . }}
         - name: GRAFANA_ROOT_URL
-          value: {{ template "pulsar.control_center_url" . }}{{ template "pulsar.control_center_path.grafana" . }}/
+          value: https://{{ template "pulsar.control_center_domain" . }}:3000{{ template "pulsar.control_center_url" . }}{{ template "pulsar.control_center_path.grafana" . }}/
         - name: GRAFANA_SERVE_FROM_SUB_PATH
           value: "true"
 {{- else }}


### PR DESCRIPTION

Document https://grafana.com/docs/grafana/latest/administration/configuration/#root_url
This is the full URL used to access Grafana from a web browser. This is important if you use Google or GitHub OAuth authentication (for the callback URL to be correct).

