### PR TITLE
feat(crd): migrate crd from v1beta1 to v1

### DIFF
--- a/charts/function-mesh-operator/crds/compute.functionmesh.io_functionmeshes.yaml
+++ b/charts/function-mesh-operator/crds/compute.functionmesh.io_functionmeshes.yaml
@@ -1,6 +1,5 @@
-
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,6620 +14,6619 @@ spec:
     plural: functionmeshes
     singular: functionmesh
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            functions:
-              items:
-                properties:
-                  autoAck:
-                    type: boolean
-                  className:
-                    type: string
-                  cleanupSubscription:
-                    type: boolean
-                  clusterName:
-                    type: string
-                  deadLetterTopic:
-                    type: string
-                  forwardSourceMessageProperty:
-                    type: boolean
-                  funcConfig:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  golang:
-                    properties:
-                      go:
-                        type: string
-                      goLocation:
-                        type: string
-                    type: object
-                  image:
-                    type: string
-                  imagePullPolicy:
-                    type: string
-                  input:
-                    properties:
-                      customSchemaSources:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      customSerdeSources:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      sourceSpecs:
-                        additionalProperties:
-                          properties:
-                            consumerProperties:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            cryptoConfig:
-                              properties:
-                                consumerCryptoFailureAction:
-                                  type: string
-                                cryptoKeyReaderClassName:
-                                  type: string
-                                cryptoKeyReaderConfig:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                cryptoSecrets:
-                                  items:
-                                    properties:
-                                      asVolume:
-                                        type: string
-                                      secretKey:
-                                        type: string
-                                      secretName:
-                                        type: string
-                                    required:
-                                    - secretKey
-                                    - secretName
-                                    type: object
-                                  type: array
-                                encryptionKeys:
-                                  items:
-                                    type: string
-                                  type: array
-                                producerCryptoFailureAction:
-                                  type: string
-                              type: object
-                            isRegexPattern:
-                              type: boolean
-                            receiverQueueSize:
-                              format: int32
-                              type: integer
-                            schemaProperties:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            schemaType:
-                              type: string
-                            serdeClassname:
-                              type: string
-                          type: object
-                        type: object
-                      topicPattern:
-                        type: string
-                      topics:
-                        items:
-                          type: string
-                        type: array
-                      typeClassName:
-                        type: string
-                    type: object
-                  java:
-                    properties:
-                      extraDependenciesDir:
-                        type: string
-                      jar:
-                        type: string
-                      jarLocation:
-                        type: string
-                    type: object
-                  logTopic:
-                    type: string
-                  maxMessageRetry:
-                    format: int32
-                    type: integer
-                  maxPendingAsyncRequests:
-                    format: int32
-                    type: integer
-                  maxReplicas:
-                    format: int32
-                    type: integer
-                  name:
-                    type: string
-                  output:
-                    properties:
-                      customSchemaSinks:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      producerConf:
-                        properties:
-                          batchBuilder:
-                            type: string
-                          cryptoConfig:
-                            properties:
-                              consumerCryptoFailureAction:
-                                type: string
-                              cryptoKeyReaderClassName:
-                                type: string
-                              cryptoKeyReaderConfig:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              cryptoSecrets:
-                                items:
-                                  properties:
-                                    asVolume:
-                                      type: string
-                                    secretKey:
-                                      type: string
-                                    secretName:
-                                      type: string
-                                  required:
-                                  - secretKey
-                                  - secretName
-                                  type: object
-                                type: array
-                              encryptionKeys:
-                                items:
-                                  type: string
-                                type: array
-                              producerCryptoFailureAction:
-                                type: string
-                            type: object
-                          maxPendingMessages:
-                            format: int32
-                            type: integer
-                          maxPendingMessagesAcrossPartitions:
-                            format: int32
-                            type: integer
-                          useThreadLocalProducers:
-                            type: boolean
-                        type: object
-                      sinkSchemaType:
-                        type: string
-                      sinkSerdeClassName:
-                        type: string
-                      topic:
-                        type: string
-                      typeClassName:
-                        type: string
-                    type: object
-                  pod:
-                    properties:
-                      affinity:
-                        properties:
-                          nodeAffinity:
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    preference:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchFields:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                      type: object
-                                    weight:
-                                      format: int32
-                                      type: integer
-                                  required:
-                                  - preference
-                                  - weight
-                                  type: object
-                                type: array
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                properties:
-                                  nodeSelectorTerms:
-                                    items:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchFields:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                      type: object
-                                    type: array
-                                required:
-                                - nodeSelectorTerms
-                                type: object
-                            type: object
-                          podAffinity:
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    podAffinityTerm:
-                                      properties:
-                                        labelSelector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        namespaces:
-                                          items:
-                                            type: string
-                                          type: array
-                                        topologyKey:
-                                          type: string
-                                      required:
-                                      - topologyKey
-                                      type: object
-                                    weight:
-                                      format: int32
-                                      type: integer
-                                  required:
-                                  - podAffinityTerm
-                                  - weight
-                                  type: object
-                                type: array
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                type: array
-                            type: object
-                          podAntiAffinity:
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    podAffinityTerm:
-                                      properties:
-                                        labelSelector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        namespaces:
-                                          items:
-                                            type: string
-                                          type: array
-                                        topologyKey:
-                                          type: string
-                                      required:
-                                      - topologyKey
-                                      type: object
-                                    weight:
-                                      format: int32
-                                      type: integer
-                                  required:
-                                  - podAffinityTerm
-                                  - weight
-                                  type: object
-                                type: array
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                type: array
-                            type: object
-                        type: object
-                      annotations:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      imagePullSecrets:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                        type: array
-                      initContainers:
-                        items:
-                          properties:
-                            args:
-                              items:
-                                type: string
-                              type: array
-                            command:
-                              items:
-                                type: string
-                              type: array
-                            env:
-                              items:
-                                properties:
-                                  name:
-                                    type: string
-                                  value:
-                                    type: string
-                                  valueFrom:
-                                    properties:
-                                      configMapKeyRef:
-                                        properties:
-                                          key:
-                                            type: string
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        required:
-                                        - key
-                                        type: object
-                                      fieldRef:
-                                        properties:
-                                          apiVersion:
-                                            type: string
-                                          fieldPath:
-                                            type: string
-                                        required:
-                                        - fieldPath
-                                        type: object
-                                      resourceFieldRef:
-                                        properties:
-                                          containerName:
-                                            type: string
-                                          divisor:
-                                            type: string
-                                          resource:
-                                            type: string
-                                        required:
-                                        - resource
-                                        type: object
-                                      secretKeyRef:
-                                        properties:
-                                          key:
-                                            type: string
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        required:
-                                        - key
-                                        type: object
-                                    type: object
-                                required:
-                                - name
-                                type: object
-                              type: array
-                            envFrom:
-                              items:
-                                properties:
-                                  configMapRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                  prefix:
-                                    type: string
-                                  secretRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                type: object
-                              type: array
-                            image:
-                              type: string
-                            imagePullPolicy:
-                              type: string
-                            lifecycle:
-                              properties:
-                                postStart:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                  type: object
-                                preStop:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                  type: object
-                              type: object
-                            livenessProbe:
-                              properties:
-                                exec:
-                                  properties:
-                                    command:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                failureThreshold:
-                                  format: int32
-                                  type: integer
-                                httpGet:
-                                  properties:
-                                    host:
-                                      type: string
-                                    httpHeaders:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      type: array
-                                    path:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                    scheme:
-                                      type: string
-                                  required:
-                                  - port
-                                  type: object
-                                initialDelaySeconds:
-                                  format: int32
-                                  type: integer
-                                periodSeconds:
-                                  format: int32
-                                  type: integer
-                                successThreshold:
-                                  format: int32
-                                  type: integer
-                                tcpSocket:
-                                  properties:
-                                    host:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                  required:
-                                  - port
-                                  type: object
-                                timeoutSeconds:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            name:
-                              type: string
-                            ports:
-                              items:
-                                properties:
-                                  containerPort:
-                                    format: int32
-                                    type: integer
-                                  hostIP:
-                                    type: string
-                                  hostPort:
-                                    format: int32
-                                    type: integer
-                                  name:
-                                    type: string
-                                  protocol:
-                                    type: string
-                                required:
-                                - containerPort
-                                type: object
-                              type: array
-                            readinessProbe:
-                              properties:
-                                exec:
-                                  properties:
-                                    command:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                failureThreshold:
-                                  format: int32
-                                  type: integer
-                                httpGet:
-                                  properties:
-                                    host:
-                                      type: string
-                                    httpHeaders:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      type: array
-                                    path:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                    scheme:
-                                      type: string
-                                  required:
-                                  - port
-                                  type: object
-                                initialDelaySeconds:
-                                  format: int32
-                                  type: integer
-                                periodSeconds:
-                                  format: int32
-                                  type: integer
-                                successThreshold:
-                                  format: int32
-                                  type: integer
-                                tcpSocket:
-                                  properties:
-                                    host:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                  required:
-                                  - port
-                                  type: object
-                                timeoutSeconds:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            resources:
-                              properties:
-                                limits:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                requests:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              type: object
-                            securityContext:
-                              properties:
-                                allowPrivilegeEscalation:
-                                  type: boolean
-                                capabilities:
-                                  properties:
-                                    add:
-                                      items:
-                                        type: string
-                                      type: array
-                                    drop:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                privileged:
-                                  type: boolean
-                                procMount:
-                                  type: string
-                                readOnlyRootFilesystem:
-                                  type: boolean
-                                runAsGroup:
-                                  format: int64
-                                  type: integer
-                                runAsNonRoot:
-                                  type: boolean
-                                runAsUser:
-                                  format: int64
-                                  type: integer
-                                seLinuxOptions:
-                                  properties:
-                                    level:
-                                      type: string
-                                    role:
-                                      type: string
-                                    type:
-                                      type: string
-                                    user:
-                                      type: string
-                                  type: object
-                                windowsOptions:
-                                  properties:
-                                    gmsaCredentialSpec:
-                                      type: string
-                                    gmsaCredentialSpecName:
-                                      type: string
-                                    runAsUserName:
-                                      type: string
-                                  type: object
-                              type: object
-                            startupProbe:
-                              properties:
-                                exec:
-                                  properties:
-                                    command:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                failureThreshold:
-                                  format: int32
-                                  type: integer
-                                httpGet:
-                                  properties:
-                                    host:
-                                      type: string
-                                    httpHeaders:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      type: array
-                                    path:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                    scheme:
-                                      type: string
-                                  required:
-                                  - port
-                                  type: object
-                                initialDelaySeconds:
-                                  format: int32
-                                  type: integer
-                                periodSeconds:
-                                  format: int32
-                                  type: integer
-                                successThreshold:
-                                  format: int32
-                                  type: integer
-                                tcpSocket:
-                                  properties:
-                                    host:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                  required:
-                                  - port
-                                  type: object
-                                timeoutSeconds:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            stdin:
-                              type: boolean
-                            stdinOnce:
-                              type: boolean
-                            terminationMessagePath:
-                              type: string
-                            terminationMessagePolicy:
-                              type: string
-                            tty:
-                              type: boolean
-                            volumeDevices:
-                              items:
-                                properties:
-                                  devicePath:
-                                    type: string
-                                  name:
-                                    type: string
-                                required:
-                                - devicePath
-                                - name
-                                type: object
-                              type: array
-                            volumeMounts:
-                              items:
-                                properties:
-                                  mountPath:
-                                    type: string
-                                  mountPropagation:
-                                    type: string
-                                  name:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                  subPath:
-                                    type: string
-                                  subPathExpr:
-                                    type: string
-                                required:
-                                - mountPath
-                                - name
-                                type: object
-                              type: array
-                            workingDir:
-                              type: string
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      labels:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      nodeSelector:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      securityContext:
-                        properties:
-                          fsGroup:
-                            format: int64
-                            type: integer
-                          fsGroupChangePolicy:
-                            type: string
-                          runAsGroup:
-                            format: int64
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            format: int64
-                            type: integer
-                          seLinuxOptions:
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                            type: object
-                          supplementalGroups:
-                            items:
-                              format: int64
-                              type: integer
-                            type: array
-                          sysctls:
-                            items:
-                              properties:
-                                name:
-                                  type: string
-                                value:
-                                  type: string
-                              required:
-                              - name
-                              - value
-                              type: object
-                            type: array
-                          windowsOptions:
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              runAsUserName:
-                                type: string
-                            type: object
-                        type: object
-                      sidecars:
-                        items:
-                          properties:
-                            args:
-                              items:
-                                type: string
-                              type: array
-                            command:
-                              items:
-                                type: string
-                              type: array
-                            env:
-                              items:
-                                properties:
-                                  name:
-                                    type: string
-                                  value:
-                                    type: string
-                                  valueFrom:
-                                    properties:
-                                      configMapKeyRef:
-                                        properties:
-                                          key:
-                                            type: string
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        required:
-                                        - key
-                                        type: object
-                                      fieldRef:
-                                        properties:
-                                          apiVersion:
-                                            type: string
-                                          fieldPath:
-                                            type: string
-                                        required:
-                                        - fieldPath
-                                        type: object
-                                      resourceFieldRef:
-                                        properties:
-                                          containerName:
-                                            type: string
-                                          divisor:
-                                            type: string
-                                          resource:
-                                            type: string
-                                        required:
-                                        - resource
-                                        type: object
-                                      secretKeyRef:
-                                        properties:
-                                          key:
-                                            type: string
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        required:
-                                        - key
-                                        type: object
-                                    type: object
-                                required:
-                                - name
-                                type: object
-                              type: array
-                            envFrom:
-                              items:
-                                properties:
-                                  configMapRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                  prefix:
-                                    type: string
-                                  secretRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                type: object
-                              type: array
-                            image:
-                              type: string
-                            imagePullPolicy:
-                              type: string
-                            lifecycle:
-                              properties:
-                                postStart:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                  type: object
-                                preStop:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                  type: object
-                              type: object
-                            livenessProbe:
-                              properties:
-                                exec:
-                                  properties:
-                                    command:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                failureThreshold:
-                                  format: int32
-                                  type: integer
-                                httpGet:
-                                  properties:
-                                    host:
-                                      type: string
-                                    httpHeaders:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      type: array
-                                    path:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                    scheme:
-                                      type: string
-                                  required:
-                                  - port
-                                  type: object
-                                initialDelaySeconds:
-                                  format: int32
-                                  type: integer
-                                periodSeconds:
-                                  format: int32
-                                  type: integer
-                                successThreshold:
-                                  format: int32
-                                  type: integer
-                                tcpSocket:
-                                  properties:
-                                    host:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                  required:
-                                  - port
-                                  type: object
-                                timeoutSeconds:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            name:
-                              type: string
-                            ports:
-                              items:
-                                properties:
-                                  containerPort:
-                                    format: int32
-                                    type: integer
-                                  hostIP:
-                                    type: string
-                                  hostPort:
-                                    format: int32
-                                    type: integer
-                                  name:
-                                    type: string
-                                  protocol:
-                                    type: string
-                                required:
-                                - containerPort
-                                type: object
-                              type: array
-                            readinessProbe:
-                              properties:
-                                exec:
-                                  properties:
-                                    command:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                failureThreshold:
-                                  format: int32
-                                  type: integer
-                                httpGet:
-                                  properties:
-                                    host:
-                                      type: string
-                                    httpHeaders:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      type: array
-                                    path:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                    scheme:
-                                      type: string
-                                  required:
-                                  - port
-                                  type: object
-                                initialDelaySeconds:
-                                  format: int32
-                                  type: integer
-                                periodSeconds:
-                                  format: int32
-                                  type: integer
-                                successThreshold:
-                                  format: int32
-                                  type: integer
-                                tcpSocket:
-                                  properties:
-                                    host:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                  required:
-                                  - port
-                                  type: object
-                                timeoutSeconds:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            resources:
-                              properties:
-                                limits:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                requests:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              type: object
-                            securityContext:
-                              properties:
-                                allowPrivilegeEscalation:
-                                  type: boolean
-                                capabilities:
-                                  properties:
-                                    add:
-                                      items:
-                                        type: string
-                                      type: array
-                                    drop:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                privileged:
-                                  type: boolean
-                                procMount:
-                                  type: string
-                                readOnlyRootFilesystem:
-                                  type: boolean
-                                runAsGroup:
-                                  format: int64
-                                  type: integer
-                                runAsNonRoot:
-                                  type: boolean
-                                runAsUser:
-                                  format: int64
-                                  type: integer
-                                seLinuxOptions:
-                                  properties:
-                                    level:
-                                      type: string
-                                    role:
-                                      type: string
-                                    type:
-                                      type: string
-                                    user:
-                                      type: string
-                                  type: object
-                                windowsOptions:
-                                  properties:
-                                    gmsaCredentialSpec:
-                                      type: string
-                                    gmsaCredentialSpecName:
-                                      type: string
-                                    runAsUserName:
-                                      type: string
-                                  type: object
-                              type: object
-                            startupProbe:
-                              properties:
-                                exec:
-                                  properties:
-                                    command:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                failureThreshold:
-                                  format: int32
-                                  type: integer
-                                httpGet:
-                                  properties:
-                                    host:
-                                      type: string
-                                    httpHeaders:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      type: array
-                                    path:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                    scheme:
-                                      type: string
-                                  required:
-                                  - port
-                                  type: object
-                                initialDelaySeconds:
-                                  format: int32
-                                  type: integer
-                                periodSeconds:
-                                  format: int32
-                                  type: integer
-                                successThreshold:
-                                  format: int32
-                                  type: integer
-                                tcpSocket:
-                                  properties:
-                                    host:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                  required:
-                                  - port
-                                  type: object
-                                timeoutSeconds:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            stdin:
-                              type: boolean
-                            stdinOnce:
-                              type: boolean
-                            terminationMessagePath:
-                              type: string
-                            terminationMessagePolicy:
-                              type: string
-                            tty:
-                              type: boolean
-                            volumeDevices:
-                              items:
-                                properties:
-                                  devicePath:
-                                    type: string
-                                  name:
-                                    type: string
-                                required:
-                                - devicePath
-                                - name
-                                type: object
-                              type: array
-                            volumeMounts:
-                              items:
-                                properties:
-                                  mountPath:
-                                    type: string
-                                  mountPropagation:
-                                    type: string
-                                  name:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                  subPath:
-                                    type: string
-                                  subPathExpr:
-                                    type: string
-                                required:
-                                - mountPath
-                                - name
-                                type: object
-                              type: array
-                            workingDir:
-                              type: string
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      terminationGracePeriodSeconds:
-                        format: int64
-                        type: integer
-                      tolerations:
-                        items:
-                          properties:
-                            effect:
-                              type: string
-                            key:
-                              type: string
-                            operator:
-                              type: string
-                            tolerationSeconds:
-                              format: int64
-                              type: integer
-                            value:
-                              type: string
-                          type: object
-                        type: array
-                      volumes:
-                        items:
-                          properties:
-                            awsElasticBlockStore:
-                              properties:
-                                fsType:
-                                  type: string
-                                partition:
-                                  format: int32
-                                  type: integer
-                                readOnly:
-                                  type: boolean
-                                volumeID:
-                                  type: string
-                              required:
-                              - volumeID
-                              type: object
-                            azureDisk:
-                              properties:
-                                cachingMode:
-                                  type: string
-                                diskName:
-                                  type: string
-                                diskURI:
-                                  type: string
-                                fsType:
-                                  type: string
-                                kind:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - diskName
-                              - diskURI
-                              type: object
-                            azureFile:
-                              properties:
-                                readOnly:
-                                  type: boolean
-                                secretName:
-                                  type: string
-                                shareName:
-                                  type: string
-                              required:
-                              - secretName
-                              - shareName
-                              type: object
-                            cephfs:
-                              properties:
-                                monitors:
-                                  items:
-                                    type: string
-                                  type: array
-                                path:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretFile:
-                                  type: string
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                user:
-                                  type: string
-                              required:
-                              - monitors
-                              type: object
-                            cinder:
-                              properties:
-                                fsType:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                volumeID:
-                                  type: string
-                              required:
-                              - volumeID
-                              type: object
-                            configMap:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                items:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      mode:
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              type: object
-                            csi:
-                              properties:
-                                driver:
-                                  type: string
-                                fsType:
-                                  type: string
-                                nodePublishSecretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                readOnly:
-                                  type: boolean
-                                volumeAttributes:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              required:
-                              - driver
-                              type: object
-                            downwardAPI:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                items:
-                                  items:
-                                    properties:
-                                      fieldRef:
-                                        properties:
-                                          apiVersion:
-                                            type: string
-                                          fieldPath:
-                                            type: string
-                                        required:
-                                        - fieldPath
-                                        type: object
-                                      mode:
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        type: string
-                                      resourceFieldRef:
-                                        properties:
-                                          containerName:
-                                            type: string
-                                          divisor:
-                                            type: string
-                                          resource:
-                                            type: string
-                                        required:
-                                        - resource
-                                        type: object
-                                    required:
-                                    - path
-                                    type: object
-                                  type: array
-                              type: object
-                            emptyDir:
-                              properties:
-                                medium:
-                                  type: string
-                                sizeLimit:
-                                  type: string
-                              type: object
-                            fc:
-                              properties:
-                                fsType:
-                                  type: string
-                                lun:
-                                  format: int32
-                                  type: integer
-                                readOnly:
-                                  type: boolean
-                                targetWWNs:
-                                  items:
-                                    type: string
-                                  type: array
-                                wwids:
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            flexVolume:
-                              properties:
-                                driver:
-                                  type: string
-                                fsType:
-                                  type: string
-                                options:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                              required:
-                              - driver
-                              type: object
-                            flocker:
-                              properties:
-                                datasetName:
-                                  type: string
-                                datasetUUID:
-                                  type: string
-                              type: object
-                            gcePersistentDisk:
-                              properties:
-                                fsType:
-                                  type: string
-                                partition:
-                                  format: int32
-                                  type: integer
-                                pdName:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - pdName
-                              type: object
-                            gitRepo:
-                              properties:
-                                directory:
-                                  type: string
-                                repository:
-                                  type: string
-                                revision:
-                                  type: string
-                              required:
-                              - repository
-                              type: object
-                            glusterfs:
-                              properties:
-                                endpoints:
-                                  type: string
-                                path:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - endpoints
-                              - path
-                              type: object
-                            hostPath:
-                              properties:
-                                path:
-                                  type: string
-                                type:
-                                  type: string
-                              required:
-                              - path
-                              type: object
-                            iscsi:
-                              properties:
-                                chapAuthDiscovery:
-                                  type: boolean
-                                chapAuthSession:
-                                  type: boolean
-                                fsType:
-                                  type: string
-                                initiatorName:
-                                  type: string
-                                iqn:
-                                  type: string
-                                iscsiInterface:
-                                  type: string
-                                lun:
-                                  format: int32
-                                  type: integer
-                                portals:
-                                  items:
-                                    type: string
-                                  type: array
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                targetPortal:
-                                  type: string
-                              required:
-                              - iqn
-                              - lun
-                              - targetPortal
-                              type: object
-                            name:
-                              type: string
-                            nfs:
-                              properties:
-                                path:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                server:
-                                  type: string
-                              required:
-                              - path
-                              - server
-                              type: object
-                            persistentVolumeClaim:
-                              properties:
-                                claimName:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - claimName
-                              type: object
-                            photonPersistentDisk:
-                              properties:
-                                fsType:
-                                  type: string
-                                pdID:
-                                  type: string
-                              required:
-                              - pdID
-                              type: object
-                            portworxVolume:
-                              properties:
-                                fsType:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                volumeID:
-                                  type: string
-                              required:
-                              - volumeID
-                              type: object
-                            projected:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                sources:
-                                  items:
-                                    properties:
-                                      configMap:
-                                        properties:
-                                          items:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                mode:
-                                                  format: int32
-                                                  type: integer
-                                                path:
-                                                  type: string
-                                              required:
-                                              - key
-                                              - path
-                                              type: object
-                                            type: array
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        type: object
-                                      downwardAPI:
-                                        properties:
-                                          items:
-                                            items:
-                                              properties:
-                                                fieldRef:
-                                                  properties:
-                                                    apiVersion:
-                                                      type: string
-                                                    fieldPath:
-                                                      type: string
-                                                  required:
-                                                  - fieldPath
-                                                  type: object
-                                                mode:
-                                                  format: int32
-                                                  type: integer
-                                                path:
-                                                  type: string
-                                                resourceFieldRef:
-                                                  properties:
-                                                    containerName:
-                                                      type: string
-                                                    divisor:
-                                                      type: string
-                                                    resource:
-                                                      type: string
-                                                  required:
-                                                  - resource
-                                                  type: object
-                                              required:
-                                              - path
-                                              type: object
-                                            type: array
-                                        type: object
-                                      secret:
-                                        properties:
-                                          items:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                mode:
-                                                  format: int32
-                                                  type: integer
-                                                path:
-                                                  type: string
-                                              required:
-                                              - key
-                                              - path
-                                              type: object
-                                            type: array
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        type: object
-                                      serviceAccountToken:
-                                        properties:
-                                          audience:
-                                            type: string
-                                          expirationSeconds:
-                                            format: int64
-                                            type: integer
-                                          path:
-                                            type: string
-                                        required:
-                                        - path
-                                        type: object
-                                    type: object
-                                  type: array
-                              required:
-                              - sources
-                              type: object
-                            quobyte:
-                              properties:
-                                group:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                registry:
-                                  type: string
-                                tenant:
-                                  type: string
-                                user:
-                                  type: string
-                                volume:
-                                  type: string
-                              required:
-                              - registry
-                              - volume
-                              type: object
-                            rbd:
-                              properties:
-                                fsType:
-                                  type: string
-                                image:
-                                  type: string
-                                keyring:
-                                  type: string
-                                monitors:
-                                  items:
-                                    type: string
-                                  type: array
-                                pool:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                user:
-                                  type: string
-                              required:
-                              - image
-                              - monitors
-                              type: object
-                            scaleIO:
-                              properties:
-                                fsType:
-                                  type: string
-                                gateway:
-                                  type: string
-                                protectionDomain:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                sslEnabled:
-                                  type: boolean
-                                storageMode:
-                                  type: string
-                                storagePool:
-                                  type: string
-                                system:
-                                  type: string
-                                volumeName:
-                                  type: string
-                              required:
-                              - gateway
-                              - secretRef
-                              - system
-                              type: object
-                            secret:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                items:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      mode:
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                optional:
-                                  type: boolean
-                                secretName:
-                                  type: string
-                              type: object
-                            storageos:
-                              properties:
-                                fsType:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                volumeName:
-                                  type: string
-                                volumeNamespace:
-                                  type: string
-                              type: object
-                            vsphereVolume:
-                              properties:
-                                fsType:
-                                  type: string
-                                storagePolicyID:
-                                  type: string
-                                storagePolicyName:
-                                  type: string
-                                volumePath:
-                                  type: string
-                              required:
-                              - volumePath
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                    type: object
-                  processingGuarantee:
-                    type: string
-                  pulsar:
-                    properties:
-                      authSecret:
-                        type: string
-                      pulsarConfig:
-                        type: string
-                      tlsSecret:
-                        type: string
-                    type: object
-                  python:
-                    properties:
-                      py:
-                        type: string
-                      pyLocation:
-                        type: string
-                    type: object
-                  replicas:
-                    format: int32
-                    type: integer
-                  resources:
-                    properties:
-                      limits:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      requests:
-                        additionalProperties:
-                          type: string
-                        type: object
-                    type: object
-                  retainKeyOrdering:
-                    type: boolean
-                  retainOrdering:
-                    type: boolean
-                  runtimeFlags:
-                    type: string
-                  secretsMap:
-                    additionalProperties:
-                      properties:
-                        key:
-                          type: string
-                        path:
-                          type: string
-                      type: object
-                    type: object
-                  subscriptionName:
-                    type: string
-                  subscriptionPosition:
-                    type: string
-                  tenant:
-                    type: string
-                  timeout:
-                    format: int32
-                    type: integer
-                  volumeMounts:
-                    items:
-                      properties:
-                        mountPath:
-                          type: string
-                        mountPropagation:
-                          type: string
-                        name:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        subPath:
-                          type: string
-                        subPathExpr:
-                          type: string
-                      required:
-                      - mountPath
-                      - name
-                      type: object
-                    type: array
-                type: object
-              type: array
-            sinks:
-              items:
-                properties:
-                  autoAck:
-                    type: boolean
-                  className:
-                    type: string
-                  cleanupSubscription:
-                    type: boolean
-                  clusterName:
-                    type: string
-                  deadLetterTopic:
-                    type: string
-                  golang:
-                    properties:
-                      go:
-                        type: string
-                      goLocation:
-                        type: string
-                    type: object
-                  image:
-                    type: string
-                  imagePullPolicy:
-                    type: string
-                  input:
-                    properties:
-                      customSchemaSources:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      customSerdeSources:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      sourceSpecs:
-                        additionalProperties:
-                          properties:
-                            consumerProperties:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            cryptoConfig:
-                              properties:
-                                consumerCryptoFailureAction:
-                                  type: string
-                                cryptoKeyReaderClassName:
-                                  type: string
-                                cryptoKeyReaderConfig:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                cryptoSecrets:
-                                  items:
-                                    properties:
-                                      asVolume:
-                                        type: string
-                                      secretKey:
-                                        type: string
-                                      secretName:
-                                        type: string
-                                    required:
-                                    - secretKey
-                                    - secretName
-                                    type: object
-                                  type: array
-                                encryptionKeys:
-                                  items:
-                                    type: string
-                                  type: array
-                                producerCryptoFailureAction:
-                                  type: string
-                              type: object
-                            isRegexPattern:
-                              type: boolean
-                            receiverQueueSize:
-                              format: int32
-                              type: integer
-                            schemaProperties:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            schemaType:
-                              type: string
-                            serdeClassname:
-                              type: string
-                          type: object
-                        type: object
-                      topicPattern:
-                        type: string
-                      topics:
-                        items:
-                          type: string
-                        type: array
-                      typeClassName:
-                        type: string
-                    type: object
-                  java:
-                    properties:
-                      extraDependenciesDir:
-                        type: string
-                      jar:
-                        type: string
-                      jarLocation:
-                        type: string
-                    type: object
-                  logTopic:
-                    type: string
-                  maxMessageRetry:
-                    format: int32
-                    type: integer
-                  maxReplicas:
-                    format: int32
-                    type: integer
-                  name:
-                    type: string
-                  negativeAckRedeliveryDelayMs:
-                    format: int32
-                    type: integer
-                  pod:
-                    properties:
-                      affinity:
-                        properties:
-                          nodeAffinity:
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    preference:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchFields:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                      type: object
-                                    weight:
-                                      format: int32
-                                      type: integer
-                                  required:
-                                  - preference
-                                  - weight
-                                  type: object
-                                type: array
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                properties:
-                                  nodeSelectorTerms:
-                                    items:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchFields:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                      type: object
-                                    type: array
-                                required:
-                                - nodeSelectorTerms
-                                type: object
-                            type: object
-                          podAffinity:
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    podAffinityTerm:
-                                      properties:
-                                        labelSelector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        namespaces:
-                                          items:
-                                            type: string
-                                          type: array
-                                        topologyKey:
-                                          type: string
-                                      required:
-                                      - topologyKey
-                                      type: object
-                                    weight:
-                                      format: int32
-                                      type: integer
-                                  required:
-                                  - podAffinityTerm
-                                  - weight
-                                  type: object
-                                type: array
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                type: array
-                            type: object
-                          podAntiAffinity:
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    podAffinityTerm:
-                                      properties:
-                                        labelSelector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        namespaces:
-                                          items:
-                                            type: string
-                                          type: array
-                                        topologyKey:
-                                          type: string
-                                      required:
-                                      - topologyKey
-                                      type: object
-                                    weight:
-                                      format: int32
-                                      type: integer
-                                  required:
-                                  - podAffinityTerm
-                                  - weight
-                                  type: object
-                                type: array
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                type: array
-                            type: object
-                        type: object
-                      annotations:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      imagePullSecrets:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                        type: array
-                      initContainers:
-                        items:
-                          properties:
-                            args:
-                              items:
-                                type: string
-                              type: array
-                            command:
-                              items:
-                                type: string
-                              type: array
-                            env:
-                              items:
-                                properties:
-                                  name:
-                                    type: string
-                                  value:
-                                    type: string
-                                  valueFrom:
-                                    properties:
-                                      configMapKeyRef:
-                                        properties:
-                                          key:
-                                            type: string
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        required:
-                                        - key
-                                        type: object
-                                      fieldRef:
-                                        properties:
-                                          apiVersion:
-                                            type: string
-                                          fieldPath:
-                                            type: string
-                                        required:
-                                        - fieldPath
-                                        type: object
-                                      resourceFieldRef:
-                                        properties:
-                                          containerName:
-                                            type: string
-                                          divisor:
-                                            type: string
-                                          resource:
-                                            type: string
-                                        required:
-                                        - resource
-                                        type: object
-                                      secretKeyRef:
-                                        properties:
-                                          key:
-                                            type: string
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        required:
-                                        - key
-                                        type: object
-                                    type: object
-                                required:
-                                - name
-                                type: object
-                              type: array
-                            envFrom:
-                              items:
-                                properties:
-                                  configMapRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                  prefix:
-                                    type: string
-                                  secretRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                type: object
-                              type: array
-                            image:
-                              type: string
-                            imagePullPolicy:
-                              type: string
-                            lifecycle:
-                              properties:
-                                postStart:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                  type: object
-                                preStop:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                  type: object
-                              type: object
-                            livenessProbe:
-                              properties:
-                                exec:
-                                  properties:
-                                    command:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                failureThreshold:
-                                  format: int32
-                                  type: integer
-                                httpGet:
-                                  properties:
-                                    host:
-                                      type: string
-                                    httpHeaders:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      type: array
-                                    path:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                    scheme:
-                                      type: string
-                                  required:
-                                  - port
-                                  type: object
-                                initialDelaySeconds:
-                                  format: int32
-                                  type: integer
-                                periodSeconds:
-                                  format: int32
-                                  type: integer
-                                successThreshold:
-                                  format: int32
-                                  type: integer
-                                tcpSocket:
-                                  properties:
-                                    host:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                  required:
-                                  - port
-                                  type: object
-                                timeoutSeconds:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            name:
-                              type: string
-                            ports:
-                              items:
-                                properties:
-                                  containerPort:
-                                    format: int32
-                                    type: integer
-                                  hostIP:
-                                    type: string
-                                  hostPort:
-                                    format: int32
-                                    type: integer
-                                  name:
-                                    type: string
-                                  protocol:
-                                    type: string
-                                required:
-                                - containerPort
-                                type: object
-                              type: array
-                            readinessProbe:
-                              properties:
-                                exec:
-                                  properties:
-                                    command:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                failureThreshold:
-                                  format: int32
-                                  type: integer
-                                httpGet:
-                                  properties:
-                                    host:
-                                      type: string
-                                    httpHeaders:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      type: array
-                                    path:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                    scheme:
-                                      type: string
-                                  required:
-                                  - port
-                                  type: object
-                                initialDelaySeconds:
-                                  format: int32
-                                  type: integer
-                                periodSeconds:
-                                  format: int32
-                                  type: integer
-                                successThreshold:
-                                  format: int32
-                                  type: integer
-                                tcpSocket:
-                                  properties:
-                                    host:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                  required:
-                                  - port
-                                  type: object
-                                timeoutSeconds:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            resources:
-                              properties:
-                                limits:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                requests:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              type: object
-                            securityContext:
-                              properties:
-                                allowPrivilegeEscalation:
-                                  type: boolean
-                                capabilities:
-                                  properties:
-                                    add:
-                                      items:
-                                        type: string
-                                      type: array
-                                    drop:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                privileged:
-                                  type: boolean
-                                procMount:
-                                  type: string
-                                readOnlyRootFilesystem:
-                                  type: boolean
-                                runAsGroup:
-                                  format: int64
-                                  type: integer
-                                runAsNonRoot:
-                                  type: boolean
-                                runAsUser:
-                                  format: int64
-                                  type: integer
-                                seLinuxOptions:
-                                  properties:
-                                    level:
-                                      type: string
-                                    role:
-                                      type: string
-                                    type:
-                                      type: string
-                                    user:
-                                      type: string
-                                  type: object
-                                windowsOptions:
-                                  properties:
-                                    gmsaCredentialSpec:
-                                      type: string
-                                    gmsaCredentialSpecName:
-                                      type: string
-                                    runAsUserName:
-                                      type: string
-                                  type: object
-                              type: object
-                            startupProbe:
-                              properties:
-                                exec:
-                                  properties:
-                                    command:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                failureThreshold:
-                                  format: int32
-                                  type: integer
-                                httpGet:
-                                  properties:
-                                    host:
-                                      type: string
-                                    httpHeaders:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      type: array
-                                    path:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                    scheme:
-                                      type: string
-                                  required:
-                                  - port
-                                  type: object
-                                initialDelaySeconds:
-                                  format: int32
-                                  type: integer
-                                periodSeconds:
-                                  format: int32
-                                  type: integer
-                                successThreshold:
-                                  format: int32
-                                  type: integer
-                                tcpSocket:
-                                  properties:
-                                    host:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                  required:
-                                  - port
-                                  type: object
-                                timeoutSeconds:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            stdin:
-                              type: boolean
-                            stdinOnce:
-                              type: boolean
-                            terminationMessagePath:
-                              type: string
-                            terminationMessagePolicy:
-                              type: string
-                            tty:
-                              type: boolean
-                            volumeDevices:
-                              items:
-                                properties:
-                                  devicePath:
-                                    type: string
-                                  name:
-                                    type: string
-                                required:
-                                - devicePath
-                                - name
-                                type: object
-                              type: array
-                            volumeMounts:
-                              items:
-                                properties:
-                                  mountPath:
-                                    type: string
-                                  mountPropagation:
-                                    type: string
-                                  name:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                  subPath:
-                                    type: string
-                                  subPathExpr:
-                                    type: string
-                                required:
-                                - mountPath
-                                - name
-                                type: object
-                              type: array
-                            workingDir:
-                              type: string
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      labels:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      nodeSelector:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      securityContext:
-                        properties:
-                          fsGroup:
-                            format: int64
-                            type: integer
-                          fsGroupChangePolicy:
-                            type: string
-                          runAsGroup:
-                            format: int64
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            format: int64
-                            type: integer
-                          seLinuxOptions:
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                            type: object
-                          supplementalGroups:
-                            items:
-                              format: int64
-                              type: integer
-                            type: array
-                          sysctls:
-                            items:
-                              properties:
-                                name:
-                                  type: string
-                                value:
-                                  type: string
-                              required:
-                              - name
-                              - value
-                              type: object
-                            type: array
-                          windowsOptions:
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              runAsUserName:
-                                type: string
-                            type: object
-                        type: object
-                      sidecars:
-                        items:
-                          properties:
-                            args:
-                              items:
-                                type: string
-                              type: array
-                            command:
-                              items:
-                                type: string
-                              type: array
-                            env:
-                              items:
-                                properties:
-                                  name:
-                                    type: string
-                                  value:
-                                    type: string
-                                  valueFrom:
-                                    properties:
-                                      configMapKeyRef:
-                                        properties:
-                                          key:
-                                            type: string
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        required:
-                                        - key
-                                        type: object
-                                      fieldRef:
-                                        properties:
-                                          apiVersion:
-                                            type: string
-                                          fieldPath:
-                                            type: string
-                                        required:
-                                        - fieldPath
-                                        type: object
-                                      resourceFieldRef:
-                                        properties:
-                                          containerName:
-                                            type: string
-                                          divisor:
-                                            type: string
-                                          resource:
-                                            type: string
-                                        required:
-                                        - resource
-                                        type: object
-                                      secretKeyRef:
-                                        properties:
-                                          key:
-                                            type: string
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        required:
-                                        - key
-                                        type: object
-                                    type: object
-                                required:
-                                - name
-                                type: object
-                              type: array
-                            envFrom:
-                              items:
-                                properties:
-                                  configMapRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                  prefix:
-                                    type: string
-                                  secretRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                type: object
-                              type: array
-                            image:
-                              type: string
-                            imagePullPolicy:
-                              type: string
-                            lifecycle:
-                              properties:
-                                postStart:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                  type: object
-                                preStop:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                  type: object
-                              type: object
-                            livenessProbe:
-                              properties:
-                                exec:
-                                  properties:
-                                    command:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                failureThreshold:
-                                  format: int32
-                                  type: integer
-                                httpGet:
-                                  properties:
-                                    host:
-                                      type: string
-                                    httpHeaders:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      type: array
-                                    path:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                    scheme:
-                                      type: string
-                                  required:
-                                  - port
-                                  type: object
-                                initialDelaySeconds:
-                                  format: int32
-                                  type: integer
-                                periodSeconds:
-                                  format: int32
-                                  type: integer
-                                successThreshold:
-                                  format: int32
-                                  type: integer
-                                tcpSocket:
-                                  properties:
-                                    host:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                  required:
-                                  - port
-                                  type: object
-                                timeoutSeconds:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            name:
-                              type: string
-                            ports:
-                              items:
-                                properties:
-                                  containerPort:
-                                    format: int32
-                                    type: integer
-                                  hostIP:
-                                    type: string
-                                  hostPort:
-                                    format: int32
-                                    type: integer
-                                  name:
-                                    type: string
-                                  protocol:
-                                    type: string
-                                required:
-                                - containerPort
-                                type: object
-                              type: array
-                            readinessProbe:
-                              properties:
-                                exec:
-                                  properties:
-                                    command:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                failureThreshold:
-                                  format: int32
-                                  type: integer
-                                httpGet:
-                                  properties:
-                                    host:
-                                      type: string
-                                    httpHeaders:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      type: array
-                                    path:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                    scheme:
-                                      type: string
-                                  required:
-                                  - port
-                                  type: object
-                                initialDelaySeconds:
-                                  format: int32
-                                  type: integer
-                                periodSeconds:
-                                  format: int32
-                                  type: integer
-                                successThreshold:
-                                  format: int32
-                                  type: integer
-                                tcpSocket:
-                                  properties:
-                                    host:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                  required:
-                                  - port
-                                  type: object
-                                timeoutSeconds:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            resources:
-                              properties:
-                                limits:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                requests:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              type: object
-                            securityContext:
-                              properties:
-                                allowPrivilegeEscalation:
-                                  type: boolean
-                                capabilities:
-                                  properties:
-                                    add:
-                                      items:
-                                        type: string
-                                      type: array
-                                    drop:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                privileged:
-                                  type: boolean
-                                procMount:
-                                  type: string
-                                readOnlyRootFilesystem:
-                                  type: boolean
-                                runAsGroup:
-                                  format: int64
-                                  type: integer
-                                runAsNonRoot:
-                                  type: boolean
-                                runAsUser:
-                                  format: int64
-                                  type: integer
-                                seLinuxOptions:
-                                  properties:
-                                    level:
-                                      type: string
-                                    role:
-                                      type: string
-                                    type:
-                                      type: string
-                                    user:
-                                      type: string
-                                  type: object
-                                windowsOptions:
-                                  properties:
-                                    gmsaCredentialSpec:
-                                      type: string
-                                    gmsaCredentialSpecName:
-                                      type: string
-                                    runAsUserName:
-                                      type: string
-                                  type: object
-                              type: object
-                            startupProbe:
-                              properties:
-                                exec:
-                                  properties:
-                                    command:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                failureThreshold:
-                                  format: int32
-                                  type: integer
-                                httpGet:
-                                  properties:
-                                    host:
-                                      type: string
-                                    httpHeaders:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      type: array
-                                    path:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                    scheme:
-                                      type: string
-                                  required:
-                                  - port
-                                  type: object
-                                initialDelaySeconds:
-                                  format: int32
-                                  type: integer
-                                periodSeconds:
-                                  format: int32
-                                  type: integer
-                                successThreshold:
-                                  format: int32
-                                  type: integer
-                                tcpSocket:
-                                  properties:
-                                    host:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                  required:
-                                  - port
-                                  type: object
-                                timeoutSeconds:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            stdin:
-                              type: boolean
-                            stdinOnce:
-                              type: boolean
-                            terminationMessagePath:
-                              type: string
-                            terminationMessagePolicy:
-                              type: string
-                            tty:
-                              type: boolean
-                            volumeDevices:
-                              items:
-                                properties:
-                                  devicePath:
-                                    type: string
-                                  name:
-                                    type: string
-                                required:
-                                - devicePath
-                                - name
-                                type: object
-                              type: array
-                            volumeMounts:
-                              items:
-                                properties:
-                                  mountPath:
-                                    type: string
-                                  mountPropagation:
-                                    type: string
-                                  name:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                  subPath:
-                                    type: string
-                                  subPathExpr:
-                                    type: string
-                                required:
-                                - mountPath
-                                - name
-                                type: object
-                              type: array
-                            workingDir:
-                              type: string
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      terminationGracePeriodSeconds:
-                        format: int64
-                        type: integer
-                      tolerations:
-                        items:
-                          properties:
-                            effect:
-                              type: string
-                            key:
-                              type: string
-                            operator:
-                              type: string
-                            tolerationSeconds:
-                              format: int64
-                              type: integer
-                            value:
-                              type: string
-                          type: object
-                        type: array
-                      volumes:
-                        items:
-                          properties:
-                            awsElasticBlockStore:
-                              properties:
-                                fsType:
-                                  type: string
-                                partition:
-                                  format: int32
-                                  type: integer
-                                readOnly:
-                                  type: boolean
-                                volumeID:
-                                  type: string
-                              required:
-                              - volumeID
-                              type: object
-                            azureDisk:
-                              properties:
-                                cachingMode:
-                                  type: string
-                                diskName:
-                                  type: string
-                                diskURI:
-                                  type: string
-                                fsType:
-                                  type: string
-                                kind:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - diskName
-                              - diskURI
-                              type: object
-                            azureFile:
-                              properties:
-                                readOnly:
-                                  type: boolean
-                                secretName:
-                                  type: string
-                                shareName:
-                                  type: string
-                              required:
-                              - secretName
-                              - shareName
-                              type: object
-                            cephfs:
-                              properties:
-                                monitors:
-                                  items:
-                                    type: string
-                                  type: array
-                                path:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretFile:
-                                  type: string
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                user:
-                                  type: string
-                              required:
-                              - monitors
-                              type: object
-                            cinder:
-                              properties:
-                                fsType:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                volumeID:
-                                  type: string
-                              required:
-                              - volumeID
-                              type: object
-                            configMap:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                items:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      mode:
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              type: object
-                            csi:
-                              properties:
-                                driver:
-                                  type: string
-                                fsType:
-                                  type: string
-                                nodePublishSecretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                readOnly:
-                                  type: boolean
-                                volumeAttributes:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              required:
-                              - driver
-                              type: object
-                            downwardAPI:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                items:
-                                  items:
-                                    properties:
-                                      fieldRef:
-                                        properties:
-                                          apiVersion:
-                                            type: string
-                                          fieldPath:
-                                            type: string
-                                        required:
-                                        - fieldPath
-                                        type: object
-                                      mode:
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        type: string
-                                      resourceFieldRef:
-                                        properties:
-                                          containerName:
-                                            type: string
-                                          divisor:
-                                            type: string
-                                          resource:
-                                            type: string
-                                        required:
-                                        - resource
-                                        type: object
-                                    required:
-                                    - path
-                                    type: object
-                                  type: array
-                              type: object
-                            emptyDir:
-                              properties:
-                                medium:
-                                  type: string
-                                sizeLimit:
-                                  type: string
-                              type: object
-                            fc:
-                              properties:
-                                fsType:
-                                  type: string
-                                lun:
-                                  format: int32
-                                  type: integer
-                                readOnly:
-                                  type: boolean
-                                targetWWNs:
-                                  items:
-                                    type: string
-                                  type: array
-                                wwids:
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            flexVolume:
-                              properties:
-                                driver:
-                                  type: string
-                                fsType:
-                                  type: string
-                                options:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                              required:
-                              - driver
-                              type: object
-                            flocker:
-                              properties:
-                                datasetName:
-                                  type: string
-                                datasetUUID:
-                                  type: string
-                              type: object
-                            gcePersistentDisk:
-                              properties:
-                                fsType:
-                                  type: string
-                                partition:
-                                  format: int32
-                                  type: integer
-                                pdName:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - pdName
-                              type: object
-                            gitRepo:
-                              properties:
-                                directory:
-                                  type: string
-                                repository:
-                                  type: string
-                                revision:
-                                  type: string
-                              required:
-                              - repository
-                              type: object
-                            glusterfs:
-                              properties:
-                                endpoints:
-                                  type: string
-                                path:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - endpoints
-                              - path
-                              type: object
-                            hostPath:
-                              properties:
-                                path:
-                                  type: string
-                                type:
-                                  type: string
-                              required:
-                              - path
-                              type: object
-                            iscsi:
-                              properties:
-                                chapAuthDiscovery:
-                                  type: boolean
-                                chapAuthSession:
-                                  type: boolean
-                                fsType:
-                                  type: string
-                                initiatorName:
-                                  type: string
-                                iqn:
-                                  type: string
-                                iscsiInterface:
-                                  type: string
-                                lun:
-                                  format: int32
-                                  type: integer
-                                portals:
-                                  items:
-                                    type: string
-                                  type: array
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                targetPortal:
-                                  type: string
-                              required:
-                              - iqn
-                              - lun
-                              - targetPortal
-                              type: object
-                            name:
-                              type: string
-                            nfs:
-                              properties:
-                                path:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                server:
-                                  type: string
-                              required:
-                              - path
-                              - server
-                              type: object
-                            persistentVolumeClaim:
-                              properties:
-                                claimName:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - claimName
-                              type: object
-                            photonPersistentDisk:
-                              properties:
-                                fsType:
-                                  type: string
-                                pdID:
-                                  type: string
-                              required:
-                              - pdID
-                              type: object
-                            portworxVolume:
-                              properties:
-                                fsType:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                volumeID:
-                                  type: string
-                              required:
-                              - volumeID
-                              type: object
-                            projected:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                sources:
-                                  items:
-                                    properties:
-                                      configMap:
-                                        properties:
-                                          items:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                mode:
-                                                  format: int32
-                                                  type: integer
-                                                path:
-                                                  type: string
-                                              required:
-                                              - key
-                                              - path
-                                              type: object
-                                            type: array
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        type: object
-                                      downwardAPI:
-                                        properties:
-                                          items:
-                                            items:
-                                              properties:
-                                                fieldRef:
-                                                  properties:
-                                                    apiVersion:
-                                                      type: string
-                                                    fieldPath:
-                                                      type: string
-                                                  required:
-                                                  - fieldPath
-                                                  type: object
-                                                mode:
-                                                  format: int32
-                                                  type: integer
-                                                path:
-                                                  type: string
-                                                resourceFieldRef:
-                                                  properties:
-                                                    containerName:
-                                                      type: string
-                                                    divisor:
-                                                      type: string
-                                                    resource:
-                                                      type: string
-                                                  required:
-                                                  - resource
-                                                  type: object
-                                              required:
-                                              - path
-                                              type: object
-                                            type: array
-                                        type: object
-                                      secret:
-                                        properties:
-                                          items:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                mode:
-                                                  format: int32
-                                                  type: integer
-                                                path:
-                                                  type: string
-                                              required:
-                                              - key
-                                              - path
-                                              type: object
-                                            type: array
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        type: object
-                                      serviceAccountToken:
-                                        properties:
-                                          audience:
-                                            type: string
-                                          expirationSeconds:
-                                            format: int64
-                                            type: integer
-                                          path:
-                                            type: string
-                                        required:
-                                        - path
-                                        type: object
-                                    type: object
-                                  type: array
-                              required:
-                              - sources
-                              type: object
-                            quobyte:
-                              properties:
-                                group:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                registry:
-                                  type: string
-                                tenant:
-                                  type: string
-                                user:
-                                  type: string
-                                volume:
-                                  type: string
-                              required:
-                              - registry
-                              - volume
-                              type: object
-                            rbd:
-                              properties:
-                                fsType:
-                                  type: string
-                                image:
-                                  type: string
-                                keyring:
-                                  type: string
-                                monitors:
-                                  items:
-                                    type: string
-                                  type: array
-                                pool:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                user:
-                                  type: string
-                              required:
-                              - image
-                              - monitors
-                              type: object
-                            scaleIO:
-                              properties:
-                                fsType:
-                                  type: string
-                                gateway:
-                                  type: string
-                                protectionDomain:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                sslEnabled:
-                                  type: boolean
-                                storageMode:
-                                  type: string
-                                storagePool:
-                                  type: string
-                                system:
-                                  type: string
-                                volumeName:
-                                  type: string
-                              required:
-                              - gateway
-                              - secretRef
-                              - system
-                              type: object
-                            secret:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                items:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      mode:
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                optional:
-                                  type: boolean
-                                secretName:
-                                  type: string
-                              type: object
-                            storageos:
-                              properties:
-                                fsType:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                volumeName:
-                                  type: string
-                                volumeNamespace:
-                                  type: string
-                              type: object
-                            vsphereVolume:
-                              properties:
-                                fsType:
-                                  type: string
-                                storagePolicyID:
-                                  type: string
-                                storagePolicyName:
-                                  type: string
-                                volumePath:
-                                  type: string
-                              required:
-                              - volumePath
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                    type: object
-                  processingGuarantee:
-                    type: string
-                  pulsar:
-                    properties:
-                      authSecret:
-                        type: string
-                      pulsarConfig:
-                        type: string
-                      tlsSecret:
-                        type: string
-                    type: object
-                  python:
-                    properties:
-                      py:
-                        type: string
-                      pyLocation:
-                        type: string
-                    type: object
-                  replicas:
-                    format: int32
-                    type: integer
-                  resources:
-                    properties:
-                      limits:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      requests:
-                        additionalProperties:
-                          type: string
-                        type: object
-                    type: object
-                  retainOrdering:
-                    type: boolean
-                  runtimeFlags:
-                    type: string
-                  secretsMap:
-                    additionalProperties:
-                      properties:
-                        key:
-                          type: string
-                        path:
-                          type: string
-                      type: object
-                    type: object
-                  sinkConfig:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  sinkType:
-                    type: string
-                  subscriptionName:
-                    type: string
-                  subscriptionPosition:
-                    type: string
-                  tenant:
-                    type: string
-                  timeout:
-                    format: int32
-                    type: integer
-                  volumeMounts:
-                    items:
-                      properties:
-                        mountPath:
-                          type: string
-                        mountPropagation:
-                          type: string
-                        name:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        subPath:
-                          type: string
-                        subPathExpr:
-                          type: string
-                      required:
-                      - mountPath
-                      - name
-                      type: object
-                    type: array
-                type: object
-              type: array
-            sources:
-              items:
-                properties:
-                  className:
-                    type: string
-                  clusterName:
-                    type: string
-                  golang:
-                    properties:
-                      go:
-                        type: string
-                      goLocation:
-                        type: string
-                    type: object
-                  image:
-                    type: string
-                  imagePullPolicy:
-                    type: string
-                  java:
-                    properties:
-                      extraDependenciesDir:
-                        type: string
-                      jar:
-                        type: string
-                      jarLocation:
-                        type: string
-                    type: object
-                  logTopic:
-                    type: string
-                  maxReplicas:
-                    format: int32
-                    type: integer
-                  name:
-                    type: string
-                  output:
-                    properties:
-                      customSchemaSinks:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      producerConf:
-                        properties:
-                          batchBuilder:
-                            type: string
-                          cryptoConfig:
-                            properties:
-                              consumerCryptoFailureAction:
-                                type: string
-                              cryptoKeyReaderClassName:
-                                type: string
-                              cryptoKeyReaderConfig:
-                                additionalProperties:
-                                  type: string
-                                type: object
-                              cryptoSecrets:
-                                items:
-                                  properties:
-                                    asVolume:
-                                      type: string
-                                    secretKey:
-                                      type: string
-                                    secretName:
-                                      type: string
-                                  required:
-                                  - secretKey
-                                  - secretName
-                                  type: object
-                                type: array
-                              encryptionKeys:
-                                items:
-                                  type: string
-                                type: array
-                              producerCryptoFailureAction:
-                                type: string
-                            type: object
-                          maxPendingMessages:
-                            format: int32
-                            type: integer
-                          maxPendingMessagesAcrossPartitions:
-                            format: int32
-                            type: integer
-                          useThreadLocalProducers:
-                            type: boolean
-                        type: object
-                      sinkSchemaType:
-                        type: string
-                      sinkSerdeClassName:
-                        type: string
-                      topic:
-                        type: string
-                      typeClassName:
-                        type: string
-                    type: object
-                  pod:
-                    properties:
-                      affinity:
-                        properties:
-                          nodeAffinity:
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    preference:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchFields:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                      type: object
-                                    weight:
-                                      format: int32
-                                      type: integer
-                                  required:
-                                  - preference
-                                  - weight
-                                  type: object
-                                type: array
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                properties:
-                                  nodeSelectorTerms:
-                                    items:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchFields:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                      type: object
-                                    type: array
-                                required:
-                                - nodeSelectorTerms
-                                type: object
-                            type: object
-                          podAffinity:
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    podAffinityTerm:
-                                      properties:
-                                        labelSelector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        namespaces:
-                                          items:
-                                            type: string
-                                          type: array
-                                        topologyKey:
-                                          type: string
-                                      required:
-                                      - topologyKey
-                                      type: object
-                                    weight:
-                                      format: int32
-                                      type: integer
-                                  required:
-                                  - podAffinityTerm
-                                  - weight
-                                  type: object
-                                type: array
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                type: array
-                            type: object
-                          podAntiAffinity:
-                            properties:
-                              preferredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    podAffinityTerm:
-                                      properties:
-                                        labelSelector:
-                                          properties:
-                                            matchExpressions:
-                                              items:
-                                                properties:
-                                                  key:
-                                                    type: string
-                                                  operator:
-                                                    type: string
-                                                  values:
-                                                    items:
-                                                      type: string
-                                                    type: array
-                                                required:
-                                                - key
-                                                - operator
-                                                type: object
-                                              type: array
-                                            matchLabels:
-                                              additionalProperties:
-                                                type: string
-                                              type: object
-                                          type: object
-                                        namespaces:
-                                          items:
-                                            type: string
-                                          type: array
-                                        topologyKey:
-                                          type: string
-                                      required:
-                                      - topologyKey
-                                      type: object
-                                    weight:
-                                      format: int32
-                                      type: integer
-                                  required:
-                                  - podAffinityTerm
-                                  - weight
-                                  type: object
-                                type: array
-                              requiredDuringSchedulingIgnoredDuringExecution:
-                                items:
-                                  properties:
-                                    labelSelector:
-                                      properties:
-                                        matchExpressions:
-                                          items:
-                                            properties:
-                                              key:
-                                                type: string
-                                              operator:
-                                                type: string
-                                              values:
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                type: array
-                            type: object
-                        type: object
-                      annotations:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      imagePullSecrets:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                          type: object
-                        type: array
-                      initContainers:
-                        items:
-                          properties:
-                            args:
-                              items:
-                                type: string
-                              type: array
-                            command:
-                              items:
-                                type: string
-                              type: array
-                            env:
-                              items:
-                                properties:
-                                  name:
-                                    type: string
-                                  value:
-                                    type: string
-                                  valueFrom:
-                                    properties:
-                                      configMapKeyRef:
-                                        properties:
-                                          key:
-                                            type: string
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        required:
-                                        - key
-                                        type: object
-                                      fieldRef:
-                                        properties:
-                                          apiVersion:
-                                            type: string
-                                          fieldPath:
-                                            type: string
-                                        required:
-                                        - fieldPath
-                                        type: object
-                                      resourceFieldRef:
-                                        properties:
-                                          containerName:
-                                            type: string
-                                          divisor:
-                                            type: string
-                                          resource:
-                                            type: string
-                                        required:
-                                        - resource
-                                        type: object
-                                      secretKeyRef:
-                                        properties:
-                                          key:
-                                            type: string
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        required:
-                                        - key
-                                        type: object
-                                    type: object
-                                required:
-                                - name
-                                type: object
-                              type: array
-                            envFrom:
-                              items:
-                                properties:
-                                  configMapRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                  prefix:
-                                    type: string
-                                  secretRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                type: object
-                              type: array
-                            image:
-                              type: string
-                            imagePullPolicy:
-                              type: string
-                            lifecycle:
-                              properties:
-                                postStart:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                  type: object
-                                preStop:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                  type: object
-                              type: object
-                            livenessProbe:
-                              properties:
-                                exec:
-                                  properties:
-                                    command:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                failureThreshold:
-                                  format: int32
-                                  type: integer
-                                httpGet:
-                                  properties:
-                                    host:
-                                      type: string
-                                    httpHeaders:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      type: array
-                                    path:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                    scheme:
-                                      type: string
-                                  required:
-                                  - port
-                                  type: object
-                                initialDelaySeconds:
-                                  format: int32
-                                  type: integer
-                                periodSeconds:
-                                  format: int32
-                                  type: integer
-                                successThreshold:
-                                  format: int32
-                                  type: integer
-                                tcpSocket:
-                                  properties:
-                                    host:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                  required:
-                                  - port
-                                  type: object
-                                timeoutSeconds:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            name:
-                              type: string
-                            ports:
-                              items:
-                                properties:
-                                  containerPort:
-                                    format: int32
-                                    type: integer
-                                  hostIP:
-                                    type: string
-                                  hostPort:
-                                    format: int32
-                                    type: integer
-                                  name:
-                                    type: string
-                                  protocol:
-                                    type: string
-                                required:
-                                - containerPort
-                                type: object
-                              type: array
-                            readinessProbe:
-                              properties:
-                                exec:
-                                  properties:
-                                    command:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                failureThreshold:
-                                  format: int32
-                                  type: integer
-                                httpGet:
-                                  properties:
-                                    host:
-                                      type: string
-                                    httpHeaders:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      type: array
-                                    path:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                    scheme:
-                                      type: string
-                                  required:
-                                  - port
-                                  type: object
-                                initialDelaySeconds:
-                                  format: int32
-                                  type: integer
-                                periodSeconds:
-                                  format: int32
-                                  type: integer
-                                successThreshold:
-                                  format: int32
-                                  type: integer
-                                tcpSocket:
-                                  properties:
-                                    host:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                  required:
-                                  - port
-                                  type: object
-                                timeoutSeconds:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            resources:
-                              properties:
-                                limits:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                requests:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              type: object
-                            securityContext:
-                              properties:
-                                allowPrivilegeEscalation:
-                                  type: boolean
-                                capabilities:
-                                  properties:
-                                    add:
-                                      items:
-                                        type: string
-                                      type: array
-                                    drop:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                privileged:
-                                  type: boolean
-                                procMount:
-                                  type: string
-                                readOnlyRootFilesystem:
-                                  type: boolean
-                                runAsGroup:
-                                  format: int64
-                                  type: integer
-                                runAsNonRoot:
-                                  type: boolean
-                                runAsUser:
-                                  format: int64
-                                  type: integer
-                                seLinuxOptions:
-                                  properties:
-                                    level:
-                                      type: string
-                                    role:
-                                      type: string
-                                    type:
-                                      type: string
-                                    user:
-                                      type: string
-                                  type: object
-                                windowsOptions:
-                                  properties:
-                                    gmsaCredentialSpec:
-                                      type: string
-                                    gmsaCredentialSpecName:
-                                      type: string
-                                    runAsUserName:
-                                      type: string
-                                  type: object
-                              type: object
-                            startupProbe:
-                              properties:
-                                exec:
-                                  properties:
-                                    command:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                failureThreshold:
-                                  format: int32
-                                  type: integer
-                                httpGet:
-                                  properties:
-                                    host:
-                                      type: string
-                                    httpHeaders:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      type: array
-                                    path:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                    scheme:
-                                      type: string
-                                  required:
-                                  - port
-                                  type: object
-                                initialDelaySeconds:
-                                  format: int32
-                                  type: integer
-                                periodSeconds:
-                                  format: int32
-                                  type: integer
-                                successThreshold:
-                                  format: int32
-                                  type: integer
-                                tcpSocket:
-                                  properties:
-                                    host:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                  required:
-                                  - port
-                                  type: object
-                                timeoutSeconds:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            stdin:
-                              type: boolean
-                            stdinOnce:
-                              type: boolean
-                            terminationMessagePath:
-                              type: string
-                            terminationMessagePolicy:
-                              type: string
-                            tty:
-                              type: boolean
-                            volumeDevices:
-                              items:
-                                properties:
-                                  devicePath:
-                                    type: string
-                                  name:
-                                    type: string
-                                required:
-                                - devicePath
-                                - name
-                                type: object
-                              type: array
-                            volumeMounts:
-                              items:
-                                properties:
-                                  mountPath:
-                                    type: string
-                                  mountPropagation:
-                                    type: string
-                                  name:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                  subPath:
-                                    type: string
-                                  subPathExpr:
-                                    type: string
-                                required:
-                                - mountPath
-                                - name
-                                type: object
-                              type: array
-                            workingDir:
-                              type: string
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      labels:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      nodeSelector:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      securityContext:
-                        properties:
-                          fsGroup:
-                            format: int64
-                            type: integer
-                          fsGroupChangePolicy:
-                            type: string
-                          runAsGroup:
-                            format: int64
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            format: int64
-                            type: integer
-                          seLinuxOptions:
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                            type: object
-                          supplementalGroups:
-                            items:
-                              format: int64
-                              type: integer
-                            type: array
-                          sysctls:
-                            items:
-                              properties:
-                                name:
-                                  type: string
-                                value:
-                                  type: string
-                              required:
-                              - name
-                              - value
-                              type: object
-                            type: array
-                          windowsOptions:
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              runAsUserName:
-                                type: string
-                            type: object
-                        type: object
-                      sidecars:
-                        items:
-                          properties:
-                            args:
-                              items:
-                                type: string
-                              type: array
-                            command:
-                              items:
-                                type: string
-                              type: array
-                            env:
-                              items:
-                                properties:
-                                  name:
-                                    type: string
-                                  value:
-                                    type: string
-                                  valueFrom:
-                                    properties:
-                                      configMapKeyRef:
-                                        properties:
-                                          key:
-                                            type: string
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        required:
-                                        - key
-                                        type: object
-                                      fieldRef:
-                                        properties:
-                                          apiVersion:
-                                            type: string
-                                          fieldPath:
-                                            type: string
-                                        required:
-                                        - fieldPath
-                                        type: object
-                                      resourceFieldRef:
-                                        properties:
-                                          containerName:
-                                            type: string
-                                          divisor:
-                                            type: string
-                                          resource:
-                                            type: string
-                                        required:
-                                        - resource
-                                        type: object
-                                      secretKeyRef:
-                                        properties:
-                                          key:
-                                            type: string
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        required:
-                                        - key
-                                        type: object
-                                    type: object
-                                required:
-                                - name
-                                type: object
-                              type: array
-                            envFrom:
-                              items:
-                                properties:
-                                  configMapRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                  prefix:
-                                    type: string
-                                  secretRef:
-                                    properties:
-                                      name:
-                                        type: string
-                                      optional:
-                                        type: boolean
-                                    type: object
-                                type: object
-                              type: array
-                            image:
-                              type: string
-                            imagePullPolicy:
-                              type: string
-                            lifecycle:
-                              properties:
-                                postStart:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                  type: object
-                                preStop:
-                                  properties:
-                                    exec:
-                                      properties:
-                                        command:
-                                          items:
-                                            type: string
-                                          type: array
-                                      type: object
-                                    httpGet:
-                                      properties:
-                                        host:
-                                          type: string
-                                        httpHeaders:
-                                          items:
-                                            properties:
-                                              name:
-                                                type: string
-                                              value:
-                                                type: string
-                                            required:
-                                            - name
-                                            - value
-                                            type: object
-                                          type: array
-                                        path:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                        scheme:
-                                          type: string
-                                      required:
-                                      - port
-                                      type: object
-                                    tcpSocket:
-                                      properties:
-                                        host:
-                                          type: string
-                                        port:
-                                          anyOf:
-                                          - type: integer
-                                          - type: string
-                                          x-kubernetes-int-or-string: true
-                                      required:
-                                      - port
-                                      type: object
-                                  type: object
-                              type: object
-                            livenessProbe:
-                              properties:
-                                exec:
-                                  properties:
-                                    command:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                failureThreshold:
-                                  format: int32
-                                  type: integer
-                                httpGet:
-                                  properties:
-                                    host:
-                                      type: string
-                                    httpHeaders:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      type: array
-                                    path:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                    scheme:
-                                      type: string
-                                  required:
-                                  - port
-                                  type: object
-                                initialDelaySeconds:
-                                  format: int32
-                                  type: integer
-                                periodSeconds:
-                                  format: int32
-                                  type: integer
-                                successThreshold:
-                                  format: int32
-                                  type: integer
-                                tcpSocket:
-                                  properties:
-                                    host:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                  required:
-                                  - port
-                                  type: object
-                                timeoutSeconds:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            name:
-                              type: string
-                            ports:
-                              items:
-                                properties:
-                                  containerPort:
-                                    format: int32
-                                    type: integer
-                                  hostIP:
-                                    type: string
-                                  hostPort:
-                                    format: int32
-                                    type: integer
-                                  name:
-                                    type: string
-                                  protocol:
-                                    type: string
-                                required:
-                                - containerPort
-                                type: object
-                              type: array
-                            readinessProbe:
-                              properties:
-                                exec:
-                                  properties:
-                                    command:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                failureThreshold:
-                                  format: int32
-                                  type: integer
-                                httpGet:
-                                  properties:
-                                    host:
-                                      type: string
-                                    httpHeaders:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      type: array
-                                    path:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                    scheme:
-                                      type: string
-                                  required:
-                                  - port
-                                  type: object
-                                initialDelaySeconds:
-                                  format: int32
-                                  type: integer
-                                periodSeconds:
-                                  format: int32
-                                  type: integer
-                                successThreshold:
-                                  format: int32
-                                  type: integer
-                                tcpSocket:
-                                  properties:
-                                    host:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                  required:
-                                  - port
-                                  type: object
-                                timeoutSeconds:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            resources:
-                              properties:
-                                limits:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                requests:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              type: object
-                            securityContext:
-                              properties:
-                                allowPrivilegeEscalation:
-                                  type: boolean
-                                capabilities:
-                                  properties:
-                                    add:
-                                      items:
-                                        type: string
-                                      type: array
-                                    drop:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                privileged:
-                                  type: boolean
-                                procMount:
-                                  type: string
-                                readOnlyRootFilesystem:
-                                  type: boolean
-                                runAsGroup:
-                                  format: int64
-                                  type: integer
-                                runAsNonRoot:
-                                  type: boolean
-                                runAsUser:
-                                  format: int64
-                                  type: integer
-                                seLinuxOptions:
-                                  properties:
-                                    level:
-                                      type: string
-                                    role:
-                                      type: string
-                                    type:
-                                      type: string
-                                    user:
-                                      type: string
-                                  type: object
-                                windowsOptions:
-                                  properties:
-                                    gmsaCredentialSpec:
-                                      type: string
-                                    gmsaCredentialSpecName:
-                                      type: string
-                                    runAsUserName:
-                                      type: string
-                                  type: object
-                              type: object
-                            startupProbe:
-                              properties:
-                                exec:
-                                  properties:
-                                    command:
-                                      items:
-                                        type: string
-                                      type: array
-                                  type: object
-                                failureThreshold:
-                                  format: int32
-                                  type: integer
-                                httpGet:
-                                  properties:
-                                    host:
-                                      type: string
-                                    httpHeaders:
-                                      items:
-                                        properties:
-                                          name:
-                                            type: string
-                                          value:
-                                            type: string
-                                        required:
-                                        - name
-                                        - value
-                                        type: object
-                                      type: array
-                                    path:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                    scheme:
-                                      type: string
-                                  required:
-                                  - port
-                                  type: object
-                                initialDelaySeconds:
-                                  format: int32
-                                  type: integer
-                                periodSeconds:
-                                  format: int32
-                                  type: integer
-                                successThreshold:
-                                  format: int32
-                                  type: integer
-                                tcpSocket:
-                                  properties:
-                                    host:
-                                      type: string
-                                    port:
-                                      anyOf:
-                                      - type: integer
-                                      - type: string
-                                      x-kubernetes-int-or-string: true
-                                  required:
-                                  - port
-                                  type: object
-                                timeoutSeconds:
-                                  format: int32
-                                  type: integer
-                              type: object
-                            stdin:
-                              type: boolean
-                            stdinOnce:
-                              type: boolean
-                            terminationMessagePath:
-                              type: string
-                            terminationMessagePolicy:
-                              type: string
-                            tty:
-                              type: boolean
-                            volumeDevices:
-                              items:
-                                properties:
-                                  devicePath:
-                                    type: string
-                                  name:
-                                    type: string
-                                required:
-                                - devicePath
-                                - name
-                                type: object
-                              type: array
-                            volumeMounts:
-                              items:
-                                properties:
-                                  mountPath:
-                                    type: string
-                                  mountPropagation:
-                                    type: string
-                                  name:
-                                    type: string
-                                  readOnly:
-                                    type: boolean
-                                  subPath:
-                                    type: string
-                                  subPathExpr:
-                                    type: string
-                                required:
-                                - mountPath
-                                - name
-                                type: object
-                              type: array
-                            workingDir:
-                              type: string
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      terminationGracePeriodSeconds:
-                        format: int64
-                        type: integer
-                      tolerations:
-                        items:
-                          properties:
-                            effect:
-                              type: string
-                            key:
-                              type: string
-                            operator:
-                              type: string
-                            tolerationSeconds:
-                              format: int64
-                              type: integer
-                            value:
-                              type: string
-                          type: object
-                        type: array
-                      volumes:
-                        items:
-                          properties:
-                            awsElasticBlockStore:
-                              properties:
-                                fsType:
-                                  type: string
-                                partition:
-                                  format: int32
-                                  type: integer
-                                readOnly:
-                                  type: boolean
-                                volumeID:
-                                  type: string
-                              required:
-                              - volumeID
-                              type: object
-                            azureDisk:
-                              properties:
-                                cachingMode:
-                                  type: string
-                                diskName:
-                                  type: string
-                                diskURI:
-                                  type: string
-                                fsType:
-                                  type: string
-                                kind:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - diskName
-                              - diskURI
-                              type: object
-                            azureFile:
-                              properties:
-                                readOnly:
-                                  type: boolean
-                                secretName:
-                                  type: string
-                                shareName:
-                                  type: string
-                              required:
-                              - secretName
-                              - shareName
-                              type: object
-                            cephfs:
-                              properties:
-                                monitors:
-                                  items:
-                                    type: string
-                                  type: array
-                                path:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretFile:
-                                  type: string
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                user:
-                                  type: string
-                              required:
-                              - monitors
-                              type: object
-                            cinder:
-                              properties:
-                                fsType:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                volumeID:
-                                  type: string
-                              required:
-                              - volumeID
-                              type: object
-                            configMap:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                items:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      mode:
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              type: object
-                            csi:
-                              properties:
-                                driver:
-                                  type: string
-                                fsType:
-                                  type: string
-                                nodePublishSecretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                readOnly:
-                                  type: boolean
-                                volumeAttributes:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                              required:
-                              - driver
-                              type: object
-                            downwardAPI:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                items:
-                                  items:
-                                    properties:
-                                      fieldRef:
-                                        properties:
-                                          apiVersion:
-                                            type: string
-                                          fieldPath:
-                                            type: string
-                                        required:
-                                        - fieldPath
-                                        type: object
-                                      mode:
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        type: string
-                                      resourceFieldRef:
-                                        properties:
-                                          containerName:
-                                            type: string
-                                          divisor:
-                                            type: string
-                                          resource:
-                                            type: string
-                                        required:
-                                        - resource
-                                        type: object
-                                    required:
-                                    - path
-                                    type: object
-                                  type: array
-                              type: object
-                            emptyDir:
-                              properties:
-                                medium:
-                                  type: string
-                                sizeLimit:
-                                  type: string
-                              type: object
-                            fc:
-                              properties:
-                                fsType:
-                                  type: string
-                                lun:
-                                  format: int32
-                                  type: integer
-                                readOnly:
-                                  type: boolean
-                                targetWWNs:
-                                  items:
-                                    type: string
-                                  type: array
-                                wwids:
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            flexVolume:
-                              properties:
-                                driver:
-                                  type: string
-                                fsType:
-                                  type: string
-                                options:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                              required:
-                              - driver
-                              type: object
-                            flocker:
-                              properties:
-                                datasetName:
-                                  type: string
-                                datasetUUID:
-                                  type: string
-                              type: object
-                            gcePersistentDisk:
-                              properties:
-                                fsType:
-                                  type: string
-                                partition:
-                                  format: int32
-                                  type: integer
-                                pdName:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - pdName
-                              type: object
-                            gitRepo:
-                              properties:
-                                directory:
-                                  type: string
-                                repository:
-                                  type: string
-                                revision:
-                                  type: string
-                              required:
-                              - repository
-                              type: object
-                            glusterfs:
-                              properties:
-                                endpoints:
-                                  type: string
-                                path:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - endpoints
-                              - path
-                              type: object
-                            hostPath:
-                              properties:
-                                path:
-                                  type: string
-                                type:
-                                  type: string
-                              required:
-                              - path
-                              type: object
-                            iscsi:
-                              properties:
-                                chapAuthDiscovery:
-                                  type: boolean
-                                chapAuthSession:
-                                  type: boolean
-                                fsType:
-                                  type: string
-                                initiatorName:
-                                  type: string
-                                iqn:
-                                  type: string
-                                iscsiInterface:
-                                  type: string
-                                lun:
-                                  format: int32
-                                  type: integer
-                                portals:
-                                  items:
-                                    type: string
-                                  type: array
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                targetPortal:
-                                  type: string
-                              required:
-                              - iqn
-                              - lun
-                              - targetPortal
-                              type: object
-                            name:
-                              type: string
-                            nfs:
-                              properties:
-                                path:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                server:
-                                  type: string
-                              required:
-                              - path
-                              - server
-                              type: object
-                            persistentVolumeClaim:
-                              properties:
-                                claimName:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                              required:
-                              - claimName
-                              type: object
-                            photonPersistentDisk:
-                              properties:
-                                fsType:
-                                  type: string
-                                pdID:
-                                  type: string
-                              required:
-                              - pdID
-                              type: object
-                            portworxVolume:
-                              properties:
-                                fsType:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                volumeID:
-                                  type: string
-                              required:
-                              - volumeID
-                              type: object
-                            projected:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                sources:
-                                  items:
-                                    properties:
-                                      configMap:
-                                        properties:
-                                          items:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                mode:
-                                                  format: int32
-                                                  type: integer
-                                                path:
-                                                  type: string
-                                              required:
-                                              - key
-                                              - path
-                                              type: object
-                                            type: array
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        type: object
-                                      downwardAPI:
-                                        properties:
-                                          items:
-                                            items:
-                                              properties:
-                                                fieldRef:
-                                                  properties:
-                                                    apiVersion:
-                                                      type: string
-                                                    fieldPath:
-                                                      type: string
-                                                  required:
-                                                  - fieldPath
-                                                  type: object
-                                                mode:
-                                                  format: int32
-                                                  type: integer
-                                                path:
-                                                  type: string
-                                                resourceFieldRef:
-                                                  properties:
-                                                    containerName:
-                                                      type: string
-                                                    divisor:
-                                                      type: string
-                                                    resource:
-                                                      type: string
-                                                  required:
-                                                  - resource
-                                                  type: object
-                                              required:
-                                              - path
-                                              type: object
-                                            type: array
-                                        type: object
-                                      secret:
-                                        properties:
-                                          items:
-                                            items:
-                                              properties:
-                                                key:
-                                                  type: string
-                                                mode:
-                                                  format: int32
-                                                  type: integer
-                                                path:
-                                                  type: string
-                                              required:
-                                              - key
-                                              - path
-                                              type: object
-                                            type: array
-                                          name:
-                                            type: string
-                                          optional:
-                                            type: boolean
-                                        type: object
-                                      serviceAccountToken:
-                                        properties:
-                                          audience:
-                                            type: string
-                                          expirationSeconds:
-                                            format: int64
-                                            type: integer
-                                          path:
-                                            type: string
-                                        required:
-                                        - path
-                                        type: object
-                                    type: object
-                                  type: array
-                              required:
-                              - sources
-                              type: object
-                            quobyte:
-                              properties:
-                                group:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                registry:
-                                  type: string
-                                tenant:
-                                  type: string
-                                user:
-                                  type: string
-                                volume:
-                                  type: string
-                              required:
-                              - registry
-                              - volume
-                              type: object
-                            rbd:
-                              properties:
-                                fsType:
-                                  type: string
-                                image:
-                                  type: string
-                                keyring:
-                                  type: string
-                                monitors:
-                                  items:
-                                    type: string
-                                  type: array
-                                pool:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                user:
-                                  type: string
-                              required:
-                              - image
-                              - monitors
-                              type: object
-                            scaleIO:
-                              properties:
-                                fsType:
-                                  type: string
-                                gateway:
-                                  type: string
-                                protectionDomain:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                sslEnabled:
-                                  type: boolean
-                                storageMode:
-                                  type: string
-                                storagePool:
-                                  type: string
-                                system:
-                                  type: string
-                                volumeName:
-                                  type: string
-                              required:
-                              - gateway
-                              - secretRef
-                              - system
-                              type: object
-                            secret:
-                              properties:
-                                defaultMode:
-                                  format: int32
-                                  type: integer
-                                items:
-                                  items:
-                                    properties:
-                                      key:
-                                        type: string
-                                      mode:
-                                        format: int32
-                                        type: integer
-                                      path:
-                                        type: string
-                                    required:
-                                    - key
-                                    - path
-                                    type: object
-                                  type: array
-                                optional:
-                                  type: boolean
-                                secretName:
-                                  type: string
-                              type: object
-                            storageos:
-                              properties:
-                                fsType:
-                                  type: string
-                                readOnly:
-                                  type: boolean
-                                secretRef:
-                                  properties:
-                                    name:
-                                      type: string
-                                  type: object
-                                volumeName:
-                                  type: string
-                                volumeNamespace:
-                                  type: string
-                              type: object
-                            vsphereVolume:
-                              properties:
-                                fsType:
-                                  type: string
-                                storagePolicyID:
-                                  type: string
-                                storagePolicyName:
-                                  type: string
-                                volumePath:
-                                  type: string
-                              required:
-                              - volumePath
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                    type: object
-                  processingGuarantee:
-                    type: string
-                  pulsar:
-                    properties:
-                      authSecret:
-                        type: string
-                      pulsarConfig:
-                        type: string
-                      tlsSecret:
-                        type: string
-                    type: object
-                  python:
-                    properties:
-                      py:
-                        type: string
-                      pyLocation:
-                        type: string
-                    type: object
-                  replicas:
-                    format: int32
-                    type: integer
-                  resources:
-                    properties:
-                      limits:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      requests:
-                        additionalProperties:
-                          type: string
-                        type: object
-                    type: object
-                  runtimeFlags:
-                    type: string
-                  secretsMap:
-                    additionalProperties:
-                      properties:
-                        key:
-                          type: string
-                        path:
-                          type: string
-                      type: object
-                    type: object
-                  sourceConfig:
-                    additionalProperties:
-                      type: string
-                    type: object
-                  sourceType:
-                    type: string
-                  tenant:
-                    type: string
-                  volumeMounts:
-                    items:
-                      properties:
-                        mountPath:
-                          type: string
-                        mountPropagation:
-                          type: string
-                        name:
-                          type: string
-                        readOnly:
-                          type: boolean
-                        subPath:
-                          type: string
-                        subPathExpr:
-                          type: string
-                      required:
-                      - mountPath
-                      - name
-                      type: object
-                    type: array
-                type: object
-              type: array
-          type: object
-        status:
-          properties:
-            functionConditions:
-              additionalProperties:
-                properties:
-                  action:
-                    type: string
-                  condition:
-                    type: string
-                  status:
-                    type: string
-                type: object
-              type: object
-            sinkConditions:
-              additionalProperties:
-                properties:
-                  action:
-                    type: string
-                  condition:
-                    type: string
-                  status:
-                    type: string
-                type: object
-              type: object
-            sourceConditions:
-              additionalProperties:
-                properties:
-                  action:
-                    type: string
-                  condition:
-                    type: string
-                  status:
-                    type: string
-                type: object
-              type: object
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              functions:
+                items:
+                  properties:
+                    autoAck:
+                      type: boolean
+                    className:
+                      type: string
+                    cleanupSubscription:
+                      type: boolean
+                    clusterName:
+                      type: string
+                    deadLetterTopic:
+                      type: string
+                    forwardSourceMessageProperty:
+                      type: boolean
+                    funcConfig:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    golang:
+                      properties:
+                        go:
+                          type: string
+                        goLocation:
+                          type: string
+                      type: object
+                    image:
+                      type: string
+                    imagePullPolicy:
+                      type: string
+                    input:
+                      properties:
+                        customSchemaSources:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        customSerdeSources:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        sourceSpecs:
+                          additionalProperties:
+                            properties:
+                              consumerProperties:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              cryptoConfig:
+                                properties:
+                                  consumerCryptoFailureAction:
+                                    type: string
+                                  cryptoKeyReaderClassName:
+                                    type: string
+                                  cryptoKeyReaderConfig:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  cryptoSecrets:
+                                    items:
+                                      properties:
+                                        asVolume:
+                                          type: string
+                                        secretKey:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                      - secretKey
+                                      - secretName
+                                      type: object
+                                    type: array
+                                  encryptionKeys:
+                                    items:
+                                      type: string
+                                    type: array
+                                  producerCryptoFailureAction:
+                                    type: string
+                                type: object
+                              isRegexPattern:
+                                type: boolean
+                              receiverQueueSize:
+                                format: int32
+                                type: integer
+                              schemaProperties:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              schemaType:
+                                type: string
+                              serdeClassname:
+                                type: string
+                            type: object
+                          type: object
+                        topicPattern:
+                          type: string
+                        topics:
+                          items:
+                            type: string
+                          type: array
+                        typeClassName:
+                          type: string
+                      type: object
+                    java:
+                      properties:
+                        extraDependenciesDir:
+                          type: string
+                        jar:
+                          type: string
+                        jarLocation:
+                          type: string
+                      type: object
+                    logTopic:
+                      type: string
+                    maxMessageRetry:
+                      format: int32
+                      type: integer
+                    maxPendingAsyncRequests:
+                      format: int32
+                      type: integer
+                    maxReplicas:
+                      format: int32
+                      type: integer
+                    name:
+                      type: string
+                    output:
+                      properties:
+                        customSchemaSinks:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        producerConf:
+                          properties:
+                            batchBuilder:
+                              type: string
+                            cryptoConfig:
+                              properties:
+                                consumerCryptoFailureAction:
+                                  type: string
+                                cryptoKeyReaderClassName:
+                                  type: string
+                                cryptoKeyReaderConfig:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                cryptoSecrets:
+                                  items:
+                                    properties:
+                                      asVolume:
+                                        type: string
+                                      secretKey:
+                                        type: string
+                                      secretName:
+                                        type: string
+                                    required:
+                                    - secretKey
+                                    - secretName
+                                    type: object
+                                  type: array
+                                encryptionKeys:
+                                  items:
+                                    type: string
+                                  type: array
+                                producerCryptoFailureAction:
+                                  type: string
+                              type: object
+                            maxPendingMessages:
+                              format: int32
+                              type: integer
+                            maxPendingMessagesAcrossPartitions:
+                              format: int32
+                              type: integer
+                            useThreadLocalProducers:
+                              type: boolean
+                          type: object
+                        sinkSchemaType:
+                          type: string
+                        sinkSerdeClassName:
+                          type: string
+                        topic:
+                          type: string
+                        typeClassName:
+                          type: string
+                      type: object
+                    pod:
+                      properties:
+                        affinity:
+                          properties:
+                            nodeAffinity:
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  items:
+                                    properties:
+                                      preference:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchFields:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                        type: object
+                                      weight:
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - preference
+                                    - weight
+                                    type: object
+                                  type: array
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  properties:
+                                    nodeSelectorTerms:
+                                      items:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchFields:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                        type: object
+                                      type: array
+                                  required:
+                                  - nodeSelectorTerms
+                                  type: object
+                              type: object
+                            podAffinity:
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  items:
+                                    properties:
+                                      podAffinityTerm:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      weight:
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - podAffinityTerm
+                                    - weight
+                                    type: object
+                                  type: array
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  items:
+                                    properties:
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  type: array
+                              type: object
+                            podAntiAffinity:
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  items:
+                                    properties:
+                                      podAffinityTerm:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      weight:
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - podAffinityTerm
+                                    - weight
+                                    type: object
+                                  type: array
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  items:
+                                    properties:
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  type: array
+                              type: object
+                          type: object
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        imagePullSecrets:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          type: array
+                        initContainers:
+                          items:
+                            properties:
+                              args:
+                                items:
+                                  type: string
+                                type: array
+                              command:
+                                items:
+                                  type: string
+                                type: array
+                              env:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                    valueFrom:
+                                      properties:
+                                        configMapKeyRef:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        fieldRef:
+                                          properties:
+                                            apiVersion:
+                                              type: string
+                                            fieldPath:
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                        resourceFieldRef:
+                                          properties:
+                                            containerName:
+                                              type: string
+                                            divisor:
+                                              type: string
+                                            resource:
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                        secretKeyRef:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              envFrom:
+                                items:
+                                  properties:
+                                    configMapRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                    prefix:
+                                      type: string
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                  type: object
+                                type: array
+                              image:
+                                type: string
+                              imagePullPolicy:
+                                type: string
+                              lifecycle:
+                                properties:
+                                  postStart:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                    type: object
+                                  preStop:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                    type: object
+                                type: object
+                              livenessProbe:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  failureThreshold:
+                                    format: int32
+                                    type: integer
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  timeoutSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              name:
+                                type: string
+                              ports:
+                                items:
+                                  properties:
+                                    containerPort:
+                                      format: int32
+                                      type: integer
+                                    hostIP:
+                                      type: string
+                                    hostPort:
+                                      format: int32
+                                      type: integer
+                                    name:
+                                      type: string
+                                    protocol:
+                                      type: string
+                                  required:
+                                  - containerPort
+                                  type: object
+                                type: array
+                              readinessProbe:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  failureThreshold:
+                                    format: int32
+                                    type: integer
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  timeoutSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              resources:
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              securityContext:
+                                properties:
+                                  allowPrivilegeEscalation:
+                                    type: boolean
+                                  capabilities:
+                                    properties:
+                                      add:
+                                        items:
+                                          type: string
+                                        type: array
+                                      drop:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  privileged:
+                                    type: boolean
+                                  procMount:
+                                    type: string
+                                  readOnlyRootFilesystem:
+                                    type: boolean
+                                  runAsGroup:
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    type: boolean
+                                  runAsUser:
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    properties:
+                                      level:
+                                        type: string
+                                      role:
+                                        type: string
+                                      type:
+                                        type: string
+                                      user:
+                                        type: string
+                                    type: object
+                                  windowsOptions:
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        type: string
+                                      runAsUserName:
+                                        type: string
+                                    type: object
+                                type: object
+                              startupProbe:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  failureThreshold:
+                                    format: int32
+                                    type: integer
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  timeoutSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              stdin:
+                                type: boolean
+                              stdinOnce:
+                                type: boolean
+                              terminationMessagePath:
+                                type: string
+                              terminationMessagePolicy:
+                                type: string
+                              tty:
+                                type: boolean
+                              volumeDevices:
+                                items:
+                                  properties:
+                                    devicePath:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - devicePath
+                                  - name
+                                  type: object
+                                type: array
+                              volumeMounts:
+                                items:
+                                  properties:
+                                    mountPath:
+                                      type: string
+                                    mountPropagation:
+                                      type: string
+                                    name:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    subPath:
+                                      type: string
+                                    subPathExpr:
+                                      type: string
+                                  required:
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                              workingDir:
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        securityContext:
+                          properties:
+                            fsGroup:
+                              format: int64
+                              type: integer
+                            fsGroupChangePolicy:
+                              type: string
+                            runAsGroup:
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                              type: object
+                            supplementalGroups:
+                              items:
+                                format: int64
+                                type: integer
+                              type: array
+                            sysctls:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            windowsOptions:
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
+                                  type: string
+                              type: object
+                          type: object
+                        sidecars:
+                          items:
+                            properties:
+                              args:
+                                items:
+                                  type: string
+                                type: array
+                              command:
+                                items:
+                                  type: string
+                                type: array
+                              env:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                    valueFrom:
+                                      properties:
+                                        configMapKeyRef:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        fieldRef:
+                                          properties:
+                                            apiVersion:
+                                              type: string
+                                            fieldPath:
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                        resourceFieldRef:
+                                          properties:
+                                            containerName:
+                                              type: string
+                                            divisor:
+                                              type: string
+                                            resource:
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                        secretKeyRef:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              envFrom:
+                                items:
+                                  properties:
+                                    configMapRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                    prefix:
+                                      type: string
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                  type: object
+                                type: array
+                              image:
+                                type: string
+                              imagePullPolicy:
+                                type: string
+                              lifecycle:
+                                properties:
+                                  postStart:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                    type: object
+                                  preStop:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                    type: object
+                                type: object
+                              livenessProbe:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  failureThreshold:
+                                    format: int32
+                                    type: integer
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  timeoutSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              name:
+                                type: string
+                              ports:
+                                items:
+                                  properties:
+                                    containerPort:
+                                      format: int32
+                                      type: integer
+                                    hostIP:
+                                      type: string
+                                    hostPort:
+                                      format: int32
+                                      type: integer
+                                    name:
+                                      type: string
+                                    protocol:
+                                      type: string
+                                  required:
+                                  - containerPort
+                                  type: object
+                                type: array
+                              readinessProbe:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  failureThreshold:
+                                    format: int32
+                                    type: integer
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  timeoutSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              resources:
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              securityContext:
+                                properties:
+                                  allowPrivilegeEscalation:
+                                    type: boolean
+                                  capabilities:
+                                    properties:
+                                      add:
+                                        items:
+                                          type: string
+                                        type: array
+                                      drop:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  privileged:
+                                    type: boolean
+                                  procMount:
+                                    type: string
+                                  readOnlyRootFilesystem:
+                                    type: boolean
+                                  runAsGroup:
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    type: boolean
+                                  runAsUser:
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    properties:
+                                      level:
+                                        type: string
+                                      role:
+                                        type: string
+                                      type:
+                                        type: string
+                                      user:
+                                        type: string
+                                    type: object
+                                  windowsOptions:
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        type: string
+                                      runAsUserName:
+                                        type: string
+                                    type: object
+                                type: object
+                              startupProbe:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  failureThreshold:
+                                    format: int32
+                                    type: integer
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  timeoutSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              stdin:
+                                type: boolean
+                              stdinOnce:
+                                type: boolean
+                              terminationMessagePath:
+                                type: string
+                              terminationMessagePolicy:
+                                type: string
+                              tty:
+                                type: boolean
+                              volumeDevices:
+                                items:
+                                  properties:
+                                    devicePath:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - devicePath
+                                  - name
+                                  type: object
+                                type: array
+                              volumeMounts:
+                                items:
+                                  properties:
+                                    mountPath:
+                                      type: string
+                                    mountPropagation:
+                                      type: string
+                                    name:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    subPath:
+                                      type: string
+                                    subPathExpr:
+                                      type: string
+                                  required:
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                              workingDir:
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        terminationGracePeriodSeconds:
+                          format: int64
+                          type: integer
+                        tolerations:
+                          items:
+                            properties:
+                              effect:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              tolerationSeconds:
+                                format: int64
+                                type: integer
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                        volumes:
+                          items:
+                            properties:
+                              awsElasticBlockStore:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  partition:
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    type: boolean
+                                  volumeID:
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              azureDisk:
+                                properties:
+                                  cachingMode:
+                                    type: string
+                                  diskName:
+                                    type: string
+                                  diskURI:
+                                    type: string
+                                  fsType:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                - diskName
+                                - diskURI
+                                type: object
+                              azureFile:
+                                properties:
+                                  readOnly:
+                                    type: boolean
+                                  secretName:
+                                    type: string
+                                  shareName:
+                                    type: string
+                                required:
+                                - secretName
+                                - shareName
+                                type: object
+                              cephfs:
+                                properties:
+                                  monitors:
+                                    items:
+                                      type: string
+                                    type: array
+                                  path:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretFile:
+                                    type: string
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  user:
+                                    type: string
+                                required:
+                                - monitors
+                                type: object
+                              cinder:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  volumeID:
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              configMap:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                type: object
+                              csi:
+                                properties:
+                                  driver:
+                                    type: string
+                                  fsType:
+                                    type: string
+                                  nodePublishSecretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  readOnly:
+                                    type: boolean
+                                  volumeAttributes:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                required:
+                                - driver
+                                type: object
+                              downwardAPI:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    items:
+                                      properties:
+                                        fieldRef:
+                                          properties:
+                                            apiVersion:
+                                              type: string
+                                            fieldPath:
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                        resourceFieldRef:
+                                          properties:
+                                            containerName:
+                                              type: string
+                                            divisor:
+                                              type: string
+                                            resource:
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                type: object
+                              emptyDir:
+                                properties:
+                                  medium:
+                                    type: string
+                                  sizeLimit:
+                                    type: string
+                                type: object
+                              fc:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  lun:
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    type: boolean
+                                  targetWWNs:
+                                    items:
+                                      type: string
+                                    type: array
+                                  wwids:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              flexVolume:
+                                properties:
+                                  driver:
+                                    type: string
+                                  fsType:
+                                    type: string
+                                  options:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                required:
+                                - driver
+                                type: object
+                              flocker:
+                                properties:
+                                  datasetName:
+                                    type: string
+                                  datasetUUID:
+                                    type: string
+                                type: object
+                              gcePersistentDisk:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  partition:
+                                    format: int32
+                                    type: integer
+                                  pdName:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                - pdName
+                                type: object
+                              gitRepo:
+                                properties:
+                                  directory:
+                                    type: string
+                                  repository:
+                                    type: string
+                                  revision:
+                                    type: string
+                                required:
+                                - repository
+                                type: object
+                              glusterfs:
+                                properties:
+                                  endpoints:
+                                    type: string
+                                  path:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                - endpoints
+                                - path
+                                type: object
+                              hostPath:
+                                properties:
+                                  path:
+                                    type: string
+                                  type:
+                                    type: string
+                                required:
+                                - path
+                                type: object
+                              iscsi:
+                                properties:
+                                  chapAuthDiscovery:
+                                    type: boolean
+                                  chapAuthSession:
+                                    type: boolean
+                                  fsType:
+                                    type: string
+                                  initiatorName:
+                                    type: string
+                                  iqn:
+                                    type: string
+                                  iscsiInterface:
+                                    type: string
+                                  lun:
+                                    format: int32
+                                    type: integer
+                                  portals:
+                                    items:
+                                      type: string
+                                    type: array
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  targetPortal:
+                                    type: string
+                                required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                                type: object
+                              name:
+                                type: string
+                              nfs:
+                                properties:
+                                  path:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  server:
+                                    type: string
+                                required:
+                                - path
+                                - server
+                                type: object
+                              persistentVolumeClaim:
+                                properties:
+                                  claimName:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                - claimName
+                                type: object
+                              photonPersistentDisk:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  pdID:
+                                    type: string
+                                required:
+                                - pdID
+                                type: object
+                              portworxVolume:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  volumeID:
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              projected:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  sources:
+                                    items:
+                                      properties:
+                                        configMap:
+                                          properties:
+                                            items:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        downwardAPI:
+                                          properties:
+                                            items:
+                                              items:
+                                                properties:
+                                                  fieldRef:
+                                                    properties:
+                                                      apiVersion:
+                                                        type: string
+                                                      fieldPath:
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                  resourceFieldRef:
+                                                    properties:
+                                                      containerName:
+                                                        type: string
+                                                      divisor:
+                                                        type: string
+                                                      resource:
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                required:
+                                                - path
+                                                type: object
+                                              type: array
+                                          type: object
+                                        secret:
+                                          properties:
+                                            items:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        serviceAccountToken:
+                                          properties:
+                                            audience:
+                                              type: string
+                                            expirationSeconds:
+                                              format: int64
+                                              type: integer
+                                            path:
+                                              type: string
+                                          required:
+                                          - path
+                                          type: object
+                                      type: object
+                                    type: array
+                                required:
+                                - sources
+                                type: object
+                              quobyte:
+                                properties:
+                                  group:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  registry:
+                                    type: string
+                                  tenant:
+                                    type: string
+                                  user:
+                                    type: string
+                                  volume:
+                                    type: string
+                                required:
+                                - registry
+                                - volume
+                                type: object
+                              rbd:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  image:
+                                    type: string
+                                  keyring:
+                                    type: string
+                                  monitors:
+                                    items:
+                                      type: string
+                                    type: array
+                                  pool:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  user:
+                                    type: string
+                                required:
+                                - image
+                                - monitors
+                                type: object
+                              scaleIO:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  gateway:
+                                    type: string
+                                  protectionDomain:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  sslEnabled:
+                                    type: boolean
+                                  storageMode:
+                                    type: string
+                                  storagePool:
+                                    type: string
+                                  system:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                - gateway
+                                - secretRef
+                                - system
+                                type: object
+                              secret:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  optional:
+                                    type: boolean
+                                  secretName:
+                                    type: string
+                                type: object
+                              storageos:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  volumeName:
+                                    type: string
+                                  volumeNamespace:
+                                    type: string
+                                type: object
+                              vsphereVolume:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  storagePolicyID:
+                                    type: string
+                                  storagePolicyName:
+                                    type: string
+                                  volumePath:
+                                    type: string
+                                required:
+                                - volumePath
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                      type: object
+                    processingGuarantee:
+                      type: string
+                    pulsar:
+                      properties:
+                        authSecret:
+                          type: string
+                        pulsarConfig:
+                          type: string
+                        tlsSecret:
+                          type: string
+                      type: object
+                    python:
+                      properties:
+                        py:
+                          type: string
+                        pyLocation:
+                          type: string
+                      type: object
+                    replicas:
+                      format: int32
+                      type: integer
+                    resources:
+                      properties:
+                        limits:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        requests:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    retainKeyOrdering:
+                      type: boolean
+                    retainOrdering:
+                      type: boolean
+                    runtimeFlags:
+                      type: string
+                    secretsMap:
+                      additionalProperties:
+                        properties:
+                          key:
+                            type: string
+                          path:
+                            type: string
+                        type: object
+                      type: object
+                    subscriptionName:
+                      type: string
+                    subscriptionPosition:
+                      type: string
+                    tenant:
+                      type: string
+                    timeout:
+                      format: int32
+                      type: integer
+                    volumeMounts:
+                      items:
+                        properties:
+                          mountPath:
+                            type: string
+                          mountPropagation:
+                            type: string
+                          name:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          subPath:
+                            type: string
+                          subPathExpr:
+                            type: string
+                        required:
+                        - mountPath
+                        - name
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              sinks:
+                items:
+                  properties:
+                    autoAck:
+                      type: boolean
+                    className:
+                      type: string
+                    cleanupSubscription:
+                      type: boolean
+                    clusterName:
+                      type: string
+                    deadLetterTopic:
+                      type: string
+                    golang:
+                      properties:
+                        go:
+                          type: string
+                        goLocation:
+                          type: string
+                      type: object
+                    image:
+                      type: string
+                    imagePullPolicy:
+                      type: string
+                    input:
+                      properties:
+                        customSchemaSources:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        customSerdeSources:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        sourceSpecs:
+                          additionalProperties:
+                            properties:
+                              consumerProperties:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              cryptoConfig:
+                                properties:
+                                  consumerCryptoFailureAction:
+                                    type: string
+                                  cryptoKeyReaderClassName:
+                                    type: string
+                                  cryptoKeyReaderConfig:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  cryptoSecrets:
+                                    items:
+                                      properties:
+                                        asVolume:
+                                          type: string
+                                        secretKey:
+                                          type: string
+                                        secretName:
+                                          type: string
+                                      required:
+                                      - secretKey
+                                      - secretName
+                                      type: object
+                                    type: array
+                                  encryptionKeys:
+                                    items:
+                                      type: string
+                                    type: array
+                                  producerCryptoFailureAction:
+                                    type: string
+                                type: object
+                              isRegexPattern:
+                                type: boolean
+                              receiverQueueSize:
+                                format: int32
+                                type: integer
+                              schemaProperties:
+                                additionalProperties:
+                                  type: string
+                                type: object
+                              schemaType:
+                                type: string
+                              serdeClassname:
+                                type: string
+                            type: object
+                          type: object
+                        topicPattern:
+                          type: string
+                        topics:
+                          items:
+                            type: string
+                          type: array
+                        typeClassName:
+                          type: string
+                      type: object
+                    java:
+                      properties:
+                        extraDependenciesDir:
+                          type: string
+                        jar:
+                          type: string
+                        jarLocation:
+                          type: string
+                      type: object
+                    logTopic:
+                      type: string
+                    maxMessageRetry:
+                      format: int32
+                      type: integer
+                    maxReplicas:
+                      format: int32
+                      type: integer
+                    name:
+                      type: string
+                    negativeAckRedeliveryDelayMs:
+                      format: int32
+                      type: integer
+                    pod:
+                      properties:
+                        affinity:
+                          properties:
+                            nodeAffinity:
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  items:
+                                    properties:
+                                      preference:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchFields:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                        type: object
+                                      weight:
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - preference
+                                    - weight
+                                    type: object
+                                  type: array
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  properties:
+                                    nodeSelectorTerms:
+                                      items:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchFields:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                        type: object
+                                      type: array
+                                  required:
+                                  - nodeSelectorTerms
+                                  type: object
+                              type: object
+                            podAffinity:
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  items:
+                                    properties:
+                                      podAffinityTerm:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      weight:
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - podAffinityTerm
+                                    - weight
+                                    type: object
+                                  type: array
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  items:
+                                    properties:
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  type: array
+                              type: object
+                            podAntiAffinity:
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  items:
+                                    properties:
+                                      podAffinityTerm:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      weight:
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - podAffinityTerm
+                                    - weight
+                                    type: object
+                                  type: array
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  items:
+                                    properties:
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  type: array
+                              type: object
+                          type: object
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        imagePullSecrets:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          type: array
+                        initContainers:
+                          items:
+                            properties:
+                              args:
+                                items:
+                                  type: string
+                                type: array
+                              command:
+                                items:
+                                  type: string
+                                type: array
+                              env:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                    valueFrom:
+                                      properties:
+                                        configMapKeyRef:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        fieldRef:
+                                          properties:
+                                            apiVersion:
+                                              type: string
+                                            fieldPath:
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                        resourceFieldRef:
+                                          properties:
+                                            containerName:
+                                              type: string
+                                            divisor:
+                                              type: string
+                                            resource:
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                        secretKeyRef:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              envFrom:
+                                items:
+                                  properties:
+                                    configMapRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                    prefix:
+                                      type: string
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                  type: object
+                                type: array
+                              image:
+                                type: string
+                              imagePullPolicy:
+                                type: string
+                              lifecycle:
+                                properties:
+                                  postStart:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                    type: object
+                                  preStop:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                    type: object
+                                type: object
+                              livenessProbe:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  failureThreshold:
+                                    format: int32
+                                    type: integer
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  timeoutSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              name:
+                                type: string
+                              ports:
+                                items:
+                                  properties:
+                                    containerPort:
+                                      format: int32
+                                      type: integer
+                                    hostIP:
+                                      type: string
+                                    hostPort:
+                                      format: int32
+                                      type: integer
+                                    name:
+                                      type: string
+                                    protocol:
+                                      type: string
+                                  required:
+                                  - containerPort
+                                  type: object
+                                type: array
+                              readinessProbe:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  failureThreshold:
+                                    format: int32
+                                    type: integer
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  timeoutSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              resources:
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              securityContext:
+                                properties:
+                                  allowPrivilegeEscalation:
+                                    type: boolean
+                                  capabilities:
+                                    properties:
+                                      add:
+                                        items:
+                                          type: string
+                                        type: array
+                                      drop:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  privileged:
+                                    type: boolean
+                                  procMount:
+                                    type: string
+                                  readOnlyRootFilesystem:
+                                    type: boolean
+                                  runAsGroup:
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    type: boolean
+                                  runAsUser:
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    properties:
+                                      level:
+                                        type: string
+                                      role:
+                                        type: string
+                                      type:
+                                        type: string
+                                      user:
+                                        type: string
+                                    type: object
+                                  windowsOptions:
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        type: string
+                                      runAsUserName:
+                                        type: string
+                                    type: object
+                                type: object
+                              startupProbe:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  failureThreshold:
+                                    format: int32
+                                    type: integer
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  timeoutSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              stdin:
+                                type: boolean
+                              stdinOnce:
+                                type: boolean
+                              terminationMessagePath:
+                                type: string
+                              terminationMessagePolicy:
+                                type: string
+                              tty:
+                                type: boolean
+                              volumeDevices:
+                                items:
+                                  properties:
+                                    devicePath:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - devicePath
+                                  - name
+                                  type: object
+                                type: array
+                              volumeMounts:
+                                items:
+                                  properties:
+                                    mountPath:
+                                      type: string
+                                    mountPropagation:
+                                      type: string
+                                    name:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    subPath:
+                                      type: string
+                                    subPathExpr:
+                                      type: string
+                                  required:
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                              workingDir:
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        securityContext:
+                          properties:
+                            fsGroup:
+                              format: int64
+                              type: integer
+                            fsGroupChangePolicy:
+                              type: string
+                            runAsGroup:
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                              type: object
+                            supplementalGroups:
+                              items:
+                                format: int64
+                                type: integer
+                              type: array
+                            sysctls:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            windowsOptions:
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
+                                  type: string
+                              type: object
+                          type: object
+                        sidecars:
+                          items:
+                            properties:
+                              args:
+                                items:
+                                  type: string
+                                type: array
+                              command:
+                                items:
+                                  type: string
+                                type: array
+                              env:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                    valueFrom:
+                                      properties:
+                                        configMapKeyRef:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        fieldRef:
+                                          properties:
+                                            apiVersion:
+                                              type: string
+                                            fieldPath:
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                        resourceFieldRef:
+                                          properties:
+                                            containerName:
+                                              type: string
+                                            divisor:
+                                              type: string
+                                            resource:
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                        secretKeyRef:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              envFrom:
+                                items:
+                                  properties:
+                                    configMapRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                    prefix:
+                                      type: string
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                  type: object
+                                type: array
+                              image:
+                                type: string
+                              imagePullPolicy:
+                                type: string
+                              lifecycle:
+                                properties:
+                                  postStart:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                    type: object
+                                  preStop:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                    type: object
+                                type: object
+                              livenessProbe:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  failureThreshold:
+                                    format: int32
+                                    type: integer
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  timeoutSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              name:
+                                type: string
+                              ports:
+                                items:
+                                  properties:
+                                    containerPort:
+                                      format: int32
+                                      type: integer
+                                    hostIP:
+                                      type: string
+                                    hostPort:
+                                      format: int32
+                                      type: integer
+                                    name:
+                                      type: string
+                                    protocol:
+                                      type: string
+                                  required:
+                                  - containerPort
+                                  type: object
+                                type: array
+                              readinessProbe:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  failureThreshold:
+                                    format: int32
+                                    type: integer
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  timeoutSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              resources:
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              securityContext:
+                                properties:
+                                  allowPrivilegeEscalation:
+                                    type: boolean
+                                  capabilities:
+                                    properties:
+                                      add:
+                                        items:
+                                          type: string
+                                        type: array
+                                      drop:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  privileged:
+                                    type: boolean
+                                  procMount:
+                                    type: string
+                                  readOnlyRootFilesystem:
+                                    type: boolean
+                                  runAsGroup:
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    type: boolean
+                                  runAsUser:
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    properties:
+                                      level:
+                                        type: string
+                                      role:
+                                        type: string
+                                      type:
+                                        type: string
+                                      user:
+                                        type: string
+                                    type: object
+                                  windowsOptions:
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        type: string
+                                      runAsUserName:
+                                        type: string
+                                    type: object
+                                type: object
+                              startupProbe:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  failureThreshold:
+                                    format: int32
+                                    type: integer
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  timeoutSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              stdin:
+                                type: boolean
+                              stdinOnce:
+                                type: boolean
+                              terminationMessagePath:
+                                type: string
+                              terminationMessagePolicy:
+                                type: string
+                              tty:
+                                type: boolean
+                              volumeDevices:
+                                items:
+                                  properties:
+                                    devicePath:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - devicePath
+                                  - name
+                                  type: object
+                                type: array
+                              volumeMounts:
+                                items:
+                                  properties:
+                                    mountPath:
+                                      type: string
+                                    mountPropagation:
+                                      type: string
+                                    name:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    subPath:
+                                      type: string
+                                    subPathExpr:
+                                      type: string
+                                  required:
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                              workingDir:
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        terminationGracePeriodSeconds:
+                          format: int64
+                          type: integer
+                        tolerations:
+                          items:
+                            properties:
+                              effect:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              tolerationSeconds:
+                                format: int64
+                                type: integer
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                        volumes:
+                          items:
+                            properties:
+                              awsElasticBlockStore:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  partition:
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    type: boolean
+                                  volumeID:
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              azureDisk:
+                                properties:
+                                  cachingMode:
+                                    type: string
+                                  diskName:
+                                    type: string
+                                  diskURI:
+                                    type: string
+                                  fsType:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                - diskName
+                                - diskURI
+                                type: object
+                              azureFile:
+                                properties:
+                                  readOnly:
+                                    type: boolean
+                                  secretName:
+                                    type: string
+                                  shareName:
+                                    type: string
+                                required:
+                                - secretName
+                                - shareName
+                                type: object
+                              cephfs:
+                                properties:
+                                  monitors:
+                                    items:
+                                      type: string
+                                    type: array
+                                  path:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretFile:
+                                    type: string
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  user:
+                                    type: string
+                                required:
+                                - monitors
+                                type: object
+                              cinder:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  volumeID:
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              configMap:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                type: object
+                              csi:
+                                properties:
+                                  driver:
+                                    type: string
+                                  fsType:
+                                    type: string
+                                  nodePublishSecretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  readOnly:
+                                    type: boolean
+                                  volumeAttributes:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                required:
+                                - driver
+                                type: object
+                              downwardAPI:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    items:
+                                      properties:
+                                        fieldRef:
+                                          properties:
+                                            apiVersion:
+                                              type: string
+                                            fieldPath:
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                        resourceFieldRef:
+                                          properties:
+                                            containerName:
+                                              type: string
+                                            divisor:
+                                              type: string
+                                            resource:
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                type: object
+                              emptyDir:
+                                properties:
+                                  medium:
+                                    type: string
+                                  sizeLimit:
+                                    type: string
+                                type: object
+                              fc:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  lun:
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    type: boolean
+                                  targetWWNs:
+                                    items:
+                                      type: string
+                                    type: array
+                                  wwids:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              flexVolume:
+                                properties:
+                                  driver:
+                                    type: string
+                                  fsType:
+                                    type: string
+                                  options:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                required:
+                                - driver
+                                type: object
+                              flocker:
+                                properties:
+                                  datasetName:
+                                    type: string
+                                  datasetUUID:
+                                    type: string
+                                type: object
+                              gcePersistentDisk:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  partition:
+                                    format: int32
+                                    type: integer
+                                  pdName:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                - pdName
+                                type: object
+                              gitRepo:
+                                properties:
+                                  directory:
+                                    type: string
+                                  repository:
+                                    type: string
+                                  revision:
+                                    type: string
+                                required:
+                                - repository
+                                type: object
+                              glusterfs:
+                                properties:
+                                  endpoints:
+                                    type: string
+                                  path:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                - endpoints
+                                - path
+                                type: object
+                              hostPath:
+                                properties:
+                                  path:
+                                    type: string
+                                  type:
+                                    type: string
+                                required:
+                                - path
+                                type: object
+                              iscsi:
+                                properties:
+                                  chapAuthDiscovery:
+                                    type: boolean
+                                  chapAuthSession:
+                                    type: boolean
+                                  fsType:
+                                    type: string
+                                  initiatorName:
+                                    type: string
+                                  iqn:
+                                    type: string
+                                  iscsiInterface:
+                                    type: string
+                                  lun:
+                                    format: int32
+                                    type: integer
+                                  portals:
+                                    items:
+                                      type: string
+                                    type: array
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  targetPortal:
+                                    type: string
+                                required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                                type: object
+                              name:
+                                type: string
+                              nfs:
+                                properties:
+                                  path:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  server:
+                                    type: string
+                                required:
+                                - path
+                                - server
+                                type: object
+                              persistentVolumeClaim:
+                                properties:
+                                  claimName:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                - claimName
+                                type: object
+                              photonPersistentDisk:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  pdID:
+                                    type: string
+                                required:
+                                - pdID
+                                type: object
+                              portworxVolume:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  volumeID:
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              projected:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  sources:
+                                    items:
+                                      properties:
+                                        configMap:
+                                          properties:
+                                            items:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        downwardAPI:
+                                          properties:
+                                            items:
+                                              items:
+                                                properties:
+                                                  fieldRef:
+                                                    properties:
+                                                      apiVersion:
+                                                        type: string
+                                                      fieldPath:
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                  resourceFieldRef:
+                                                    properties:
+                                                      containerName:
+                                                        type: string
+                                                      divisor:
+                                                        type: string
+                                                      resource:
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                required:
+                                                - path
+                                                type: object
+                                              type: array
+                                          type: object
+                                        secret:
+                                          properties:
+                                            items:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        serviceAccountToken:
+                                          properties:
+                                            audience:
+                                              type: string
+                                            expirationSeconds:
+                                              format: int64
+                                              type: integer
+                                            path:
+                                              type: string
+                                          required:
+                                          - path
+                                          type: object
+                                      type: object
+                                    type: array
+                                required:
+                                - sources
+                                type: object
+                              quobyte:
+                                properties:
+                                  group:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  registry:
+                                    type: string
+                                  tenant:
+                                    type: string
+                                  user:
+                                    type: string
+                                  volume:
+                                    type: string
+                                required:
+                                - registry
+                                - volume
+                                type: object
+                              rbd:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  image:
+                                    type: string
+                                  keyring:
+                                    type: string
+                                  monitors:
+                                    items:
+                                      type: string
+                                    type: array
+                                  pool:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  user:
+                                    type: string
+                                required:
+                                - image
+                                - monitors
+                                type: object
+                              scaleIO:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  gateway:
+                                    type: string
+                                  protectionDomain:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  sslEnabled:
+                                    type: boolean
+                                  storageMode:
+                                    type: string
+                                  storagePool:
+                                    type: string
+                                  system:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                - gateway
+                                - secretRef
+                                - system
+                                type: object
+                              secret:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  optional:
+                                    type: boolean
+                                  secretName:
+                                    type: string
+                                type: object
+                              storageos:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  volumeName:
+                                    type: string
+                                  volumeNamespace:
+                                    type: string
+                                type: object
+                              vsphereVolume:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  storagePolicyID:
+                                    type: string
+                                  storagePolicyName:
+                                    type: string
+                                  volumePath:
+                                    type: string
+                                required:
+                                - volumePath
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                      type: object
+                    processingGuarantee:
+                      type: string
+                    pulsar:
+                      properties:
+                        authSecret:
+                          type: string
+                        pulsarConfig:
+                          type: string
+                        tlsSecret:
+                          type: string
+                      type: object
+                    python:
+                      properties:
+                        py:
+                          type: string
+                        pyLocation:
+                          type: string
+                      type: object
+                    replicas:
+                      format: int32
+                      type: integer
+                    resources:
+                      properties:
+                        limits:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        requests:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    retainOrdering:
+                      type: boolean
+                    runtimeFlags:
+                      type: string
+                    secretsMap:
+                      additionalProperties:
+                        properties:
+                          key:
+                            type: string
+                          path:
+                            type: string
+                        type: object
+                      type: object
+                    sinkConfig:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    sinkType:
+                      type: string
+                    subscriptionName:
+                      type: string
+                    subscriptionPosition:
+                      type: string
+                    tenant:
+                      type: string
+                    timeout:
+                      format: int32
+                      type: integer
+                    volumeMounts:
+                      items:
+                        properties:
+                          mountPath:
+                            type: string
+                          mountPropagation:
+                            type: string
+                          name:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          subPath:
+                            type: string
+                          subPathExpr:
+                            type: string
+                        required:
+                        - mountPath
+                        - name
+                        type: object
+                      type: array
+                  type: object
+                type: array
+              sources:
+                items:
+                  properties:
+                    className:
+                      type: string
+                    clusterName:
+                      type: string
+                    golang:
+                      properties:
+                        go:
+                          type: string
+                        goLocation:
+                          type: string
+                      type: object
+                    image:
+                      type: string
+                    imagePullPolicy:
+                      type: string
+                    java:
+                      properties:
+                        extraDependenciesDir:
+                          type: string
+                        jar:
+                          type: string
+                        jarLocation:
+                          type: string
+                      type: object
+                    logTopic:
+                      type: string
+                    maxReplicas:
+                      format: int32
+                      type: integer
+                    name:
+                      type: string
+                    output:
+                      properties:
+                        customSchemaSinks:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        producerConf:
+                          properties:
+                            batchBuilder:
+                              type: string
+                            cryptoConfig:
+                              properties:
+                                consumerCryptoFailureAction:
+                                  type: string
+                                cryptoKeyReaderClassName:
+                                  type: string
+                                cryptoKeyReaderConfig:
+                                  additionalProperties:
+                                    type: string
+                                  type: object
+                                cryptoSecrets:
+                                  items:
+                                    properties:
+                                      asVolume:
+                                        type: string
+                                      secretKey:
+                                        type: string
+                                      secretName:
+                                        type: string
+                                    required:
+                                    - secretKey
+                                    - secretName
+                                    type: object
+                                  type: array
+                                encryptionKeys:
+                                  items:
+                                    type: string
+                                  type: array
+                                producerCryptoFailureAction:
+                                  type: string
+                              type: object
+                            maxPendingMessages:
+                              format: int32
+                              type: integer
+                            maxPendingMessagesAcrossPartitions:
+                              format: int32
+                              type: integer
+                            useThreadLocalProducers:
+                              type: boolean
+                          type: object
+                        sinkSchemaType:
+                          type: string
+                        sinkSerdeClassName:
+                          type: string
+                        topic:
+                          type: string
+                        typeClassName:
+                          type: string
+                      type: object
+                    pod:
+                      properties:
+                        affinity:
+                          properties:
+                            nodeAffinity:
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  items:
+                                    properties:
+                                      preference:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchFields:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                        type: object
+                                      weight:
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - preference
+                                    - weight
+                                    type: object
+                                  type: array
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  properties:
+                                    nodeSelectorTerms:
+                                      items:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchFields:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                        type: object
+                                      type: array
+                                  required:
+                                  - nodeSelectorTerms
+                                  type: object
+                              type: object
+                            podAffinity:
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  items:
+                                    properties:
+                                      podAffinityTerm:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      weight:
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - podAffinityTerm
+                                    - weight
+                                    type: object
+                                  type: array
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  items:
+                                    properties:
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  type: array
+                              type: object
+                            podAntiAffinity:
+                              properties:
+                                preferredDuringSchedulingIgnoredDuringExecution:
+                                  items:
+                                    properties:
+                                      podAffinityTerm:
+                                        properties:
+                                          labelSelector:
+                                            properties:
+                                              matchExpressions:
+                                                items:
+                                                  properties:
+                                                    key:
+                                                      type: string
+                                                    operator:
+                                                      type: string
+                                                    values:
+                                                      items:
+                                                        type: string
+                                                      type: array
+                                                  required:
+                                                  - key
+                                                  - operator
+                                                  type: object
+                                                type: array
+                                              matchLabels:
+                                                additionalProperties:
+                                                  type: string
+                                                type: object
+                                            type: object
+                                          namespaces:
+                                            items:
+                                              type: string
+                                            type: array
+                                          topologyKey:
+                                            type: string
+                                        required:
+                                        - topologyKey
+                                        type: object
+                                      weight:
+                                        format: int32
+                                        type: integer
+                                    required:
+                                    - podAffinityTerm
+                                    - weight
+                                    type: object
+                                  type: array
+                                requiredDuringSchedulingIgnoredDuringExecution:
+                                  items:
+                                    properties:
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        type: string
+                                    required:
+                                    - topologyKey
+                                    type: object
+                                  type: array
+                              type: object
+                          type: object
+                        annotations:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        imagePullSecrets:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          type: array
+                        initContainers:
+                          items:
+                            properties:
+                              args:
+                                items:
+                                  type: string
+                                type: array
+                              command:
+                                items:
+                                  type: string
+                                type: array
+                              env:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                    valueFrom:
+                                      properties:
+                                        configMapKeyRef:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        fieldRef:
+                                          properties:
+                                            apiVersion:
+                                              type: string
+                                            fieldPath:
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                        resourceFieldRef:
+                                          properties:
+                                            containerName:
+                                              type: string
+                                            divisor:
+                                              type: string
+                                            resource:
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                        secretKeyRef:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              envFrom:
+                                items:
+                                  properties:
+                                    configMapRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                    prefix:
+                                      type: string
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                  type: object
+                                type: array
+                              image:
+                                type: string
+                              imagePullPolicy:
+                                type: string
+                              lifecycle:
+                                properties:
+                                  postStart:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                    type: object
+                                  preStop:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                    type: object
+                                type: object
+                              livenessProbe:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  failureThreshold:
+                                    format: int32
+                                    type: integer
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  timeoutSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              name:
+                                type: string
+                              ports:
+                                items:
+                                  properties:
+                                    containerPort:
+                                      format: int32
+                                      type: integer
+                                    hostIP:
+                                      type: string
+                                    hostPort:
+                                      format: int32
+                                      type: integer
+                                    name:
+                                      type: string
+                                    protocol:
+                                      type: string
+                                  required:
+                                  - containerPort
+                                  type: object
+                                type: array
+                              readinessProbe:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  failureThreshold:
+                                    format: int32
+                                    type: integer
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  timeoutSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              resources:
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              securityContext:
+                                properties:
+                                  allowPrivilegeEscalation:
+                                    type: boolean
+                                  capabilities:
+                                    properties:
+                                      add:
+                                        items:
+                                          type: string
+                                        type: array
+                                      drop:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  privileged:
+                                    type: boolean
+                                  procMount:
+                                    type: string
+                                  readOnlyRootFilesystem:
+                                    type: boolean
+                                  runAsGroup:
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    type: boolean
+                                  runAsUser:
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    properties:
+                                      level:
+                                        type: string
+                                      role:
+                                        type: string
+                                      type:
+                                        type: string
+                                      user:
+                                        type: string
+                                    type: object
+                                  windowsOptions:
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        type: string
+                                      runAsUserName:
+                                        type: string
+                                    type: object
+                                type: object
+                              startupProbe:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  failureThreshold:
+                                    format: int32
+                                    type: integer
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  timeoutSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              stdin:
+                                type: boolean
+                              stdinOnce:
+                                type: boolean
+                              terminationMessagePath:
+                                type: string
+                              terminationMessagePolicy:
+                                type: string
+                              tty:
+                                type: boolean
+                              volumeDevices:
+                                items:
+                                  properties:
+                                    devicePath:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - devicePath
+                                  - name
+                                  type: object
+                                type: array
+                              volumeMounts:
+                                items:
+                                  properties:
+                                    mountPath:
+                                      type: string
+                                    mountPropagation:
+                                      type: string
+                                    name:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    subPath:
+                                      type: string
+                                    subPathExpr:
+                                      type: string
+                                  required:
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                              workingDir:
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        labels:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        nodeSelector:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        securityContext:
+                          properties:
+                            fsGroup:
+                              format: int64
+                              type: integer
+                            fsGroupChangePolicy:
+                              type: string
+                            runAsGroup:
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                              type: object
+                            supplementalGroups:
+                              items:
+                                format: int64
+                                type: integer
+                              type: array
+                            sysctls:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                  value:
+                                    type: string
+                                required:
+                                - name
+                                - value
+                                type: object
+                              type: array
+                            windowsOptions:
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
+                                  type: string
+                              type: object
+                          type: object
+                        sidecars:
+                          items:
+                            properties:
+                              args:
+                                items:
+                                  type: string
+                                type: array
+                              command:
+                                items:
+                                  type: string
+                                type: array
+                              env:
+                                items:
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                    valueFrom:
+                                      properties:
+                                        configMapKeyRef:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                        fieldRef:
+                                          properties:
+                                            apiVersion:
+                                              type: string
+                                            fieldPath:
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                        resourceFieldRef:
+                                          properties:
+                                            containerName:
+                                              type: string
+                                            divisor:
+                                              type: string
+                                            resource:
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                        secretKeyRef:
+                                          properties:
+                                            key:
+                                              type: string
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          required:
+                                          - key
+                                          type: object
+                                      type: object
+                                  required:
+                                  - name
+                                  type: object
+                                type: array
+                              envFrom:
+                                items:
+                                  properties:
+                                    configMapRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                    prefix:
+                                      type: string
+                                    secretRef:
+                                      properties:
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      type: object
+                                  type: object
+                                type: array
+                              image:
+                                type: string
+                              imagePullPolicy:
+                                type: string
+                              lifecycle:
+                                properties:
+                                  postStart:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                    type: object
+                                  preStop:
+                                    properties:
+                                      exec:
+                                        properties:
+                                          command:
+                                            items:
+                                              type: string
+                                            type: array
+                                        type: object
+                                      httpGet:
+                                        properties:
+                                          host:
+                                            type: string
+                                          httpHeaders:
+                                            items:
+                                              properties:
+                                                name:
+                                                  type: string
+                                                value:
+                                                  type: string
+                                              required:
+                                              - name
+                                              - value
+                                              type: object
+                                            type: array
+                                          path:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                          scheme:
+                                            type: string
+                                        required:
+                                        - port
+                                        type: object
+                                      tcpSocket:
+                                        properties:
+                                          host:
+                                            type: string
+                                          port:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            x-kubernetes-int-or-string: true
+                                        required:
+                                        - port
+                                        type: object
+                                    type: object
+                                type: object
+                              livenessProbe:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  failureThreshold:
+                                    format: int32
+                                    type: integer
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  timeoutSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              name:
+                                type: string
+                              ports:
+                                items:
+                                  properties:
+                                    containerPort:
+                                      format: int32
+                                      type: integer
+                                    hostIP:
+                                      type: string
+                                    hostPort:
+                                      format: int32
+                                      type: integer
+                                    name:
+                                      type: string
+                                    protocol:
+                                      type: string
+                                  required:
+                                  - containerPort
+                                  type: object
+                                type: array
+                              readinessProbe:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  failureThreshold:
+                                    format: int32
+                                    type: integer
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  timeoutSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              resources:
+                                properties:
+                                  limits:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  requests:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                type: object
+                              securityContext:
+                                properties:
+                                  allowPrivilegeEscalation:
+                                    type: boolean
+                                  capabilities:
+                                    properties:
+                                      add:
+                                        items:
+                                          type: string
+                                        type: array
+                                      drop:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  privileged:
+                                    type: boolean
+                                  procMount:
+                                    type: string
+                                  readOnlyRootFilesystem:
+                                    type: boolean
+                                  runAsGroup:
+                                    format: int64
+                                    type: integer
+                                  runAsNonRoot:
+                                    type: boolean
+                                  runAsUser:
+                                    format: int64
+                                    type: integer
+                                  seLinuxOptions:
+                                    properties:
+                                      level:
+                                        type: string
+                                      role:
+                                        type: string
+                                      type:
+                                        type: string
+                                      user:
+                                        type: string
+                                    type: object
+                                  windowsOptions:
+                                    properties:
+                                      gmsaCredentialSpec:
+                                        type: string
+                                      gmsaCredentialSpecName:
+                                        type: string
+                                      runAsUserName:
+                                        type: string
+                                    type: object
+                                type: object
+                              startupProbe:
+                                properties:
+                                  exec:
+                                    properties:
+                                      command:
+                                        items:
+                                          type: string
+                                        type: array
+                                    type: object
+                                  failureThreshold:
+                                    format: int32
+                                    type: integer
+                                  httpGet:
+                                    properties:
+                                      host:
+                                        type: string
+                                      httpHeaders:
+                                        items:
+                                          properties:
+                                            name:
+                                              type: string
+                                            value:
+                                              type: string
+                                          required:
+                                          - name
+                                          - value
+                                          type: object
+                                        type: array
+                                      path:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                      scheme:
+                                        type: string
+                                    required:
+                                    - port
+                                    type: object
+                                  initialDelaySeconds:
+                                    format: int32
+                                    type: integer
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  successThreshold:
+                                    format: int32
+                                    type: integer
+                                  tcpSocket:
+                                    properties:
+                                      host:
+                                        type: string
+                                      port:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        x-kubernetes-int-or-string: true
+                                    required:
+                                    - port
+                                    type: object
+                                  timeoutSeconds:
+                                    format: int32
+                                    type: integer
+                                type: object
+                              stdin:
+                                type: boolean
+                              stdinOnce:
+                                type: boolean
+                              terminationMessagePath:
+                                type: string
+                              terminationMessagePolicy:
+                                type: string
+                              tty:
+                                type: boolean
+                              volumeDevices:
+                                items:
+                                  properties:
+                                    devicePath:
+                                      type: string
+                                    name:
+                                      type: string
+                                  required:
+                                  - devicePath
+                                  - name
+                                  type: object
+                                type: array
+                              volumeMounts:
+                                items:
+                                  properties:
+                                    mountPath:
+                                      type: string
+                                    mountPropagation:
+                                      type: string
+                                    name:
+                                      type: string
+                                    readOnly:
+                                      type: boolean
+                                    subPath:
+                                      type: string
+                                    subPathExpr:
+                                      type: string
+                                  required:
+                                  - mountPath
+                                  - name
+                                  type: object
+                                type: array
+                              workingDir:
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        terminationGracePeriodSeconds:
+                          format: int64
+                          type: integer
+                        tolerations:
+                          items:
+                            properties:
+                              effect:
+                                type: string
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              tolerationSeconds:
+                                format: int64
+                                type: integer
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                        volumes:
+                          items:
+                            properties:
+                              awsElasticBlockStore:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  partition:
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    type: boolean
+                                  volumeID:
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              azureDisk:
+                                properties:
+                                  cachingMode:
+                                    type: string
+                                  diskName:
+                                    type: string
+                                  diskURI:
+                                    type: string
+                                  fsType:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                - diskName
+                                - diskURI
+                                type: object
+                              azureFile:
+                                properties:
+                                  readOnly:
+                                    type: boolean
+                                  secretName:
+                                    type: string
+                                  shareName:
+                                    type: string
+                                required:
+                                - secretName
+                                - shareName
+                                type: object
+                              cephfs:
+                                properties:
+                                  monitors:
+                                    items:
+                                      type: string
+                                    type: array
+                                  path:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretFile:
+                                    type: string
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  user:
+                                    type: string
+                                required:
+                                - monitors
+                                type: object
+                              cinder:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  volumeID:
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              configMap:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                type: object
+                              csi:
+                                properties:
+                                  driver:
+                                    type: string
+                                  fsType:
+                                    type: string
+                                  nodePublishSecretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  readOnly:
+                                    type: boolean
+                                  volumeAttributes:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                required:
+                                - driver
+                                type: object
+                              downwardAPI:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    items:
+                                      properties:
+                                        fieldRef:
+                                          properties:
+                                            apiVersion:
+                                              type: string
+                                            fieldPath:
+                                              type: string
+                                          required:
+                                          - fieldPath
+                                          type: object
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                        resourceFieldRef:
+                                          properties:
+                                            containerName:
+                                              type: string
+                                            divisor:
+                                              type: string
+                                            resource:
+                                              type: string
+                                          required:
+                                          - resource
+                                          type: object
+                                      required:
+                                      - path
+                                      type: object
+                                    type: array
+                                type: object
+                              emptyDir:
+                                properties:
+                                  medium:
+                                    type: string
+                                  sizeLimit:
+                                    type: string
+                                type: object
+                              fc:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  lun:
+                                    format: int32
+                                    type: integer
+                                  readOnly:
+                                    type: boolean
+                                  targetWWNs:
+                                    items:
+                                      type: string
+                                    type: array
+                                  wwids:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              flexVolume:
+                                properties:
+                                  driver:
+                                    type: string
+                                  fsType:
+                                    type: string
+                                  options:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                required:
+                                - driver
+                                type: object
+                              flocker:
+                                properties:
+                                  datasetName:
+                                    type: string
+                                  datasetUUID:
+                                    type: string
+                                type: object
+                              gcePersistentDisk:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  partition:
+                                    format: int32
+                                    type: integer
+                                  pdName:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                - pdName
+                                type: object
+                              gitRepo:
+                                properties:
+                                  directory:
+                                    type: string
+                                  repository:
+                                    type: string
+                                  revision:
+                                    type: string
+                                required:
+                                - repository
+                                type: object
+                              glusterfs:
+                                properties:
+                                  endpoints:
+                                    type: string
+                                  path:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                - endpoints
+                                - path
+                                type: object
+                              hostPath:
+                                properties:
+                                  path:
+                                    type: string
+                                  type:
+                                    type: string
+                                required:
+                                - path
+                                type: object
+                              iscsi:
+                                properties:
+                                  chapAuthDiscovery:
+                                    type: boolean
+                                  chapAuthSession:
+                                    type: boolean
+                                  fsType:
+                                    type: string
+                                  initiatorName:
+                                    type: string
+                                  iqn:
+                                    type: string
+                                  iscsiInterface:
+                                    type: string
+                                  lun:
+                                    format: int32
+                                    type: integer
+                                  portals:
+                                    items:
+                                      type: string
+                                    type: array
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  targetPortal:
+                                    type: string
+                                required:
+                                - iqn
+                                - lun
+                                - targetPortal
+                                type: object
+                              name:
+                                type: string
+                              nfs:
+                                properties:
+                                  path:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  server:
+                                    type: string
+                                required:
+                                - path
+                                - server
+                                type: object
+                              persistentVolumeClaim:
+                                properties:
+                                  claimName:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                required:
+                                - claimName
+                                type: object
+                              photonPersistentDisk:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  pdID:
+                                    type: string
+                                required:
+                                - pdID
+                                type: object
+                              portworxVolume:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  volumeID:
+                                    type: string
+                                required:
+                                - volumeID
+                                type: object
+                              projected:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  sources:
+                                    items:
+                                      properties:
+                                        configMap:
+                                          properties:
+                                            items:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        downwardAPI:
+                                          properties:
+                                            items:
+                                              items:
+                                                properties:
+                                                  fieldRef:
+                                                    properties:
+                                                      apiVersion:
+                                                        type: string
+                                                      fieldPath:
+                                                        type: string
+                                                    required:
+                                                    - fieldPath
+                                                    type: object
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                  resourceFieldRef:
+                                                    properties:
+                                                      containerName:
+                                                        type: string
+                                                      divisor:
+                                                        type: string
+                                                      resource:
+                                                        type: string
+                                                    required:
+                                                    - resource
+                                                    type: object
+                                                required:
+                                                - path
+                                                type: object
+                                              type: array
+                                          type: object
+                                        secret:
+                                          properties:
+                                            items:
+                                              items:
+                                                properties:
+                                                  key:
+                                                    type: string
+                                                  mode:
+                                                    format: int32
+                                                    type: integer
+                                                  path:
+                                                    type: string
+                                                required:
+                                                - key
+                                                - path
+                                                type: object
+                                              type: array
+                                            name:
+                                              type: string
+                                            optional:
+                                              type: boolean
+                                          type: object
+                                        serviceAccountToken:
+                                          properties:
+                                            audience:
+                                              type: string
+                                            expirationSeconds:
+                                              format: int64
+                                              type: integer
+                                            path:
+                                              type: string
+                                          required:
+                                          - path
+                                          type: object
+                                      type: object
+                                    type: array
+                                required:
+                                - sources
+                                type: object
+                              quobyte:
+                                properties:
+                                  group:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  registry:
+                                    type: string
+                                  tenant:
+                                    type: string
+                                  user:
+                                    type: string
+                                  volume:
+                                    type: string
+                                required:
+                                - registry
+                                - volume
+                                type: object
+                              rbd:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  image:
+                                    type: string
+                                  keyring:
+                                    type: string
+                                  monitors:
+                                    items:
+                                      type: string
+                                    type: array
+                                  pool:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  user:
+                                    type: string
+                                required:
+                                - image
+                                - monitors
+                                type: object
+                              scaleIO:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  gateway:
+                                    type: string
+                                  protectionDomain:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  sslEnabled:
+                                    type: boolean
+                                  storageMode:
+                                    type: string
+                                  storagePool:
+                                    type: string
+                                  system:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                required:
+                                - gateway
+                                - secretRef
+                                - system
+                                type: object
+                              secret:
+                                properties:
+                                  defaultMode:
+                                    format: int32
+                                    type: integer
+                                  items:
+                                    items:
+                                      properties:
+                                        key:
+                                          type: string
+                                        mode:
+                                          format: int32
+                                          type: integer
+                                        path:
+                                          type: string
+                                      required:
+                                      - key
+                                      - path
+                                      type: object
+                                    type: array
+                                  optional:
+                                    type: boolean
+                                  secretName:
+                                    type: string
+                                type: object
+                              storageos:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  readOnly:
+                                    type: boolean
+                                  secretRef:
+                                    properties:
+                                      name:
+                                        type: string
+                                    type: object
+                                  volumeName:
+                                    type: string
+                                  volumeNamespace:
+                                    type: string
+                                type: object
+                              vsphereVolume:
+                                properties:
+                                  fsType:
+                                    type: string
+                                  storagePolicyID:
+                                    type: string
+                                  storagePolicyName:
+                                    type: string
+                                  volumePath:
+                                    type: string
+                                required:
+                                - volumePath
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                      type: object
+                    processingGuarantee:
+                      type: string
+                    pulsar:
+                      properties:
+                        authSecret:
+                          type: string
+                        pulsarConfig:
+                          type: string
+                        tlsSecret:
+                          type: string
+                      type: object
+                    python:
+                      properties:
+                        py:
+                          type: string
+                        pyLocation:
+                          type: string
+                      type: object
+                    replicas:
+                      format: int32
+                      type: integer
+                    resources:
+                      properties:
+                        limits:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        requests:
+                          additionalProperties:
+                            type: string
+                          type: object
+                      type: object
+                    runtimeFlags:
+                      type: string
+                    secretsMap:
+                      additionalProperties:
+                        properties:
+                          key:
+                            type: string
+                          path:
+                            type: string
+                        type: object
+                      type: object
+                    sourceConfig:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    sourceType:
+                      type: string
+                    tenant:
+                      type: string
+                    volumeMounts:
+                      items:
+                        properties:
+                          mountPath:
+                            type: string
+                          mountPropagation:
+                            type: string
+                          name:
+                            type: string
+                          readOnly:
+                            type: boolean
+                          subPath:
+                            type: string
+                          subPathExpr:
+                            type: string
+                        required:
+                        - mountPath
+                        - name
+                        type: object
+                      type: array
+                  type: object
+                type: array
+            type: object
+          status:
+            properties:
+              functionConditions:
+                additionalProperties:
+                  properties:
+                    action:
+                      type: string
+                    condition:
+                      type: string
+                    status:
+                      type: string
+                  type: object
+                type: object
+              sinkConditions:
+                additionalProperties:
+                  properties:
+                    action:
+                      type: string
+                    condition:
+                      type: string
+                    status:
+                      type: string
+                  type: object
+                type: object
+              sourceConditions:
+                additionalProperties:
+                  properties:
+                    action:
+                      type: string
+                    condition:
+                      type: string
+                    status:
+                      type: string
+                  type: object
+                type: object
+            type: object
+        type: object
 status:
   acceptedNames:
     kind: ""

--- a/charts/function-mesh-operator/crds/compute.functionmesh.io_functions.yaml
+++ b/charts/function-mesh-operator/crds/compute.functionmesh.io_functions.yaml
@@ -1,6 +1,5 @@
-
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,67 +14,158 @@ spec:
     plural: functions
     singular: function
   scope: Namespaced
-  subresources:
-    scale:
-      labelSelectorPath: .status.selector
-      specReplicasPath: .spec.replicas
-      statusReplicasPath: .status.replicas
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            autoAck:
-              type: boolean
-            className:
-              type: string
-            cleanupSubscription:
-              type: boolean
-            clusterName:
-              type: string
-            deadLetterTopic:
-              type: string
-            forwardSourceMessageProperty:
-              type: boolean
-            funcConfig:
-              additionalProperties:
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              autoAck:
+                type: boolean
+              className:
                 type: string
-              type: object
-            golang:
-              properties:
-                go:
+              cleanupSubscription:
+                type: boolean
+              clusterName:
+                type: string
+              deadLetterTopic:
+                type: string
+              forwardSourceMessageProperty:
+                type: boolean
+              funcConfig:
+                additionalProperties:
                   type: string
-                goLocation:
-                  type: string
-              type: object
-            image:
-              type: string
-            imagePullPolicy:
-              type: string
-            input:
-              properties:
-                customSchemaSources:
-                  additionalProperties:
+                type: object
+              golang:
+                properties:
+                  go:
                     type: string
-                  type: object
-                customSerdeSources:
-                  additionalProperties:
+                  goLocation:
                     type: string
-                  type: object
-                sourceSpecs:
-                  additionalProperties:
-                    properties:
-                      consumerProperties:
-                        additionalProperties:
+                type: object
+              image:
+                type: string
+              imagePullPolicy:
+                type: string
+              input:
+                properties:
+                  customSchemaSources:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  customSerdeSources:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  sourceSpecs:
+                    additionalProperties:
+                      properties:
+                        consumerProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        cryptoConfig:
+                          properties:
+                            consumerCryptoFailureAction:
+                              type: string
+                            cryptoKeyReaderClassName:
+                              type: string
+                            cryptoKeyReaderConfig:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            cryptoSecrets:
+                              items:
+                                properties:
+                                  asVolume:
+                                    type: string
+                                  secretKey:
+                                    type: string
+                                  secretName:
+                                    type: string
+                                required:
+                                - secretKey
+                                - secretName
+                                type: object
+                              type: array
+                            encryptionKeys:
+                              items:
+                                type: string
+                              type: array
+                            producerCryptoFailureAction:
+                              type: string
+                          type: object
+                        isRegexPattern:
+                          type: boolean
+                        receiverQueueSize:
+                          format: int32
+                          type: integer
+                        schemaProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        schemaType:
                           type: string
-                        type: object
+                        serdeClassname:
+                          type: string
+                      type: object
+                    type: object
+                  topicPattern:
+                    type: string
+                  topics:
+                    items:
+                      type: string
+                    type: array
+                  typeClassName:
+                    type: string
+                type: object
+              java:
+                properties:
+                  extraDependenciesDir:
+                    type: string
+                  jar:
+                    type: string
+                  jarLocation:
+                    type: string
+                type: object
+              logTopic:
+                type: string
+              maxMessageRetry:
+                format: int32
+                type: integer
+              maxPendingAsyncRequests:
+                format: int32
+                type: integer
+              maxReplicas:
+                format: int32
+                type: integer
+              name:
+                type: string
+              output:
+                properties:
+                  customSchemaSinks:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  producerConf:
+                    properties:
+                      batchBuilder:
+                        type: string
                       cryptoConfig:
                         properties:
                           consumerCryptoFailureAction:
@@ -107,2194 +197,2102 @@ spec:
                           producerCryptoFailureAction:
                             type: string
                         type: object
-                      isRegexPattern:
-                        type: boolean
-                      receiverQueueSize:
+                      maxPendingMessages:
                         format: int32
                         type: integer
-                      schemaProperties:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      schemaType:
-                        type: string
-                      serdeClassname:
-                        type: string
-                    type: object
-                  type: object
-                topicPattern:
-                  type: string
-                topics:
-                  items:
-                    type: string
-                  type: array
-                typeClassName:
-                  type: string
-              type: object
-            java:
-              properties:
-                extraDependenciesDir:
-                  type: string
-                jar:
-                  type: string
-                jarLocation:
-                  type: string
-              type: object
-            logTopic:
-              type: string
-            maxMessageRetry:
-              format: int32
-              type: integer
-            maxPendingAsyncRequests:
-              format: int32
-              type: integer
-            maxReplicas:
-              format: int32
-              type: integer
-            name:
-              type: string
-            output:
-              properties:
-                customSchemaSinks:
-                  additionalProperties:
-                    type: string
-                  type: object
-                producerConf:
-                  properties:
-                    batchBuilder:
-                      type: string
-                    cryptoConfig:
-                      properties:
-                        consumerCryptoFailureAction:
-                          type: string
-                        cryptoKeyReaderClassName:
-                          type: string
-                        cryptoKeyReaderConfig:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        cryptoSecrets:
-                          items:
-                            properties:
-                              asVolume:
-                                type: string
-                              secretKey:
-                                type: string
-                              secretName:
-                                type: string
-                            required:
-                            - secretKey
-                            - secretName
-                            type: object
-                          type: array
-                        encryptionKeys:
-                          items:
-                            type: string
-                          type: array
-                        producerCryptoFailureAction:
-                          type: string
-                      type: object
-                    maxPendingMessages:
-                      format: int32
-                      type: integer
-                    maxPendingMessagesAcrossPartitions:
-                      format: int32
-                      type: integer
-                    useThreadLocalProducers:
-                      type: boolean
-                  type: object
-                sinkSchemaType:
-                  type: string
-                sinkSerdeClassName:
-                  type: string
-                topic:
-                  type: string
-                typeClassName:
-                  type: string
-              type: object
-            pod:
-              properties:
-                affinity:
-                  properties:
-                    nodeAffinity:
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              preference:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              weight:
-                                format: int32
-                                type: integer
-                            required:
-                            - preference
-                            - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          properties:
-                            nodeSelectorTerms:
-                              items:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              type: array
-                          required:
-                          - nodeSelectorTerms
-                          type: object
-                      type: object
-                    podAffinity:
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              podAffinityTerm:
-                                properties:
-                                  labelSelector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    type: string
-                                required:
-                                - topologyKey
-                                type: object
-                              weight:
-                                format: int32
-                                type: integer
-                            required:
-                            - podAffinityTerm
-                            - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              labelSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              namespaces:
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                    podAntiAffinity:
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              podAffinityTerm:
-                                properties:
-                                  labelSelector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    type: string
-                                required:
-                                - topologyKey
-                                type: object
-                              weight:
-                                format: int32
-                                type: integer
-                            required:
-                            - podAffinityTerm
-                            - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              labelSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              namespaces:
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                  type: object
-                annotations:
-                  additionalProperties:
-                    type: string
-                  type: object
-                imagePullSecrets:
-                  items:
-                    properties:
-                      name:
-                        type: string
-                    type: object
-                  type: array
-                initContainers:
-                  items:
-                    properties:
-                      args:
-                        items:
-                          type: string
-                        type: array
-                      command:
-                        items:
-                          type: string
-                        type: array
-                      env:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            value:
-                              type: string
-                            valueFrom:
-                              properties:
-                                configMapKeyRef:
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  required:
-                                  - key
-                                  type: object
-                                fieldRef:
-                                  properties:
-                                    apiVersion:
-                                      type: string
-                                    fieldPath:
-                                      type: string
-                                  required:
-                                  - fieldPath
-                                  type: object
-                                resourceFieldRef:
-                                  properties:
-                                    containerName:
-                                      type: string
-                                    divisor:
-                                      type: string
-                                    resource:
-                                      type: string
-                                  required:
-                                  - resource
-                                  type: object
-                                secretKeyRef:
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  required:
-                                  - key
-                                  type: object
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      envFrom:
-                        items:
-                          properties:
-                            configMapRef:
-                              properties:
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              type: object
-                            prefix:
-                              type: string
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              type: object
-                          type: object
-                        type: array
-                      image:
-                        type: string
-                      imagePullPolicy:
-                        type: string
-                      lifecycle:
-                        properties:
-                          postStart:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                            type: object
-                          preStop:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                            type: object
-                        type: object
-                      livenessProbe:
-                        properties:
-                          exec:
-                            properties:
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            format: int32
-                            type: integer
-                          httpGet:
-                            properties:
-                              host:
-                                type: string
-                              httpHeaders:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            properties:
-                              host:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          timeoutSeconds:
-                            format: int32
-                            type: integer
-                        type: object
-                      name:
-                        type: string
-                      ports:
-                        items:
-                          properties:
-                            containerPort:
-                              format: int32
-                              type: integer
-                            hostIP:
-                              type: string
-                            hostPort:
-                              format: int32
-                              type: integer
-                            name:
-                              type: string
-                            protocol:
-                              type: string
-                          required:
-                          - containerPort
-                          type: object
-                        type: array
-                      readinessProbe:
-                        properties:
-                          exec:
-                            properties:
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            format: int32
-                            type: integer
-                          httpGet:
-                            properties:
-                              host:
-                                type: string
-                              httpHeaders:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            properties:
-                              host:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          timeoutSeconds:
-                            format: int32
-                            type: integer
-                        type: object
-                      resources:
-                        properties:
-                          limits:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          requests:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        type: object
-                      securityContext:
-                        properties:
-                          allowPrivilegeEscalation:
-                            type: boolean
-                          capabilities:
-                            properties:
-                              add:
-                                items:
-                                  type: string
-                                type: array
-                              drop:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          privileged:
-                            type: boolean
-                          procMount:
-                            type: string
-                          readOnlyRootFilesystem:
-                            type: boolean
-                          runAsGroup:
-                            format: int64
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            format: int64
-                            type: integer
-                          seLinuxOptions:
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                            type: object
-                          windowsOptions:
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              runAsUserName:
-                                type: string
-                            type: object
-                        type: object
-                      startupProbe:
-                        properties:
-                          exec:
-                            properties:
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            format: int32
-                            type: integer
-                          httpGet:
-                            properties:
-                              host:
-                                type: string
-                              httpHeaders:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            properties:
-                              host:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          timeoutSeconds:
-                            format: int32
-                            type: integer
-                        type: object
-                      stdin:
-                        type: boolean
-                      stdinOnce:
-                        type: boolean
-                      terminationMessagePath:
-                        type: string
-                      terminationMessagePolicy:
-                        type: string
-                      tty:
-                        type: boolean
-                      volumeDevices:
-                        items:
-                          properties:
-                            devicePath:
-                              type: string
-                            name:
-                              type: string
-                          required:
-                          - devicePath
-                          - name
-                          type: object
-                        type: array
-                      volumeMounts:
-                        items:
-                          properties:
-                            mountPath:
-                              type: string
-                            mountPropagation:
-                              type: string
-                            name:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            subPath:
-                              type: string
-                            subPathExpr:
-                              type: string
-                          required:
-                          - mountPath
-                          - name
-                          type: object
-                        type: array
-                      workingDir:
-                        type: string
-                    required:
-                    - name
-                    type: object
-                  type: array
-                labels:
-                  additionalProperties:
-                    type: string
-                  type: object
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  type: object
-                securityContext:
-                  properties:
-                    fsGroup:
-                      format: int64
-                      type: integer
-                    fsGroupChangePolicy:
-                      type: string
-                    runAsGroup:
-                      format: int64
-                      type: integer
-                    runAsNonRoot:
-                      type: boolean
-                    runAsUser:
-                      format: int64
-                      type: integer
-                    seLinuxOptions:
-                      properties:
-                        level:
-                          type: string
-                        role:
-                          type: string
-                        type:
-                          type: string
-                        user:
-                          type: string
-                      type: object
-                    supplementalGroups:
-                      items:
-                        format: int64
+                      maxPendingMessagesAcrossPartitions:
+                        format: int32
                         type: integer
-                      type: array
-                    sysctls:
-                      items:
-                        properties:
-                          name:
-                            type: string
-                          value:
-                            type: string
-                        required:
-                        - name
-                        - value
-                        type: object
-                      type: array
-                    windowsOptions:
-                      properties:
-                        gmsaCredentialSpec:
-                          type: string
-                        gmsaCredentialSpecName:
-                          type: string
-                        runAsUserName:
-                          type: string
-                      type: object
-                  type: object
-                sidecars:
-                  items:
-                    properties:
-                      args:
-                        items:
-                          type: string
-                        type: array
-                      command:
-                        items:
-                          type: string
-                        type: array
-                      env:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            value:
-                              type: string
-                            valueFrom:
-                              properties:
-                                configMapKeyRef:
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  required:
-                                  - key
-                                  type: object
-                                fieldRef:
-                                  properties:
-                                    apiVersion:
-                                      type: string
-                                    fieldPath:
-                                      type: string
-                                  required:
-                                  - fieldPath
-                                  type: object
-                                resourceFieldRef:
-                                  properties:
-                                    containerName:
-                                      type: string
-                                    divisor:
-                                      type: string
-                                    resource:
-                                      type: string
-                                  required:
-                                  - resource
-                                  type: object
-                                secretKeyRef:
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  required:
-                                  - key
-                                  type: object
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      envFrom:
-                        items:
-                          properties:
-                            configMapRef:
-                              properties:
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              type: object
-                            prefix:
-                              type: string
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              type: object
-                          type: object
-                        type: array
-                      image:
-                        type: string
-                      imagePullPolicy:
-                        type: string
-                      lifecycle:
-                        properties:
-                          postStart:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                            type: object
-                          preStop:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                            type: object
-                        type: object
-                      livenessProbe:
-                        properties:
-                          exec:
-                            properties:
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            format: int32
-                            type: integer
-                          httpGet:
-                            properties:
-                              host:
-                                type: string
-                              httpHeaders:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            properties:
-                              host:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          timeoutSeconds:
-                            format: int32
-                            type: integer
-                        type: object
-                      name:
-                        type: string
-                      ports:
-                        items:
-                          properties:
-                            containerPort:
-                              format: int32
-                              type: integer
-                            hostIP:
-                              type: string
-                            hostPort:
-                              format: int32
-                              type: integer
-                            name:
-                              type: string
-                            protocol:
-                              type: string
-                          required:
-                          - containerPort
-                          type: object
-                        type: array
-                      readinessProbe:
-                        properties:
-                          exec:
-                            properties:
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            format: int32
-                            type: integer
-                          httpGet:
-                            properties:
-                              host:
-                                type: string
-                              httpHeaders:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            properties:
-                              host:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          timeoutSeconds:
-                            format: int32
-                            type: integer
-                        type: object
-                      resources:
-                        properties:
-                          limits:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          requests:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        type: object
-                      securityContext:
-                        properties:
-                          allowPrivilegeEscalation:
-                            type: boolean
-                          capabilities:
-                            properties:
-                              add:
-                                items:
-                                  type: string
-                                type: array
-                              drop:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          privileged:
-                            type: boolean
-                          procMount:
-                            type: string
-                          readOnlyRootFilesystem:
-                            type: boolean
-                          runAsGroup:
-                            format: int64
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            format: int64
-                            type: integer
-                          seLinuxOptions:
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                            type: object
-                          windowsOptions:
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              runAsUserName:
-                                type: string
-                            type: object
-                        type: object
-                      startupProbe:
-                        properties:
-                          exec:
-                            properties:
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            format: int32
-                            type: integer
-                          httpGet:
-                            properties:
-                              host:
-                                type: string
-                              httpHeaders:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            properties:
-                              host:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          timeoutSeconds:
-                            format: int32
-                            type: integer
-                        type: object
-                      stdin:
+                      useThreadLocalProducers:
                         type: boolean
-                      stdinOnce:
-                        type: boolean
-                      terminationMessagePath:
-                        type: string
-                      terminationMessagePolicy:
-                        type: string
-                      tty:
-                        type: boolean
-                      volumeDevices:
-                        items:
-                          properties:
-                            devicePath:
-                              type: string
-                            name:
-                              type: string
-                          required:
-                          - devicePath
-                          - name
-                          type: object
-                        type: array
-                      volumeMounts:
-                        items:
-                          properties:
-                            mountPath:
-                              type: string
-                            mountPropagation:
-                              type: string
-                            name:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            subPath:
-                              type: string
-                            subPathExpr:
-                              type: string
-                          required:
-                          - mountPath
-                          - name
-                          type: object
-                        type: array
-                      workingDir:
-                        type: string
-                    required:
-                    - name
                     type: object
-                  type: array
-                terminationGracePeriodSeconds:
-                  format: int64
-                  type: integer
-                tolerations:
-                  items:
+                  sinkSchemaType:
+                    type: string
+                  sinkSerdeClassName:
+                    type: string
+                  topic:
+                    type: string
+                  typeClassName:
+                    type: string
+                type: object
+              pod:
+                properties:
+                  affinity:
                     properties:
-                      effect:
-                        type: string
-                      key:
-                        type: string
-                      operator:
-                        type: string
-                      tolerationSeconds:
-                        format: int64
-                        type: integer
-                      value:
-                        type: string
-                    type: object
-                  type: array
-                volumes:
-                  items:
-                    properties:
-                      awsElasticBlockStore:
+                      nodeAffinity:
                         properties:
-                          fsType:
-                            type: string
-                          partition:
-                            format: int32
-                            type: integer
-                          readOnly:
-                            type: boolean
-                          volumeID:
-                            type: string
-                        required:
-                        - volumeID
-                        type: object
-                      azureDisk:
-                        properties:
-                          cachingMode:
-                            type: string
-                          diskName:
-                            type: string
-                          diskURI:
-                            type: string
-                          fsType:
-                            type: string
-                          kind:
-                            type: string
-                          readOnly:
-                            type: boolean
-                        required:
-                        - diskName
-                        - diskURI
-                        type: object
-                      azureFile:
-                        properties:
-                          readOnly:
-                            type: boolean
-                          secretName:
-                            type: string
-                          shareName:
-                            type: string
-                        required:
-                        - secretName
-                        - shareName
-                        type: object
-                      cephfs:
-                        properties:
-                          monitors:
-                            items:
-                              type: string
-                            type: array
-                          path:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretFile:
-                            type: string
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          user:
-                            type: string
-                        required:
-                        - monitors
-                        type: object
-                      cinder:
-                        properties:
-                          fsType:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          volumeID:
-                            type: string
-                        required:
-                        - volumeID
-                        type: object
-                      configMap:
-                        properties:
-                          defaultMode:
-                            format: int32
-                            type: integer
-                          items:
+                          preferredDuringSchedulingIgnoredDuringExecution:
                             items:
                               properties:
-                                key:
-                                  type: string
-                                mode:
+                                preference:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
                                   format: int32
                                   type: integer
-                                path:
-                                  type: string
                               required:
-                              - key
-                              - path
+                              - preference
+                              - weight
                               type: object
                             type: array
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        type: object
-                      csi:
-                        properties:
-                          driver:
-                            type: string
-                          fsType:
-                            type: string
-                          nodePublishSecretRef:
+                          requiredDuringSchedulingIgnoredDuringExecution:
                             properties:
-                              name:
-                                type: string
+                              nodeSelectorTerms:
+                                items:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
                             type: object
-                          readOnly:
-                            type: boolean
-                          volumeAttributes:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        required:
-                        - driver
                         type: object
-                      downwardAPI:
+                      podAffinity:
                         properties:
-                          defaultMode:
-                            format: int32
-                            type: integer
-                          items:
+                          preferredDuringSchedulingIgnoredDuringExecution:
                             items:
                               properties:
-                                fieldRef:
+                                podAffinityTerm:
                                   properties:
-                                    apiVersion:
-                                      type: string
-                                    fieldPath:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
                                       type: string
                                   required:
-                                  - fieldPath
+                                  - topologyKey
                                   type: object
-                                mode:
+                                weight:
                                   format: int32
                                   type: integer
-                                path:
-                                  type: string
-                                resourceFieldRef:
-                                  properties:
-                                    containerName:
-                                      type: string
-                                    divisor:
-                                      type: string
-                                    resource:
-                                      type: string
-                                  required:
-                                  - resource
-                                  type: object
                               required:
-                              - path
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  type: string
+                              required:
+                              - topologyKey
                               type: object
                             type: array
                         type: object
-                      emptyDir:
+                      podAntiAffinity:
                         properties:
-                          medium:
-                            type: string
-                          sizeLimit:
-                            type: string
-                        type: object
-                      fc:
-                        properties:
-                          fsType:
-                            type: string
-                          lun:
-                            format: int32
-                            type: integer
-                          readOnly:
-                            type: boolean
-                          targetWWNs:
+                          preferredDuringSchedulingIgnoredDuringExecution:
                             items:
-                              type: string
+                              properties:
+                                podAffinityTerm:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
                             type: array
-                          wwids:
+                          requiredDuringSchedulingIgnoredDuringExecution:
                             items:
-                              type: string
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
                             type: array
                         type: object
-                      flexVolume:
-                        properties:
-                          driver:
+                    type: object
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  imagePullSecrets:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  initContainers:
+                    items:
+                      properties:
+                        args:
+                          items:
                             type: string
-                          fsType:
+                          type: array
+                        command:
+                          items:
                             type: string
-                          options:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          readOnly:
-                            type: boolean
-                          secretRef:
+                          type: array
+                        env:
+                          items:
                             properties:
                               name:
                                 type: string
+                              value:
+                                type: string
+                              valueFrom:
+                                properties:
+                                  configMapKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      fieldPath:
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    properties:
+                                      containerName:
+                                        type: string
+                                      divisor:
+                                        type: string
+                                      resource:
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
                             type: object
-                        required:
-                        - driver
-                        type: object
-                      flocker:
+                          type: array
+                        envFrom:
+                          items:
+                            properties:
+                              configMapRef:
+                                properties:
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                type: object
+                              prefix:
+                                type: string
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          type: string
+                        imagePullPolicy:
+                          type: string
+                        lifecycle:
+                          properties:
+                            postStart:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              format: int32
+                              type: integer
+                            httpGet:
+                              properties:
+                                host:
+                                  type: string
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                        readinessProbe:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              format: int32
+                              type: integer
+                            httpGet:
+                              properties:
+                                host:
+                                  type: string
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        securityContext:
+                          properties:
+                            allowPrivilegeEscalation:
+                              type: boolean
+                            capabilities:
+                              properties:
+                                add:
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              type: boolean
+                            procMount:
+                              type: string
+                            readOnlyRootFilesystem:
+                              type: boolean
+                            runAsGroup:
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                              type: object
+                            windowsOptions:
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              format: int32
+                              type: integer
+                            httpGet:
+                              properties:
+                                host:
+                                  type: string
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          type: boolean
+                        stdinOnce:
+                          type: boolean
+                        terminationMessagePath:
+                          type: string
+                        terminationMessagePolicy:
+                          type: string
+                        tty:
+                          type: boolean
+                        volumeDevices:
+                          items:
+                            properties:
+                              devicePath:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                        volumeMounts:
+                          items:
+                            properties:
+                              mountPath:
+                                type: string
+                              mountPropagation:
+                                type: string
+                              name:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              subPath:
+                                type: string
+                              subPathExpr:
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                        workingDir:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  securityContext:
+                    properties:
+                      fsGroup:
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        type: string
+                      runAsGroup:
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        type: boolean
+                      runAsUser:
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
                         properties:
-                          datasetName:
+                          level:
                             type: string
-                          datasetUUID:
-                            type: string
-                        type: object
-                      gcePersistentDisk:
-                        properties:
-                          fsType:
-                            type: string
-                          partition:
-                            format: int32
-                            type: integer
-                          pdName:
-                            type: string
-                          readOnly:
-                            type: boolean
-                        required:
-                        - pdName
-                        type: object
-                      gitRepo:
-                        properties:
-                          directory:
-                            type: string
-                          repository:
-                            type: string
-                          revision:
-                            type: string
-                        required:
-                        - repository
-                        type: object
-                      glusterfs:
-                        properties:
-                          endpoints:
-                            type: string
-                          path:
-                            type: string
-                          readOnly:
-                            type: boolean
-                        required:
-                        - endpoints
-                        - path
-                        type: object
-                      hostPath:
-                        properties:
-                          path:
+                          role:
                             type: string
                           type:
                             type: string
-                        required:
-                        - path
+                          user:
+                            type: string
                         type: object
-                      iscsi:
-                        properties:
-                          chapAuthDiscovery:
-                            type: boolean
-                          chapAuthSession:
-                            type: boolean
-                          fsType:
-                            type: string
-                          initiatorName:
-                            type: string
-                          iqn:
-                            type: string
-                          iscsiInterface:
-                            type: string
-                          lun:
-                            format: int32
-                            type: integer
-                          portals:
-                            items:
+                      supplementalGroups:
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        items:
+                          properties:
+                            name:
                               type: string
-                            type: array
-                          readOnly:
-                            type: boolean
-                          secretRef:
+                            value:
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        properties:
+                          gmsaCredentialSpec:
+                            type: string
+                          gmsaCredentialSpecName:
+                            type: string
+                          runAsUserName:
+                            type: string
+                        type: object
+                    type: object
+                  sidecars:
+                    items:
+                      properties:
+                        args:
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          items:
                             properties:
                               name:
                                 type: string
+                              value:
+                                type: string
+                              valueFrom:
+                                properties:
+                                  configMapKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      fieldPath:
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    properties:
+                                      containerName:
+                                        type: string
+                                      divisor:
+                                        type: string
+                                      resource:
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
                             type: object
-                          targetPortal:
-                            type: string
-                        required:
-                        - iqn
-                        - lun
-                        - targetPortal
-                        type: object
-                      name:
-                        type: string
-                      nfs:
-                        properties:
-                          path:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          server:
-                            type: string
-                        required:
-                        - path
-                        - server
-                        type: object
-                      persistentVolumeClaim:
-                        properties:
-                          claimName:
-                            type: string
-                          readOnly:
-                            type: boolean
-                        required:
-                        - claimName
-                        type: object
-                      photonPersistentDisk:
-                        properties:
-                          fsType:
-                            type: string
-                          pdID:
-                            type: string
-                        required:
-                        - pdID
-                        type: object
-                      portworxVolume:
-                        properties:
-                          fsType:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          volumeID:
-                            type: string
-                        required:
-                        - volumeID
-                        type: object
-                      projected:
-                        properties:
-                          defaultMode:
-                            format: int32
-                            type: integer
-                          sources:
-                            items:
+                          type: array
+                        envFrom:
+                          items:
+                            properties:
+                              configMapRef:
+                                properties:
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                type: object
+                              prefix:
+                                type: string
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          type: string
+                        imagePullPolicy:
+                          type: string
+                        lifecycle:
+                          properties:
+                            postStart:
                               properties:
-                                configMap:
+                                exec:
                                   properties:
-                                    items:
+                                    command:
                                       items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          mode:
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            type: string
-                                        required:
-                                        - key
-                                        - path
-                                        type: object
-                                      type: array
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  type: object
-                                downwardAPI:
-                                  properties:
-                                    items:
-                                      items:
-                                        properties:
-                                          fieldRef:
-                                            properties:
-                                              apiVersion:
-                                                type: string
-                                              fieldPath:
-                                                type: string
-                                            required:
-                                            - fieldPath
-                                            type: object
-                                          mode:
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            type: string
-                                          resourceFieldRef:
-                                            properties:
-                                              containerName:
-                                                type: string
-                                              divisor:
-                                                type: string
-                                              resource:
-                                                type: string
-                                            required:
-                                            - resource
-                                            type: object
-                                        required:
-                                        - path
-                                        type: object
+                                        type: string
                                       type: array
                                   type: object
-                                secret:
+                                httpGet:
                                   properties:
-                                    items:
+                                    host:
+                                      type: string
+                                    httpHeaders:
                                       items:
                                         properties:
-                                          key:
+                                          name:
                                             type: string
-                                          mode:
-                                            format: int32
-                                            type: integer
-                                          path:
+                                          value:
                                             type: string
                                         required:
-                                        - key
-                                        - path
+                                        - name
+                                        - value
                                         type: object
                                       type: array
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  type: object
-                                serviceAccountToken:
-                                  properties:
-                                    audience:
-                                      type: string
-                                    expirationSeconds:
-                                      format: int64
-                                      type: integer
                                     path:
                                       type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
                                   required:
-                                  - path
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
                                   type: object
                               type: object
-                            type: array
-                        required:
-                        - sources
-                        type: object
-                      quobyte:
-                        properties:
-                          group:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          registry:
-                            type: string
-                          tenant:
-                            type: string
-                          user:
-                            type: string
-                          volume:
-                            type: string
-                        required:
-                        - registry
-                        - volume
-                        type: object
-                      rbd:
-                        properties:
-                          fsType:
-                            type: string
-                          image:
-                            type: string
-                          keyring:
-                            type: string
-                          monitors:
-                            items:
-                              type: string
-                            type: array
-                          pool:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          user:
-                            type: string
-                        required:
-                        - image
-                        - monitors
-                        type: object
-                      scaleIO:
-                        properties:
-                          fsType:
-                            type: string
-                          gateway:
-                            type: string
-                          protectionDomain:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          sslEnabled:
-                            type: boolean
-                          storageMode:
-                            type: string
-                          storagePool:
-                            type: string
-                          system:
-                            type: string
-                          volumeName:
-                            type: string
-                        required:
-                        - gateway
-                        - secretRef
-                        - system
-                        type: object
-                      secret:
-                        properties:
-                          defaultMode:
-                            format: int32
-                            type: integer
-                          items:
-                            items:
+                            preStop:
                               properties:
-                                key:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              format: int32
+                              type: integer
+                            httpGet:
+                              properties:
+                                host:
                                   type: string
-                                mode:
-                                  format: int32
-                                  type: integer
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
                                 path:
                                   type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
                               required:
-                              - key
-                              - path
+                              - port
                               type: object
-                            type: array
-                          optional:
-                            type: boolean
-                          secretName:
-                            type: string
-                        type: object
-                      storageos:
-                        properties:
-                          fsType:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretRef:
+                            initialDelaySeconds:
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          type: string
+                        ports:
+                          items:
                             properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
                               name:
                                 type: string
+                              protocol:
+                                type: string
+                            required:
+                            - containerPort
                             type: object
-                          volumeName:
-                            type: string
-                          volumeNamespace:
-                            type: string
-                        type: object
-                      vsphereVolume:
-                        properties:
-                          fsType:
-                            type: string
-                          storagePolicyID:
-                            type: string
-                          storagePolicyName:
-                            type: string
-                          volumePath:
-                            type: string
-                        required:
-                        - volumePath
-                        type: object
-                    required:
-                    - name
+                          type: array
+                        readinessProbe:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              format: int32
+                              type: integer
+                            httpGet:
+                              properties:
+                                host:
+                                  type: string
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        securityContext:
+                          properties:
+                            allowPrivilegeEscalation:
+                              type: boolean
+                            capabilities:
+                              properties:
+                                add:
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              type: boolean
+                            procMount:
+                              type: string
+                            readOnlyRootFilesystem:
+                              type: boolean
+                            runAsGroup:
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                              type: object
+                            windowsOptions:
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              format: int32
+                              type: integer
+                            httpGet:
+                              properties:
+                                host:
+                                  type: string
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          type: boolean
+                        stdinOnce:
+                          type: boolean
+                        terminationMessagePath:
+                          type: string
+                        terminationMessagePolicy:
+                          type: string
+                        tty:
+                          type: boolean
+                        volumeDevices:
+                          items:
+                            properties:
+                              devicePath:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                        volumeMounts:
+                          items:
+                            properties:
+                              mountPath:
+                                type: string
+                              mountPropagation:
+                                type: string
+                              name:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              subPath:
+                                type: string
+                              subPathExpr:
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                        workingDir:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  terminationGracePeriodSeconds:
+                    format: int64
+                    type: integer
+                  tolerations:
+                    items:
+                      properties:
+                        effect:
+                          type: string
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        tolerationSeconds:
+                          format: int64
+                          type: integer
+                        value:
+                          type: string
+                      type: object
+                    type: array
+                  volumes:
+                    items:
+                      properties:
+                        awsElasticBlockStore:
+                          properties:
+                            fsType:
+                              type: string
+                            partition:
+                              format: int32
+                              type: integer
+                            readOnly:
+                              type: boolean
+                            volumeID:
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        azureDisk:
+                          properties:
+                            cachingMode:
+                              type: string
+                            diskName:
+                              type: string
+                            diskURI:
+                              type: string
+                            fsType:
+                              type: string
+                            kind:
+                              type: string
+                            readOnly:
+                              type: boolean
+                          required:
+                          - diskName
+                          - diskURI
+                          type: object
+                        azureFile:
+                          properties:
+                            readOnly:
+                              type: boolean
+                            secretName:
+                              type: string
+                            shareName:
+                              type: string
+                          required:
+                          - secretName
+                          - shareName
+                          type: object
+                        cephfs:
+                          properties:
+                            monitors:
+                              items:
+                                type: string
+                              type: array
+                            path:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            secretFile:
+                              type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            user:
+                              type: string
+                          required:
+                          - monitors
+                          type: object
+                        cinder:
+                          properties:
+                            fsType:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            volumeID:
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        configMap:
+                          properties:
+                            defaultMode:
+                              format: int32
+                              type: integer
+                            items:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  mode:
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            name:
+                              type: string
+                            optional:
+                              type: boolean
+                          type: object
+                        csi:
+                          properties:
+                            driver:
+                              type: string
+                            fsType:
+                              type: string
+                            nodePublishSecretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            readOnly:
+                              type: boolean
+                            volumeAttributes:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        downwardAPI:
+                          properties:
+                            defaultMode:
+                              format: int32
+                              type: integer
+                            items:
+                              items:
+                                properties:
+                                  fieldRef:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      fieldPath:
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  mode:
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    type: string
+                                  resourceFieldRef:
+                                    properties:
+                                      containerName:
+                                        type: string
+                                      divisor:
+                                        type: string
+                                      resource:
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                required:
+                                - path
+                                type: object
+                              type: array
+                          type: object
+                        emptyDir:
+                          properties:
+                            medium:
+                              type: string
+                            sizeLimit:
+                              type: string
+                          type: object
+                        fc:
+                          properties:
+                            fsType:
+                              type: string
+                            lun:
+                              format: int32
+                              type: integer
+                            readOnly:
+                              type: boolean
+                            targetWWNs:
+                              items:
+                                type: string
+                              type: array
+                            wwids:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        flexVolume:
+                          properties:
+                            driver:
+                              type: string
+                            fsType:
+                              type: string
+                            options:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            readOnly:
+                              type: boolean
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        flocker:
+                          properties:
+                            datasetName:
+                              type: string
+                            datasetUUID:
+                              type: string
+                          type: object
+                        gcePersistentDisk:
+                          properties:
+                            fsType:
+                              type: string
+                            partition:
+                              format: int32
+                              type: integer
+                            pdName:
+                              type: string
+                            readOnly:
+                              type: boolean
+                          required:
+                          - pdName
+                          type: object
+                        gitRepo:
+                          properties:
+                            directory:
+                              type: string
+                            repository:
+                              type: string
+                            revision:
+                              type: string
+                          required:
+                          - repository
+                          type: object
+                        glusterfs:
+                          properties:
+                            endpoints:
+                              type: string
+                            path:
+                              type: string
+                            readOnly:
+                              type: boolean
+                          required:
+                          - endpoints
+                          - path
+                          type: object
+                        hostPath:
+                          properties:
+                            path:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        iscsi:
+                          properties:
+                            chapAuthDiscovery:
+                              type: boolean
+                            chapAuthSession:
+                              type: boolean
+                            fsType:
+                              type: string
+                            initiatorName:
+                              type: string
+                            iqn:
+                              type: string
+                            iscsiInterface:
+                              type: string
+                            lun:
+                              format: int32
+                              type: integer
+                            portals:
+                              items:
+                                type: string
+                              type: array
+                            readOnly:
+                              type: boolean
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            targetPortal:
+                              type: string
+                          required:
+                          - iqn
+                          - lun
+                          - targetPortal
+                          type: object
+                        name:
+                          type: string
+                        nfs:
+                          properties:
+                            path:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            server:
+                              type: string
+                          required:
+                          - path
+                          - server
+                          type: object
+                        persistentVolumeClaim:
+                          properties:
+                            claimName:
+                              type: string
+                            readOnly:
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        photonPersistentDisk:
+                          properties:
+                            fsType:
+                              type: string
+                            pdID:
+                              type: string
+                          required:
+                          - pdID
+                          type: object
+                        portworxVolume:
+                          properties:
+                            fsType:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            volumeID:
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        projected:
+                          properties:
+                            defaultMode:
+                              format: int32
+                              type: integer
+                            sources:
+                              items:
+                                properties:
+                                  configMap:
+                                    properties:
+                                      items:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            mode:
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                  downwardAPI:
+                                    properties:
+                                      items:
+                                        items:
+                                          properties:
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            mode:
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              type: string
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  type: string
+                                                resource:
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                          required:
+                                          - path
+                                          type: object
+                                        type: array
+                                    type: object
+                                  secret:
+                                    properties:
+                                      items:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            mode:
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                  serviceAccountToken:
+                                    properties:
+                                      audience:
+                                        type: string
+                                      expirationSeconds:
+                                        format: int64
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                type: object
+                              type: array
+                          required:
+                          - sources
+                          type: object
+                        quobyte:
+                          properties:
+                            group:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            registry:
+                              type: string
+                            tenant:
+                              type: string
+                            user:
+                              type: string
+                            volume:
+                              type: string
+                          required:
+                          - registry
+                          - volume
+                          type: object
+                        rbd:
+                          properties:
+                            fsType:
+                              type: string
+                            image:
+                              type: string
+                            keyring:
+                              type: string
+                            monitors:
+                              items:
+                                type: string
+                              type: array
+                            pool:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            user:
+                              type: string
+                          required:
+                          - image
+                          - monitors
+                          type: object
+                        scaleIO:
+                          properties:
+                            fsType:
+                              type: string
+                            gateway:
+                              type: string
+                            protectionDomain:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            sslEnabled:
+                              type: boolean
+                            storageMode:
+                              type: string
+                            storagePool:
+                              type: string
+                            system:
+                              type: string
+                            volumeName:
+                              type: string
+                          required:
+                          - gateway
+                          - secretRef
+                          - system
+                          type: object
+                        secret:
+                          properties:
+                            defaultMode:
+                              format: int32
+                              type: integer
+                            items:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  mode:
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            optional:
+                              type: boolean
+                            secretName:
+                              type: string
+                          type: object
+                        storageos:
+                          properties:
+                            fsType:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            volumeName:
+                              type: string
+                            volumeNamespace:
+                              type: string
+                          type: object
+                        vsphereVolume:
+                          properties:
+                            fsType:
+                              type: string
+                            storagePolicyID:
+                              type: string
+                            storagePolicyName:
+                              type: string
+                            volumePath:
+                              type: string
+                          required:
+                          - volumePath
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
+              processingGuarantee:
+                type: string
+              pulsar:
+                properties:
+                  authSecret:
+                    type: string
+                  pulsarConfig:
+                    type: string
+                  tlsSecret:
+                    type: string
+                type: object
+              python:
+                properties:
+                  py:
+                    type: string
+                  pyLocation:
+                    type: string
+                type: object
+              replicas:
+                format: int32
+                type: integer
+              resources:
+                properties:
+                  limits:
+                    additionalProperties:
+                      type: string
                     type: object
-                  type: array
-              type: object
-            processingGuarantee:
-              type: string
-            pulsar:
-              properties:
-                authSecret:
-                  type: string
-                pulsarConfig:
-                  type: string
-                tlsSecret:
-                  type: string
-              type: object
-            python:
-              properties:
-                py:
-                  type: string
-                pyLocation:
-                  type: string
-              type: object
-            replicas:
-              format: int32
-              type: integer
-            resources:
-              properties:
-                limits:
-                  additionalProperties:
-                    type: string
+                  requests:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              retainKeyOrdering:
+                type: boolean
+              retainOrdering:
+                type: boolean
+              runtimeFlags:
+                type: string
+              secretsMap:
+                additionalProperties:
+                  properties:
+                    key:
+                      type: string
+                    path:
+                      type: string
                   type: object
-                requests:
-                  additionalProperties:
-                    type: string
+                type: object
+              subscriptionName:
+                type: string
+              subscriptionPosition:
+                type: string
+              tenant:
+                type: string
+              timeout:
+                format: int32
+                type: integer
+              volumeMounts:
+                items:
+                  properties:
+                    mountPath:
+                      type: string
+                    mountPropagation:
+                      type: string
+                    name:
+                      type: string
+                    readOnly:
+                      type: boolean
+                    subPath:
+                      type: string
+                    subPathExpr:
+                      type: string
+                  required:
+                  - mountPath
+                  - name
                   type: object
-              type: object
-            retainKeyOrdering:
-              type: boolean
-            retainOrdering:
-              type: boolean
-            runtimeFlags:
-              type: string
-            secretsMap:
-              additionalProperties:
-                properties:
-                  key:
-                    type: string
-                  path:
-                    type: string
+                type: array
+            type: object
+          status:
+            properties:
+              conditions:
+                additionalProperties:
+                  properties:
+                    action:
+                      type: string
+                    condition:
+                      type: string
+                    status:
+                      type: string
+                  type: object
                 type: object
-              type: object
-            subscriptionName:
-              type: string
-            subscriptionPosition:
-              type: string
-            tenant:
-              type: string
-            timeout:
-              format: int32
-              type: integer
-            volumeMounts:
-              items:
-                properties:
-                  mountPath:
-                    type: string
-                  mountPropagation:
-                    type: string
-                  name:
-                    type: string
-                  readOnly:
-                    type: boolean
-                  subPath:
-                    type: string
-                  subPathExpr:
-                    type: string
-                required:
-                - mountPath
-                - name
-                type: object
-              type: array
-          type: object
-        status:
-          properties:
-            conditions:
-              additionalProperties:
-                properties:
-                  action:
-                    type: string
-                  condition:
-                    type: string
-                  status:
-                    type: string
-                type: object
-              type: object
-            replicas:
-              format: int32
-              type: integer
-            selector:
-              type: string
-          required:
-          - conditions
-          - replicas
-          - selector
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
+              replicas:
+                format: int32
+                type: integer
+              selector:
+                type: string
+            required:
+            - conditions
+            - replicas
+            - selector
+            type: object
+        type: object
 status:
   acceptedNames:
     kind: ""

--- a/charts/function-mesh-operator/crds/compute.functionmesh.io_sinks.yaml
+++ b/charts/function-mesh-operator/crds/compute.functionmesh.io_sinks.yaml
@@ -1,6 +1,5 @@
-
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,2225 +14,2224 @@ spec:
     plural: sinks
     singular: sink
   scope: Namespaced
-  subresources:
-    scale:
-      labelSelectorPath: .status.selector
-      specReplicasPath: .spec.replicas
-      statusReplicasPath: .status.replicas
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            autoAck:
-              type: boolean
-            className:
-              type: string
-            cleanupSubscription:
-              type: boolean
-            clusterName:
-              type: string
-            deadLetterTopic:
-              type: string
-            golang:
-              properties:
-                go:
-                  type: string
-                goLocation:
-                  type: string
-              type: object
-            image:
-              type: string
-            imagePullPolicy:
-              type: string
-            input:
-              properties:
-                customSchemaSources:
-                  additionalProperties:
-                    type: string
-                  type: object
-                customSerdeSources:
-                  additionalProperties:
-                    type: string
-                  type: object
-                sourceSpecs:
-                  additionalProperties:
-                    properties:
-                      consumerProperties:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      cryptoConfig:
-                        properties:
-                          consumerCryptoFailureAction:
-                            type: string
-                          cryptoKeyReaderClassName:
-                            type: string
-                          cryptoKeyReaderConfig:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          cryptoSecrets:
-                            items:
-                              properties:
-                                asVolume:
-                                  type: string
-                                secretKey:
-                                  type: string
-                                secretName:
-                                  type: string
-                              required:
-                              - secretKey
-                              - secretName
-                              type: object
-                            type: array
-                          encryptionKeys:
-                            items:
-                              type: string
-                            type: array
-                          producerCryptoFailureAction:
-                            type: string
-                        type: object
-                      isRegexPattern:
-                        type: boolean
-                      receiverQueueSize:
-                        format: int32
-                        type: integer
-                      schemaProperties:
-                        additionalProperties:
-                          type: string
-                        type: object
-                      schemaType:
-                        type: string
-                      serdeClassname:
-                        type: string
-                    type: object
-                  type: object
-                topicPattern:
-                  type: string
-                topics:
-                  items:
-                    type: string
-                  type: array
-                typeClassName:
-                  type: string
-              type: object
-            java:
-              properties:
-                extraDependenciesDir:
-                  type: string
-                jar:
-                  type: string
-                jarLocation:
-                  type: string
-              type: object
-            logTopic:
-              type: string
-            maxMessageRetry:
-              format: int32
-              type: integer
-            maxReplicas:
-              format: int32
-              type: integer
-            name:
-              type: string
-            negativeAckRedeliveryDelayMs:
-              format: int32
-              type: integer
-            pod:
-              properties:
-                affinity:
-                  properties:
-                    nodeAffinity:
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              preference:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              weight:
-                                format: int32
-                                type: integer
-                            required:
-                            - preference
-                            - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          properties:
-                            nodeSelectorTerms:
-                              items:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              type: array
-                          required:
-                          - nodeSelectorTerms
-                          type: object
-                      type: object
-                    podAffinity:
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              podAffinityTerm:
-                                properties:
-                                  labelSelector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    type: string
-                                required:
-                                - topologyKey
-                                type: object
-                              weight:
-                                format: int32
-                                type: integer
-                            required:
-                            - podAffinityTerm
-                            - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              labelSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              namespaces:
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                    podAntiAffinity:
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              podAffinityTerm:
-                                properties:
-                                  labelSelector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    type: string
-                                required:
-                                - topologyKey
-                                type: object
-                              weight:
-                                format: int32
-                                type: integer
-                            required:
-                            - podAffinityTerm
-                            - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              labelSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              namespaces:
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                  type: object
-                annotations:
-                  additionalProperties:
-                    type: string
-                  type: object
-                imagePullSecrets:
-                  items:
-                    properties:
-                      name:
-                        type: string
-                    type: object
-                  type: array
-                initContainers:
-                  items:
-                    properties:
-                      args:
-                        items:
-                          type: string
-                        type: array
-                      command:
-                        items:
-                          type: string
-                        type: array
-                      env:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            value:
-                              type: string
-                            valueFrom:
-                              properties:
-                                configMapKeyRef:
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  required:
-                                  - key
-                                  type: object
-                                fieldRef:
-                                  properties:
-                                    apiVersion:
-                                      type: string
-                                    fieldPath:
-                                      type: string
-                                  required:
-                                  - fieldPath
-                                  type: object
-                                resourceFieldRef:
-                                  properties:
-                                    containerName:
-                                      type: string
-                                    divisor:
-                                      type: string
-                                    resource:
-                                      type: string
-                                  required:
-                                  - resource
-                                  type: object
-                                secretKeyRef:
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  required:
-                                  - key
-                                  type: object
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      envFrom:
-                        items:
-                          properties:
-                            configMapRef:
-                              properties:
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              type: object
-                            prefix:
-                              type: string
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              type: object
-                          type: object
-                        type: array
-                      image:
-                        type: string
-                      imagePullPolicy:
-                        type: string
-                      lifecycle:
-                        properties:
-                          postStart:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                            type: object
-                          preStop:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                            type: object
-                        type: object
-                      livenessProbe:
-                        properties:
-                          exec:
-                            properties:
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            format: int32
-                            type: integer
-                          httpGet:
-                            properties:
-                              host:
-                                type: string
-                              httpHeaders:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            properties:
-                              host:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          timeoutSeconds:
-                            format: int32
-                            type: integer
-                        type: object
-                      name:
-                        type: string
-                      ports:
-                        items:
-                          properties:
-                            containerPort:
-                              format: int32
-                              type: integer
-                            hostIP:
-                              type: string
-                            hostPort:
-                              format: int32
-                              type: integer
-                            name:
-                              type: string
-                            protocol:
-                              type: string
-                          required:
-                          - containerPort
-                          type: object
-                        type: array
-                      readinessProbe:
-                        properties:
-                          exec:
-                            properties:
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            format: int32
-                            type: integer
-                          httpGet:
-                            properties:
-                              host:
-                                type: string
-                              httpHeaders:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            properties:
-                              host:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          timeoutSeconds:
-                            format: int32
-                            type: integer
-                        type: object
-                      resources:
-                        properties:
-                          limits:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          requests:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        type: object
-                      securityContext:
-                        properties:
-                          allowPrivilegeEscalation:
-                            type: boolean
-                          capabilities:
-                            properties:
-                              add:
-                                items:
-                                  type: string
-                                type: array
-                              drop:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          privileged:
-                            type: boolean
-                          procMount:
-                            type: string
-                          readOnlyRootFilesystem:
-                            type: boolean
-                          runAsGroup:
-                            format: int64
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            format: int64
-                            type: integer
-                          seLinuxOptions:
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                            type: object
-                          windowsOptions:
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              runAsUserName:
-                                type: string
-                            type: object
-                        type: object
-                      startupProbe:
-                        properties:
-                          exec:
-                            properties:
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            format: int32
-                            type: integer
-                          httpGet:
-                            properties:
-                              host:
-                                type: string
-                              httpHeaders:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            properties:
-                              host:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          timeoutSeconds:
-                            format: int32
-                            type: integer
-                        type: object
-                      stdin:
-                        type: boolean
-                      stdinOnce:
-                        type: boolean
-                      terminationMessagePath:
-                        type: string
-                      terminationMessagePolicy:
-                        type: string
-                      tty:
-                        type: boolean
-                      volumeDevices:
-                        items:
-                          properties:
-                            devicePath:
-                              type: string
-                            name:
-                              type: string
-                          required:
-                          - devicePath
-                          - name
-                          type: object
-                        type: array
-                      volumeMounts:
-                        items:
-                          properties:
-                            mountPath:
-                              type: string
-                            mountPropagation:
-                              type: string
-                            name:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            subPath:
-                              type: string
-                            subPathExpr:
-                              type: string
-                          required:
-                          - mountPath
-                          - name
-                          type: object
-                        type: array
-                      workingDir:
-                        type: string
-                    required:
-                    - name
-                    type: object
-                  type: array
-                labels:
-                  additionalProperties:
-                    type: string
-                  type: object
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  type: object
-                securityContext:
-                  properties:
-                    fsGroup:
-                      format: int64
-                      type: integer
-                    fsGroupChangePolicy:
-                      type: string
-                    runAsGroup:
-                      format: int64
-                      type: integer
-                    runAsNonRoot:
-                      type: boolean
-                    runAsUser:
-                      format: int64
-                      type: integer
-                    seLinuxOptions:
-                      properties:
-                        level:
-                          type: string
-                        role:
-                          type: string
-                        type:
-                          type: string
-                        user:
-                          type: string
-                      type: object
-                    supplementalGroups:
-                      items:
-                        format: int64
-                        type: integer
-                      type: array
-                    sysctls:
-                      items:
-                        properties:
-                          name:
-                            type: string
-                          value:
-                            type: string
-                        required:
-                        - name
-                        - value
-                        type: object
-                      type: array
-                    windowsOptions:
-                      properties:
-                        gmsaCredentialSpec:
-                          type: string
-                        gmsaCredentialSpecName:
-                          type: string
-                        runAsUserName:
-                          type: string
-                      type: object
-                  type: object
-                sidecars:
-                  items:
-                    properties:
-                      args:
-                        items:
-                          type: string
-                        type: array
-                      command:
-                        items:
-                          type: string
-                        type: array
-                      env:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            value:
-                              type: string
-                            valueFrom:
-                              properties:
-                                configMapKeyRef:
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  required:
-                                  - key
-                                  type: object
-                                fieldRef:
-                                  properties:
-                                    apiVersion:
-                                      type: string
-                                    fieldPath:
-                                      type: string
-                                  required:
-                                  - fieldPath
-                                  type: object
-                                resourceFieldRef:
-                                  properties:
-                                    containerName:
-                                      type: string
-                                    divisor:
-                                      type: string
-                                    resource:
-                                      type: string
-                                  required:
-                                  - resource
-                                  type: object
-                                secretKeyRef:
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  required:
-                                  - key
-                                  type: object
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      envFrom:
-                        items:
-                          properties:
-                            configMapRef:
-                              properties:
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              type: object
-                            prefix:
-                              type: string
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              type: object
-                          type: object
-                        type: array
-                      image:
-                        type: string
-                      imagePullPolicy:
-                        type: string
-                      lifecycle:
-                        properties:
-                          postStart:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                            type: object
-                          preStop:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                            type: object
-                        type: object
-                      livenessProbe:
-                        properties:
-                          exec:
-                            properties:
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            format: int32
-                            type: integer
-                          httpGet:
-                            properties:
-                              host:
-                                type: string
-                              httpHeaders:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            properties:
-                              host:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          timeoutSeconds:
-                            format: int32
-                            type: integer
-                        type: object
-                      name:
-                        type: string
-                      ports:
-                        items:
-                          properties:
-                            containerPort:
-                              format: int32
-                              type: integer
-                            hostIP:
-                              type: string
-                            hostPort:
-                              format: int32
-                              type: integer
-                            name:
-                              type: string
-                            protocol:
-                              type: string
-                          required:
-                          - containerPort
-                          type: object
-                        type: array
-                      readinessProbe:
-                        properties:
-                          exec:
-                            properties:
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            format: int32
-                            type: integer
-                          httpGet:
-                            properties:
-                              host:
-                                type: string
-                              httpHeaders:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            properties:
-                              host:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          timeoutSeconds:
-                            format: int32
-                            type: integer
-                        type: object
-                      resources:
-                        properties:
-                          limits:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          requests:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        type: object
-                      securityContext:
-                        properties:
-                          allowPrivilegeEscalation:
-                            type: boolean
-                          capabilities:
-                            properties:
-                              add:
-                                items:
-                                  type: string
-                                type: array
-                              drop:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          privileged:
-                            type: boolean
-                          procMount:
-                            type: string
-                          readOnlyRootFilesystem:
-                            type: boolean
-                          runAsGroup:
-                            format: int64
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            format: int64
-                            type: integer
-                          seLinuxOptions:
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                            type: object
-                          windowsOptions:
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              runAsUserName:
-                                type: string
-                            type: object
-                        type: object
-                      startupProbe:
-                        properties:
-                          exec:
-                            properties:
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            format: int32
-                            type: integer
-                          httpGet:
-                            properties:
-                              host:
-                                type: string
-                              httpHeaders:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            properties:
-                              host:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          timeoutSeconds:
-                            format: int32
-                            type: integer
-                        type: object
-                      stdin:
-                        type: boolean
-                      stdinOnce:
-                        type: boolean
-                      terminationMessagePath:
-                        type: string
-                      terminationMessagePolicy:
-                        type: string
-                      tty:
-                        type: boolean
-                      volumeDevices:
-                        items:
-                          properties:
-                            devicePath:
-                              type: string
-                            name:
-                              type: string
-                          required:
-                          - devicePath
-                          - name
-                          type: object
-                        type: array
-                      volumeMounts:
-                        items:
-                          properties:
-                            mountPath:
-                              type: string
-                            mountPropagation:
-                              type: string
-                            name:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            subPath:
-                              type: string
-                            subPathExpr:
-                              type: string
-                          required:
-                          - mountPath
-                          - name
-                          type: object
-                        type: array
-                      workingDir:
-                        type: string
-                    required:
-                    - name
-                    type: object
-                  type: array
-                terminationGracePeriodSeconds:
-                  format: int64
-                  type: integer
-                tolerations:
-                  items:
-                    properties:
-                      effect:
-                        type: string
-                      key:
-                        type: string
-                      operator:
-                        type: string
-                      tolerationSeconds:
-                        format: int64
-                        type: integer
-                      value:
-                        type: string
-                    type: object
-                  type: array
-                volumes:
-                  items:
-                    properties:
-                      awsElasticBlockStore:
-                        properties:
-                          fsType:
-                            type: string
-                          partition:
-                            format: int32
-                            type: integer
-                          readOnly:
-                            type: boolean
-                          volumeID:
-                            type: string
-                        required:
-                        - volumeID
-                        type: object
-                      azureDisk:
-                        properties:
-                          cachingMode:
-                            type: string
-                          diskName:
-                            type: string
-                          diskURI:
-                            type: string
-                          fsType:
-                            type: string
-                          kind:
-                            type: string
-                          readOnly:
-                            type: boolean
-                        required:
-                        - diskName
-                        - diskURI
-                        type: object
-                      azureFile:
-                        properties:
-                          readOnly:
-                            type: boolean
-                          secretName:
-                            type: string
-                          shareName:
-                            type: string
-                        required:
-                        - secretName
-                        - shareName
-                        type: object
-                      cephfs:
-                        properties:
-                          monitors:
-                            items:
-                              type: string
-                            type: array
-                          path:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretFile:
-                            type: string
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          user:
-                            type: string
-                        required:
-                        - monitors
-                        type: object
-                      cinder:
-                        properties:
-                          fsType:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          volumeID:
-                            type: string
-                        required:
-                        - volumeID
-                        type: object
-                      configMap:
-                        properties:
-                          defaultMode:
-                            format: int32
-                            type: integer
-                          items:
-                            items:
-                              properties:
-                                key:
-                                  type: string
-                                mode:
-                                  format: int32
-                                  type: integer
-                                path:
-                                  type: string
-                              required:
-                              - key
-                              - path
-                              type: object
-                            type: array
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        type: object
-                      csi:
-                        properties:
-                          driver:
-                            type: string
-                          fsType:
-                            type: string
-                          nodePublishSecretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          readOnly:
-                            type: boolean
-                          volumeAttributes:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        required:
-                        - driver
-                        type: object
-                      downwardAPI:
-                        properties:
-                          defaultMode:
-                            format: int32
-                            type: integer
-                          items:
-                            items:
-                              properties:
-                                fieldRef:
-                                  properties:
-                                    apiVersion:
-                                      type: string
-                                    fieldPath:
-                                      type: string
-                                  required:
-                                  - fieldPath
-                                  type: object
-                                mode:
-                                  format: int32
-                                  type: integer
-                                path:
-                                  type: string
-                                resourceFieldRef:
-                                  properties:
-                                    containerName:
-                                      type: string
-                                    divisor:
-                                      type: string
-                                    resource:
-                                      type: string
-                                  required:
-                                  - resource
-                                  type: object
-                              required:
-                              - path
-                              type: object
-                            type: array
-                        type: object
-                      emptyDir:
-                        properties:
-                          medium:
-                            type: string
-                          sizeLimit:
-                            type: string
-                        type: object
-                      fc:
-                        properties:
-                          fsType:
-                            type: string
-                          lun:
-                            format: int32
-                            type: integer
-                          readOnly:
-                            type: boolean
-                          targetWWNs:
-                            items:
-                              type: string
-                            type: array
-                          wwids:
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      flexVolume:
-                        properties:
-                          driver:
-                            type: string
-                          fsType:
-                            type: string
-                          options:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                        required:
-                        - driver
-                        type: object
-                      flocker:
-                        properties:
-                          datasetName:
-                            type: string
-                          datasetUUID:
-                            type: string
-                        type: object
-                      gcePersistentDisk:
-                        properties:
-                          fsType:
-                            type: string
-                          partition:
-                            format: int32
-                            type: integer
-                          pdName:
-                            type: string
-                          readOnly:
-                            type: boolean
-                        required:
-                        - pdName
-                        type: object
-                      gitRepo:
-                        properties:
-                          directory:
-                            type: string
-                          repository:
-                            type: string
-                          revision:
-                            type: string
-                        required:
-                        - repository
-                        type: object
-                      glusterfs:
-                        properties:
-                          endpoints:
-                            type: string
-                          path:
-                            type: string
-                          readOnly:
-                            type: boolean
-                        required:
-                        - endpoints
-                        - path
-                        type: object
-                      hostPath:
-                        properties:
-                          path:
-                            type: string
-                          type:
-                            type: string
-                        required:
-                        - path
-                        type: object
-                      iscsi:
-                        properties:
-                          chapAuthDiscovery:
-                            type: boolean
-                          chapAuthSession:
-                            type: boolean
-                          fsType:
-                            type: string
-                          initiatorName:
-                            type: string
-                          iqn:
-                            type: string
-                          iscsiInterface:
-                            type: string
-                          lun:
-                            format: int32
-                            type: integer
-                          portals:
-                            items:
-                              type: string
-                            type: array
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          targetPortal:
-                            type: string
-                        required:
-                        - iqn
-                        - lun
-                        - targetPortal
-                        type: object
-                      name:
-                        type: string
-                      nfs:
-                        properties:
-                          path:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          server:
-                            type: string
-                        required:
-                        - path
-                        - server
-                        type: object
-                      persistentVolumeClaim:
-                        properties:
-                          claimName:
-                            type: string
-                          readOnly:
-                            type: boolean
-                        required:
-                        - claimName
-                        type: object
-                      photonPersistentDisk:
-                        properties:
-                          fsType:
-                            type: string
-                          pdID:
-                            type: string
-                        required:
-                        - pdID
-                        type: object
-                      portworxVolume:
-                        properties:
-                          fsType:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          volumeID:
-                            type: string
-                        required:
-                        - volumeID
-                        type: object
-                      projected:
-                        properties:
-                          defaultMode:
-                            format: int32
-                            type: integer
-                          sources:
-                            items:
-                              properties:
-                                configMap:
-                                  properties:
-                                    items:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          mode:
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            type: string
-                                        required:
-                                        - key
-                                        - path
-                                        type: object
-                                      type: array
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  type: object
-                                downwardAPI:
-                                  properties:
-                                    items:
-                                      items:
-                                        properties:
-                                          fieldRef:
-                                            properties:
-                                              apiVersion:
-                                                type: string
-                                              fieldPath:
-                                                type: string
-                                            required:
-                                            - fieldPath
-                                            type: object
-                                          mode:
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            type: string
-                                          resourceFieldRef:
-                                            properties:
-                                              containerName:
-                                                type: string
-                                              divisor:
-                                                type: string
-                                              resource:
-                                                type: string
-                                            required:
-                                            - resource
-                                            type: object
-                                        required:
-                                        - path
-                                        type: object
-                                      type: array
-                                  type: object
-                                secret:
-                                  properties:
-                                    items:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          mode:
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            type: string
-                                        required:
-                                        - key
-                                        - path
-                                        type: object
-                                      type: array
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  type: object
-                                serviceAccountToken:
-                                  properties:
-                                    audience:
-                                      type: string
-                                    expirationSeconds:
-                                      format: int64
-                                      type: integer
-                                    path:
-                                      type: string
-                                  required:
-                                  - path
-                                  type: object
-                              type: object
-                            type: array
-                        required:
-                        - sources
-                        type: object
-                      quobyte:
-                        properties:
-                          group:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          registry:
-                            type: string
-                          tenant:
-                            type: string
-                          user:
-                            type: string
-                          volume:
-                            type: string
-                        required:
-                        - registry
-                        - volume
-                        type: object
-                      rbd:
-                        properties:
-                          fsType:
-                            type: string
-                          image:
-                            type: string
-                          keyring:
-                            type: string
-                          monitors:
-                            items:
-                              type: string
-                            type: array
-                          pool:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          user:
-                            type: string
-                        required:
-                        - image
-                        - monitors
-                        type: object
-                      scaleIO:
-                        properties:
-                          fsType:
-                            type: string
-                          gateway:
-                            type: string
-                          protectionDomain:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          sslEnabled:
-                            type: boolean
-                          storageMode:
-                            type: string
-                          storagePool:
-                            type: string
-                          system:
-                            type: string
-                          volumeName:
-                            type: string
-                        required:
-                        - gateway
-                        - secretRef
-                        - system
-                        type: object
-                      secret:
-                        properties:
-                          defaultMode:
-                            format: int32
-                            type: integer
-                          items:
-                            items:
-                              properties:
-                                key:
-                                  type: string
-                                mode:
-                                  format: int32
-                                  type: integer
-                                path:
-                                  type: string
-                              required:
-                              - key
-                              - path
-                              type: object
-                            type: array
-                          optional:
-                            type: boolean
-                          secretName:
-                            type: string
-                        type: object
-                      storageos:
-                        properties:
-                          fsType:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          volumeName:
-                            type: string
-                          volumeNamespace:
-                            type: string
-                        type: object
-                      vsphereVolume:
-                        properties:
-                          fsType:
-                            type: string
-                          storagePolicyID:
-                            type: string
-                          storagePolicyName:
-                            type: string
-                          volumePath:
-                            type: string
-                        required:
-                        - volumePath
-                        type: object
-                    required:
-                    - name
-                    type: object
-                  type: array
-              type: object
-            processingGuarantee:
-              type: string
-            pulsar:
-              properties:
-                authSecret:
-                  type: string
-                pulsarConfig:
-                  type: string
-                tlsSecret:
-                  type: string
-              type: object
-            python:
-              properties:
-                py:
-                  type: string
-                pyLocation:
-                  type: string
-              type: object
-            replicas:
-              format: int32
-              type: integer
-            resources:
-              properties:
-                limits:
-                  additionalProperties:
-                    type: string
-                  type: object
-                requests:
-                  additionalProperties:
-                    type: string
-                  type: object
-              type: object
-            retainOrdering:
-              type: boolean
-            runtimeFlags:
-              type: string
-            secretsMap:
-              additionalProperties:
-                properties:
-                  key:
-                    type: string
-                  path:
-                    type: string
-                type: object
-              type: object
-            sinkConfig:
-              additionalProperties:
-                type: string
-              type: object
-            sinkType:
-              type: string
-            subscriptionName:
-              type: string
-            subscriptionPosition:
-              type: string
-            tenant:
-              type: string
-            timeout:
-              format: int32
-              type: integer
-            volumeMounts:
-              items:
-                properties:
-                  mountPath:
-                    type: string
-                  mountPropagation:
-                    type: string
-                  name:
-                    type: string
-                  readOnly:
-                    type: boolean
-                  subPath:
-                    type: string
-                  subPathExpr:
-                    type: string
-                required:
-                - mountPath
-                - name
-                type: object
-              type: array
-          type: object
-        status:
-          properties:
-            conditions:
-              additionalProperties:
-                properties:
-                  action:
-                    type: string
-                  condition:
-                    type: string
-                  status:
-                    type: string
-                type: object
-              type: object
-            replicas:
-              format: int32
-              type: integer
-            selector:
-              type: string
-          required:
-          - conditions
-          - replicas
-          - selector
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              autoAck:
+                type: boolean
+              className:
+                type: string
+              cleanupSubscription:
+                type: boolean
+              clusterName:
+                type: string
+              deadLetterTopic:
+                type: string
+              golang:
+                properties:
+                  go:
+                    type: string
+                  goLocation:
+                    type: string
+                type: object
+              image:
+                type: string
+              imagePullPolicy:
+                type: string
+              input:
+                properties:
+                  customSchemaSources:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  customSerdeSources:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  sourceSpecs:
+                    additionalProperties:
+                      properties:
+                        consumerProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        cryptoConfig:
+                          properties:
+                            consumerCryptoFailureAction:
+                              type: string
+                            cryptoKeyReaderClassName:
+                              type: string
+                            cryptoKeyReaderConfig:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            cryptoSecrets:
+                              items:
+                                properties:
+                                  asVolume:
+                                    type: string
+                                  secretKey:
+                                    type: string
+                                  secretName:
+                                    type: string
+                                required:
+                                - secretKey
+                                - secretName
+                                type: object
+                              type: array
+                            encryptionKeys:
+                              items:
+                                type: string
+                              type: array
+                            producerCryptoFailureAction:
+                              type: string
+                          type: object
+                        isRegexPattern:
+                          type: boolean
+                        receiverQueueSize:
+                          format: int32
+                          type: integer
+                        schemaProperties:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        schemaType:
+                          type: string
+                        serdeClassname:
+                          type: string
+                      type: object
+                    type: object
+                  topicPattern:
+                    type: string
+                  topics:
+                    items:
+                      type: string
+                    type: array
+                  typeClassName:
+                    type: string
+                type: object
+              java:
+                properties:
+                  extraDependenciesDir:
+                    type: string
+                  jar:
+                    type: string
+                  jarLocation:
+                    type: string
+                type: object
+              logTopic:
+                type: string
+              maxMessageRetry:
+                format: int32
+                type: integer
+              maxReplicas:
+                format: int32
+                type: integer
+              name:
+                type: string
+              negativeAckRedeliveryDelayMs:
+                format: int32
+                type: integer
+              pod:
+                properties:
+                  affinity:
+                    properties:
+                      nodeAffinity:
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                preference:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            properties:
+                              nodeSelectorTerms:
+                                items:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                podAffinityTerm:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                podAffinityTerm:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  imagePullSecrets:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  initContainers:
+                    items:
+                      properties:
+                        args:
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                              valueFrom:
+                                properties:
+                                  configMapKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      fieldPath:
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    properties:
+                                      containerName:
+                                        type: string
+                                      divisor:
+                                        type: string
+                                      resource:
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        envFrom:
+                          items:
+                            properties:
+                              configMapRef:
+                                properties:
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                type: object
+                              prefix:
+                                type: string
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          type: string
+                        imagePullPolicy:
+                          type: string
+                        lifecycle:
+                          properties:
+                            postStart:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              format: int32
+                              type: integer
+                            httpGet:
+                              properties:
+                                host:
+                                  type: string
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                        readinessProbe:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              format: int32
+                              type: integer
+                            httpGet:
+                              properties:
+                                host:
+                                  type: string
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        securityContext:
+                          properties:
+                            allowPrivilegeEscalation:
+                              type: boolean
+                            capabilities:
+                              properties:
+                                add:
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              type: boolean
+                            procMount:
+                              type: string
+                            readOnlyRootFilesystem:
+                              type: boolean
+                            runAsGroup:
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                              type: object
+                            windowsOptions:
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              format: int32
+                              type: integer
+                            httpGet:
+                              properties:
+                                host:
+                                  type: string
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          type: boolean
+                        stdinOnce:
+                          type: boolean
+                        terminationMessagePath:
+                          type: string
+                        terminationMessagePolicy:
+                          type: string
+                        tty:
+                          type: boolean
+                        volumeDevices:
+                          items:
+                            properties:
+                              devicePath:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                        volumeMounts:
+                          items:
+                            properties:
+                              mountPath:
+                                type: string
+                              mountPropagation:
+                                type: string
+                              name:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              subPath:
+                                type: string
+                              subPathExpr:
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                        workingDir:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  securityContext:
+                    properties:
+                      fsGroup:
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        type: string
+                      runAsGroup:
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        type: boolean
+                      runAsUser:
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        properties:
+                          level:
+                            type: string
+                          role:
+                            type: string
+                          type:
+                            type: string
+                          user:
+                            type: string
+                        type: object
+                      supplementalGroups:
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        properties:
+                          gmsaCredentialSpec:
+                            type: string
+                          gmsaCredentialSpecName:
+                            type: string
+                          runAsUserName:
+                            type: string
+                        type: object
+                    type: object
+                  sidecars:
+                    items:
+                      properties:
+                        args:
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                              valueFrom:
+                                properties:
+                                  configMapKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      fieldPath:
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    properties:
+                                      containerName:
+                                        type: string
+                                      divisor:
+                                        type: string
+                                      resource:
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        envFrom:
+                          items:
+                            properties:
+                              configMapRef:
+                                properties:
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                type: object
+                              prefix:
+                                type: string
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          type: string
+                        imagePullPolicy:
+                          type: string
+                        lifecycle:
+                          properties:
+                            postStart:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              format: int32
+                              type: integer
+                            httpGet:
+                              properties:
+                                host:
+                                  type: string
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                        readinessProbe:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              format: int32
+                              type: integer
+                            httpGet:
+                              properties:
+                                host:
+                                  type: string
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        securityContext:
+                          properties:
+                            allowPrivilegeEscalation:
+                              type: boolean
+                            capabilities:
+                              properties:
+                                add:
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              type: boolean
+                            procMount:
+                              type: string
+                            readOnlyRootFilesystem:
+                              type: boolean
+                            runAsGroup:
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                              type: object
+                            windowsOptions:
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              format: int32
+                              type: integer
+                            httpGet:
+                              properties:
+                                host:
+                                  type: string
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          type: boolean
+                        stdinOnce:
+                          type: boolean
+                        terminationMessagePath:
+                          type: string
+                        terminationMessagePolicy:
+                          type: string
+                        tty:
+                          type: boolean
+                        volumeDevices:
+                          items:
+                            properties:
+                              devicePath:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                        volumeMounts:
+                          items:
+                            properties:
+                              mountPath:
+                                type: string
+                              mountPropagation:
+                                type: string
+                              name:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              subPath:
+                                type: string
+                              subPathExpr:
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                        workingDir:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  terminationGracePeriodSeconds:
+                    format: int64
+                    type: integer
+                  tolerations:
+                    items:
+                      properties:
+                        effect:
+                          type: string
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        tolerationSeconds:
+                          format: int64
+                          type: integer
+                        value:
+                          type: string
+                      type: object
+                    type: array
+                  volumes:
+                    items:
+                      properties:
+                        awsElasticBlockStore:
+                          properties:
+                            fsType:
+                              type: string
+                            partition:
+                              format: int32
+                              type: integer
+                            readOnly:
+                              type: boolean
+                            volumeID:
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        azureDisk:
+                          properties:
+                            cachingMode:
+                              type: string
+                            diskName:
+                              type: string
+                            diskURI:
+                              type: string
+                            fsType:
+                              type: string
+                            kind:
+                              type: string
+                            readOnly:
+                              type: boolean
+                          required:
+                          - diskName
+                          - diskURI
+                          type: object
+                        azureFile:
+                          properties:
+                            readOnly:
+                              type: boolean
+                            secretName:
+                              type: string
+                            shareName:
+                              type: string
+                          required:
+                          - secretName
+                          - shareName
+                          type: object
+                        cephfs:
+                          properties:
+                            monitors:
+                              items:
+                                type: string
+                              type: array
+                            path:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            secretFile:
+                              type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            user:
+                              type: string
+                          required:
+                          - monitors
+                          type: object
+                        cinder:
+                          properties:
+                            fsType:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            volumeID:
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        configMap:
+                          properties:
+                            defaultMode:
+                              format: int32
+                              type: integer
+                            items:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  mode:
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            name:
+                              type: string
+                            optional:
+                              type: boolean
+                          type: object
+                        csi:
+                          properties:
+                            driver:
+                              type: string
+                            fsType:
+                              type: string
+                            nodePublishSecretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            readOnly:
+                              type: boolean
+                            volumeAttributes:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        downwardAPI:
+                          properties:
+                            defaultMode:
+                              format: int32
+                              type: integer
+                            items:
+                              items:
+                                properties:
+                                  fieldRef:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      fieldPath:
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  mode:
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    type: string
+                                  resourceFieldRef:
+                                    properties:
+                                      containerName:
+                                        type: string
+                                      divisor:
+                                        type: string
+                                      resource:
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                required:
+                                - path
+                                type: object
+                              type: array
+                          type: object
+                        emptyDir:
+                          properties:
+                            medium:
+                              type: string
+                            sizeLimit:
+                              type: string
+                          type: object
+                        fc:
+                          properties:
+                            fsType:
+                              type: string
+                            lun:
+                              format: int32
+                              type: integer
+                            readOnly:
+                              type: boolean
+                            targetWWNs:
+                              items:
+                                type: string
+                              type: array
+                            wwids:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        flexVolume:
+                          properties:
+                            driver:
+                              type: string
+                            fsType:
+                              type: string
+                            options:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            readOnly:
+                              type: boolean
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        flocker:
+                          properties:
+                            datasetName:
+                              type: string
+                            datasetUUID:
+                              type: string
+                          type: object
+                        gcePersistentDisk:
+                          properties:
+                            fsType:
+                              type: string
+                            partition:
+                              format: int32
+                              type: integer
+                            pdName:
+                              type: string
+                            readOnly:
+                              type: boolean
+                          required:
+                          - pdName
+                          type: object
+                        gitRepo:
+                          properties:
+                            directory:
+                              type: string
+                            repository:
+                              type: string
+                            revision:
+                              type: string
+                          required:
+                          - repository
+                          type: object
+                        glusterfs:
+                          properties:
+                            endpoints:
+                              type: string
+                            path:
+                              type: string
+                            readOnly:
+                              type: boolean
+                          required:
+                          - endpoints
+                          - path
+                          type: object
+                        hostPath:
+                          properties:
+                            path:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        iscsi:
+                          properties:
+                            chapAuthDiscovery:
+                              type: boolean
+                            chapAuthSession:
+                              type: boolean
+                            fsType:
+                              type: string
+                            initiatorName:
+                              type: string
+                            iqn:
+                              type: string
+                            iscsiInterface:
+                              type: string
+                            lun:
+                              format: int32
+                              type: integer
+                            portals:
+                              items:
+                                type: string
+                              type: array
+                            readOnly:
+                              type: boolean
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            targetPortal:
+                              type: string
+                          required:
+                          - iqn
+                          - lun
+                          - targetPortal
+                          type: object
+                        name:
+                          type: string
+                        nfs:
+                          properties:
+                            path:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            server:
+                              type: string
+                          required:
+                          - path
+                          - server
+                          type: object
+                        persistentVolumeClaim:
+                          properties:
+                            claimName:
+                              type: string
+                            readOnly:
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        photonPersistentDisk:
+                          properties:
+                            fsType:
+                              type: string
+                            pdID:
+                              type: string
+                          required:
+                          - pdID
+                          type: object
+                        portworxVolume:
+                          properties:
+                            fsType:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            volumeID:
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        projected:
+                          properties:
+                            defaultMode:
+                              format: int32
+                              type: integer
+                            sources:
+                              items:
+                                properties:
+                                  configMap:
+                                    properties:
+                                      items:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            mode:
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                  downwardAPI:
+                                    properties:
+                                      items:
+                                        items:
+                                          properties:
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            mode:
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              type: string
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  type: string
+                                                resource:
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                          required:
+                                          - path
+                                          type: object
+                                        type: array
+                                    type: object
+                                  secret:
+                                    properties:
+                                      items:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            mode:
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                  serviceAccountToken:
+                                    properties:
+                                      audience:
+                                        type: string
+                                      expirationSeconds:
+                                        format: int64
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                type: object
+                              type: array
+                          required:
+                          - sources
+                          type: object
+                        quobyte:
+                          properties:
+                            group:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            registry:
+                              type: string
+                            tenant:
+                              type: string
+                            user:
+                              type: string
+                            volume:
+                              type: string
+                          required:
+                          - registry
+                          - volume
+                          type: object
+                        rbd:
+                          properties:
+                            fsType:
+                              type: string
+                            image:
+                              type: string
+                            keyring:
+                              type: string
+                            monitors:
+                              items:
+                                type: string
+                              type: array
+                            pool:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            user:
+                              type: string
+                          required:
+                          - image
+                          - monitors
+                          type: object
+                        scaleIO:
+                          properties:
+                            fsType:
+                              type: string
+                            gateway:
+                              type: string
+                            protectionDomain:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            sslEnabled:
+                              type: boolean
+                            storageMode:
+                              type: string
+                            storagePool:
+                              type: string
+                            system:
+                              type: string
+                            volumeName:
+                              type: string
+                          required:
+                          - gateway
+                          - secretRef
+                          - system
+                          type: object
+                        secret:
+                          properties:
+                            defaultMode:
+                              format: int32
+                              type: integer
+                            items:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  mode:
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            optional:
+                              type: boolean
+                            secretName:
+                              type: string
+                          type: object
+                        storageos:
+                          properties:
+                            fsType:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            volumeName:
+                              type: string
+                            volumeNamespace:
+                              type: string
+                          type: object
+                        vsphereVolume:
+                          properties:
+                            fsType:
+                              type: string
+                            storagePolicyID:
+                              type: string
+                            storagePolicyName:
+                              type: string
+                            volumePath:
+                              type: string
+                          required:
+                          - volumePath
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
+              processingGuarantee:
+                type: string
+              pulsar:
+                properties:
+                  authSecret:
+                    type: string
+                  pulsarConfig:
+                    type: string
+                  tlsSecret:
+                    type: string
+                type: object
+              python:
+                properties:
+                  py:
+                    type: string
+                  pyLocation:
+                    type: string
+                type: object
+              replicas:
+                format: int32
+                type: integer
+              resources:
+                properties:
+                  limits:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  requests:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              retainOrdering:
+                type: boolean
+              runtimeFlags:
+                type: string
+              secretsMap:
+                additionalProperties:
+                  properties:
+                    key:
+                      type: string
+                    path:
+                      type: string
+                  type: object
+                type: object
+              sinkConfig:
+                additionalProperties:
+                  type: string
+                type: object
+              sinkType:
+                type: string
+              subscriptionName:
+                type: string
+              subscriptionPosition:
+                type: string
+              tenant:
+                type: string
+              timeout:
+                format: int32
+                type: integer
+              volumeMounts:
+                items:
+                  properties:
+                    mountPath:
+                      type: string
+                    mountPropagation:
+                      type: string
+                    name:
+                      type: string
+                    readOnly:
+                      type: boolean
+                    subPath:
+                      type: string
+                    subPathExpr:
+                      type: string
+                  required:
+                  - mountPath
+                  - name
+                  type: object
+                type: array
+            type: object
+          status:
+            properties:
+              conditions:
+                additionalProperties:
+                  properties:
+                    action:
+                      type: string
+                    condition:
+                      type: string
+                    status:
+                      type: string
+                  type: object
+                type: object
+              replicas:
+                format: int32
+                type: integer
+              selector:
+                type: string
+            required:
+            - conditions
+            - replicas
+            - selector
+            type: object
+        type: object
 status:
   acceptedNames:
     kind: ""

--- a/charts/function-mesh-operator/crds/compute.functionmesh.io_sources.yaml
+++ b/charts/function-mesh-operator/crds/compute.functionmesh.io_sources.yaml
@@ -1,6 +1,5 @@
-
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,2191 +14,2190 @@ spec:
     plural: sources
     singular: source
   scope: Namespaced
-  subresources:
-    scale:
-      labelSelectorPath: .status.selector
-      specReplicasPath: .spec.replicas
-      statusReplicasPath: .status.replicas
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            className:
-              type: string
-            clusterName:
-              type: string
-            golang:
-              properties:
-                go:
-                  type: string
-                goLocation:
-                  type: string
-              type: object
-            image:
-              type: string
-            imagePullPolicy:
-              type: string
-            java:
-              properties:
-                extraDependenciesDir:
-                  type: string
-                jar:
-                  type: string
-                jarLocation:
-                  type: string
-              type: object
-            logTopic:
-              type: string
-            maxReplicas:
-              format: int32
-              type: integer
-            name:
-              type: string
-            output:
-              properties:
-                customSchemaSinks:
-                  additionalProperties:
-                    type: string
-                  type: object
-                producerConf:
-                  properties:
-                    batchBuilder:
-                      type: string
-                    cryptoConfig:
-                      properties:
-                        consumerCryptoFailureAction:
-                          type: string
-                        cryptoKeyReaderClassName:
-                          type: string
-                        cryptoKeyReaderConfig:
-                          additionalProperties:
-                            type: string
-                          type: object
-                        cryptoSecrets:
-                          items:
-                            properties:
-                              asVolume:
-                                type: string
-                              secretKey:
-                                type: string
-                              secretName:
-                                type: string
-                            required:
-                            - secretKey
-                            - secretName
-                            type: object
-                          type: array
-                        encryptionKeys:
-                          items:
-                            type: string
-                          type: array
-                        producerCryptoFailureAction:
-                          type: string
-                      type: object
-                    maxPendingMessages:
-                      format: int32
-                      type: integer
-                    maxPendingMessagesAcrossPartitions:
-                      format: int32
-                      type: integer
-                    useThreadLocalProducers:
-                      type: boolean
-                  type: object
-                sinkSchemaType:
-                  type: string
-                sinkSerdeClassName:
-                  type: string
-                topic:
-                  type: string
-                typeClassName:
-                  type: string
-              type: object
-            pod:
-              properties:
-                affinity:
-                  properties:
-                    nodeAffinity:
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              preference:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              weight:
-                                format: int32
-                                type: integer
-                            required:
-                            - preference
-                            - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          properties:
-                            nodeSelectorTerms:
-                              items:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              type: array
-                          required:
-                          - nodeSelectorTerms
-                          type: object
-                      type: object
-                    podAffinity:
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              podAffinityTerm:
-                                properties:
-                                  labelSelector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    type: string
-                                required:
-                                - topologyKey
-                                type: object
-                              weight:
-                                format: int32
-                                type: integer
-                            required:
-                            - podAffinityTerm
-                            - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              labelSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              namespaces:
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                    podAntiAffinity:
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              podAffinityTerm:
-                                properties:
-                                  labelSelector:
-                                    properties:
-                                      matchExpressions:
-                                        items:
-                                          properties:
-                                            key:
-                                              type: string
-                                            operator:
-                                              type: string
-                                            values:
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                          - key
-                                          - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    type: string
-                                required:
-                                - topologyKey
-                                type: object
-                              weight:
-                                format: int32
-                                type: integer
-                            required:
-                            - podAffinityTerm
-                            - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          items:
-                            properties:
-                              labelSelector:
-                                properties:
-                                  matchExpressions:
-                                    items:
-                                      properties:
-                                        key:
-                                          type: string
-                                        operator:
-                                          type: string
-                                        values:
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                      - key
-                                      - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    type: object
-                                type: object
-                              namespaces:
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                type: string
-                            required:
-                            - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                  type: object
-                annotations:
-                  additionalProperties:
-                    type: string
-                  type: object
-                imagePullSecrets:
-                  items:
-                    properties:
-                      name:
-                        type: string
-                    type: object
-                  type: array
-                initContainers:
-                  items:
-                    properties:
-                      args:
-                        items:
-                          type: string
-                        type: array
-                      command:
-                        items:
-                          type: string
-                        type: array
-                      env:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            value:
-                              type: string
-                            valueFrom:
-                              properties:
-                                configMapKeyRef:
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  required:
-                                  - key
-                                  type: object
-                                fieldRef:
-                                  properties:
-                                    apiVersion:
-                                      type: string
-                                    fieldPath:
-                                      type: string
-                                  required:
-                                  - fieldPath
-                                  type: object
-                                resourceFieldRef:
-                                  properties:
-                                    containerName:
-                                      type: string
-                                    divisor:
-                                      type: string
-                                    resource:
-                                      type: string
-                                  required:
-                                  - resource
-                                  type: object
-                                secretKeyRef:
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  required:
-                                  - key
-                                  type: object
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      envFrom:
-                        items:
-                          properties:
-                            configMapRef:
-                              properties:
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              type: object
-                            prefix:
-                              type: string
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              type: object
-                          type: object
-                        type: array
-                      image:
-                        type: string
-                      imagePullPolicy:
-                        type: string
-                      lifecycle:
-                        properties:
-                          postStart:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                            type: object
-                          preStop:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                            type: object
-                        type: object
-                      livenessProbe:
-                        properties:
-                          exec:
-                            properties:
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            format: int32
-                            type: integer
-                          httpGet:
-                            properties:
-                              host:
-                                type: string
-                              httpHeaders:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            properties:
-                              host:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          timeoutSeconds:
-                            format: int32
-                            type: integer
-                        type: object
-                      name:
-                        type: string
-                      ports:
-                        items:
-                          properties:
-                            containerPort:
-                              format: int32
-                              type: integer
-                            hostIP:
-                              type: string
-                            hostPort:
-                              format: int32
-                              type: integer
-                            name:
-                              type: string
-                            protocol:
-                              type: string
-                          required:
-                          - containerPort
-                          type: object
-                        type: array
-                      readinessProbe:
-                        properties:
-                          exec:
-                            properties:
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            format: int32
-                            type: integer
-                          httpGet:
-                            properties:
-                              host:
-                                type: string
-                              httpHeaders:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            properties:
-                              host:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          timeoutSeconds:
-                            format: int32
-                            type: integer
-                        type: object
-                      resources:
-                        properties:
-                          limits:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          requests:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        type: object
-                      securityContext:
-                        properties:
-                          allowPrivilegeEscalation:
-                            type: boolean
-                          capabilities:
-                            properties:
-                              add:
-                                items:
-                                  type: string
-                                type: array
-                              drop:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          privileged:
-                            type: boolean
-                          procMount:
-                            type: string
-                          readOnlyRootFilesystem:
-                            type: boolean
-                          runAsGroup:
-                            format: int64
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            format: int64
-                            type: integer
-                          seLinuxOptions:
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                            type: object
-                          windowsOptions:
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              runAsUserName:
-                                type: string
-                            type: object
-                        type: object
-                      startupProbe:
-                        properties:
-                          exec:
-                            properties:
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            format: int32
-                            type: integer
-                          httpGet:
-                            properties:
-                              host:
-                                type: string
-                              httpHeaders:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            properties:
-                              host:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          timeoutSeconds:
-                            format: int32
-                            type: integer
-                        type: object
-                      stdin:
-                        type: boolean
-                      stdinOnce:
-                        type: boolean
-                      terminationMessagePath:
-                        type: string
-                      terminationMessagePolicy:
-                        type: string
-                      tty:
-                        type: boolean
-                      volumeDevices:
-                        items:
-                          properties:
-                            devicePath:
-                              type: string
-                            name:
-                              type: string
-                          required:
-                          - devicePath
-                          - name
-                          type: object
-                        type: array
-                      volumeMounts:
-                        items:
-                          properties:
-                            mountPath:
-                              type: string
-                            mountPropagation:
-                              type: string
-                            name:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            subPath:
-                              type: string
-                            subPathExpr:
-                              type: string
-                          required:
-                          - mountPath
-                          - name
-                          type: object
-                        type: array
-                      workingDir:
-                        type: string
-                    required:
-                    - name
-                    type: object
-                  type: array
-                labels:
-                  additionalProperties:
-                    type: string
-                  type: object
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  type: object
-                securityContext:
-                  properties:
-                    fsGroup:
-                      format: int64
-                      type: integer
-                    fsGroupChangePolicy:
-                      type: string
-                    runAsGroup:
-                      format: int64
-                      type: integer
-                    runAsNonRoot:
-                      type: boolean
-                    runAsUser:
-                      format: int64
-                      type: integer
-                    seLinuxOptions:
-                      properties:
-                        level:
-                          type: string
-                        role:
-                          type: string
-                        type:
-                          type: string
-                        user:
-                          type: string
-                      type: object
-                    supplementalGroups:
-                      items:
-                        format: int64
-                        type: integer
-                      type: array
-                    sysctls:
-                      items:
-                        properties:
-                          name:
-                            type: string
-                          value:
-                            type: string
-                        required:
-                        - name
-                        - value
-                        type: object
-                      type: array
-                    windowsOptions:
-                      properties:
-                        gmsaCredentialSpec:
-                          type: string
-                        gmsaCredentialSpecName:
-                          type: string
-                        runAsUserName:
-                          type: string
-                      type: object
-                  type: object
-                sidecars:
-                  items:
-                    properties:
-                      args:
-                        items:
-                          type: string
-                        type: array
-                      command:
-                        items:
-                          type: string
-                        type: array
-                      env:
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            value:
-                              type: string
-                            valueFrom:
-                              properties:
-                                configMapKeyRef:
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  required:
-                                  - key
-                                  type: object
-                                fieldRef:
-                                  properties:
-                                    apiVersion:
-                                      type: string
-                                    fieldPath:
-                                      type: string
-                                  required:
-                                  - fieldPath
-                                  type: object
-                                resourceFieldRef:
-                                  properties:
-                                    containerName:
-                                      type: string
-                                    divisor:
-                                      type: string
-                                    resource:
-                                      type: string
-                                  required:
-                                  - resource
-                                  type: object
-                                secretKeyRef:
-                                  properties:
-                                    key:
-                                      type: string
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  required:
-                                  - key
-                                  type: object
-                              type: object
-                          required:
-                          - name
-                          type: object
-                        type: array
-                      envFrom:
-                        items:
-                          properties:
-                            configMapRef:
-                              properties:
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              type: object
-                            prefix:
-                              type: string
-                            secretRef:
-                              properties:
-                                name:
-                                  type: string
-                                optional:
-                                  type: boolean
-                              type: object
-                          type: object
-                        type: array
-                      image:
-                        type: string
-                      imagePullPolicy:
-                        type: string
-                      lifecycle:
-                        properties:
-                          postStart:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                            type: object
-                          preStop:
-                            properties:
-                              exec:
-                                properties:
-                                  command:
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              httpGet:
-                                properties:
-                                  host:
-                                    type: string
-                                  httpHeaders:
-                                    items:
-                                      properties:
-                                        name:
-                                          type: string
-                                        value:
-                                          type: string
-                                      required:
-                                      - name
-                                      - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    type: string
-                                required:
-                                - port
-                                type: object
-                              tcpSocket:
-                                properties:
-                                  host:
-                                    type: string
-                                  port:
-                                    anyOf:
-                                    - type: integer
-                                    - type: string
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                - port
-                                type: object
-                            type: object
-                        type: object
-                      livenessProbe:
-                        properties:
-                          exec:
-                            properties:
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            format: int32
-                            type: integer
-                          httpGet:
-                            properties:
-                              host:
-                                type: string
-                              httpHeaders:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            properties:
-                              host:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          timeoutSeconds:
-                            format: int32
-                            type: integer
-                        type: object
-                      name:
-                        type: string
-                      ports:
-                        items:
-                          properties:
-                            containerPort:
-                              format: int32
-                              type: integer
-                            hostIP:
-                              type: string
-                            hostPort:
-                              format: int32
-                              type: integer
-                            name:
-                              type: string
-                            protocol:
-                              type: string
-                          required:
-                          - containerPort
-                          type: object
-                        type: array
-                      readinessProbe:
-                        properties:
-                          exec:
-                            properties:
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            format: int32
-                            type: integer
-                          httpGet:
-                            properties:
-                              host:
-                                type: string
-                              httpHeaders:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            properties:
-                              host:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          timeoutSeconds:
-                            format: int32
-                            type: integer
-                        type: object
-                      resources:
-                        properties:
-                          limits:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          requests:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        type: object
-                      securityContext:
-                        properties:
-                          allowPrivilegeEscalation:
-                            type: boolean
-                          capabilities:
-                            properties:
-                              add:
-                                items:
-                                  type: string
-                                type: array
-                              drop:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          privileged:
-                            type: boolean
-                          procMount:
-                            type: string
-                          readOnlyRootFilesystem:
-                            type: boolean
-                          runAsGroup:
-                            format: int64
-                            type: integer
-                          runAsNonRoot:
-                            type: boolean
-                          runAsUser:
-                            format: int64
-                            type: integer
-                          seLinuxOptions:
-                            properties:
-                              level:
-                                type: string
-                              role:
-                                type: string
-                              type:
-                                type: string
-                              user:
-                                type: string
-                            type: object
-                          windowsOptions:
-                            properties:
-                              gmsaCredentialSpec:
-                                type: string
-                              gmsaCredentialSpecName:
-                                type: string
-                              runAsUserName:
-                                type: string
-                            type: object
-                        type: object
-                      startupProbe:
-                        properties:
-                          exec:
-                            properties:
-                              command:
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            format: int32
-                            type: integer
-                          httpGet:
-                            properties:
-                              host:
-                                type: string
-                              httpHeaders:
-                                items:
-                                  properties:
-                                    name:
-                                      type: string
-                                    value:
-                                      type: string
-                                  required:
-                                  - name
-                                  - value
-                                  type: object
-                                type: array
-                              path:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                type: string
-                            required:
-                            - port
-                            type: object
-                          initialDelaySeconds:
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            properties:
-                              host:
-                                type: string
-                              port:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                x-kubernetes-int-or-string: true
-                            required:
-                            - port
-                            type: object
-                          timeoutSeconds:
-                            format: int32
-                            type: integer
-                        type: object
-                      stdin:
-                        type: boolean
-                      stdinOnce:
-                        type: boolean
-                      terminationMessagePath:
-                        type: string
-                      terminationMessagePolicy:
-                        type: string
-                      tty:
-                        type: boolean
-                      volumeDevices:
-                        items:
-                          properties:
-                            devicePath:
-                              type: string
-                            name:
-                              type: string
-                          required:
-                          - devicePath
-                          - name
-                          type: object
-                        type: array
-                      volumeMounts:
-                        items:
-                          properties:
-                            mountPath:
-                              type: string
-                            mountPropagation:
-                              type: string
-                            name:
-                              type: string
-                            readOnly:
-                              type: boolean
-                            subPath:
-                              type: string
-                            subPathExpr:
-                              type: string
-                          required:
-                          - mountPath
-                          - name
-                          type: object
-                        type: array
-                      workingDir:
-                        type: string
-                    required:
-                    - name
-                    type: object
-                  type: array
-                terminationGracePeriodSeconds:
-                  format: int64
-                  type: integer
-                tolerations:
-                  items:
-                    properties:
-                      effect:
-                        type: string
-                      key:
-                        type: string
-                      operator:
-                        type: string
-                      tolerationSeconds:
-                        format: int64
-                        type: integer
-                      value:
-                        type: string
-                    type: object
-                  type: array
-                volumes:
-                  items:
-                    properties:
-                      awsElasticBlockStore:
-                        properties:
-                          fsType:
-                            type: string
-                          partition:
-                            format: int32
-                            type: integer
-                          readOnly:
-                            type: boolean
-                          volumeID:
-                            type: string
-                        required:
-                        - volumeID
-                        type: object
-                      azureDisk:
-                        properties:
-                          cachingMode:
-                            type: string
-                          diskName:
-                            type: string
-                          diskURI:
-                            type: string
-                          fsType:
-                            type: string
-                          kind:
-                            type: string
-                          readOnly:
-                            type: boolean
-                        required:
-                        - diskName
-                        - diskURI
-                        type: object
-                      azureFile:
-                        properties:
-                          readOnly:
-                            type: boolean
-                          secretName:
-                            type: string
-                          shareName:
-                            type: string
-                        required:
-                        - secretName
-                        - shareName
-                        type: object
-                      cephfs:
-                        properties:
-                          monitors:
-                            items:
-                              type: string
-                            type: array
-                          path:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretFile:
-                            type: string
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          user:
-                            type: string
-                        required:
-                        - monitors
-                        type: object
-                      cinder:
-                        properties:
-                          fsType:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          volumeID:
-                            type: string
-                        required:
-                        - volumeID
-                        type: object
-                      configMap:
-                        properties:
-                          defaultMode:
-                            format: int32
-                            type: integer
-                          items:
-                            items:
-                              properties:
-                                key:
-                                  type: string
-                                mode:
-                                  format: int32
-                                  type: integer
-                                path:
-                                  type: string
-                              required:
-                              - key
-                              - path
-                              type: object
-                            type: array
-                          name:
-                            type: string
-                          optional:
-                            type: boolean
-                        type: object
-                      csi:
-                        properties:
-                          driver:
-                            type: string
-                          fsType:
-                            type: string
-                          nodePublishSecretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          readOnly:
-                            type: boolean
-                          volumeAttributes:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        required:
-                        - driver
-                        type: object
-                      downwardAPI:
-                        properties:
-                          defaultMode:
-                            format: int32
-                            type: integer
-                          items:
-                            items:
-                              properties:
-                                fieldRef:
-                                  properties:
-                                    apiVersion:
-                                      type: string
-                                    fieldPath:
-                                      type: string
-                                  required:
-                                  - fieldPath
-                                  type: object
-                                mode:
-                                  format: int32
-                                  type: integer
-                                path:
-                                  type: string
-                                resourceFieldRef:
-                                  properties:
-                                    containerName:
-                                      type: string
-                                    divisor:
-                                      type: string
-                                    resource:
-                                      type: string
-                                  required:
-                                  - resource
-                                  type: object
-                              required:
-                              - path
-                              type: object
-                            type: array
-                        type: object
-                      emptyDir:
-                        properties:
-                          medium:
-                            type: string
-                          sizeLimit:
-                            type: string
-                        type: object
-                      fc:
-                        properties:
-                          fsType:
-                            type: string
-                          lun:
-                            format: int32
-                            type: integer
-                          readOnly:
-                            type: boolean
-                          targetWWNs:
-                            items:
-                              type: string
-                            type: array
-                          wwids:
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      flexVolume:
-                        properties:
-                          driver:
-                            type: string
-                          fsType:
-                            type: string
-                          options:
-                            additionalProperties:
-                              type: string
-                            type: object
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                        required:
-                        - driver
-                        type: object
-                      flocker:
-                        properties:
-                          datasetName:
-                            type: string
-                          datasetUUID:
-                            type: string
-                        type: object
-                      gcePersistentDisk:
-                        properties:
-                          fsType:
-                            type: string
-                          partition:
-                            format: int32
-                            type: integer
-                          pdName:
-                            type: string
-                          readOnly:
-                            type: boolean
-                        required:
-                        - pdName
-                        type: object
-                      gitRepo:
-                        properties:
-                          directory:
-                            type: string
-                          repository:
-                            type: string
-                          revision:
-                            type: string
-                        required:
-                        - repository
-                        type: object
-                      glusterfs:
-                        properties:
-                          endpoints:
-                            type: string
-                          path:
-                            type: string
-                          readOnly:
-                            type: boolean
-                        required:
-                        - endpoints
-                        - path
-                        type: object
-                      hostPath:
-                        properties:
-                          path:
-                            type: string
-                          type:
-                            type: string
-                        required:
-                        - path
-                        type: object
-                      iscsi:
-                        properties:
-                          chapAuthDiscovery:
-                            type: boolean
-                          chapAuthSession:
-                            type: boolean
-                          fsType:
-                            type: string
-                          initiatorName:
-                            type: string
-                          iqn:
-                            type: string
-                          iscsiInterface:
-                            type: string
-                          lun:
-                            format: int32
-                            type: integer
-                          portals:
-                            items:
-                              type: string
-                            type: array
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          targetPortal:
-                            type: string
-                        required:
-                        - iqn
-                        - lun
-                        - targetPortal
-                        type: object
-                      name:
-                        type: string
-                      nfs:
-                        properties:
-                          path:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          server:
-                            type: string
-                        required:
-                        - path
-                        - server
-                        type: object
-                      persistentVolumeClaim:
-                        properties:
-                          claimName:
-                            type: string
-                          readOnly:
-                            type: boolean
-                        required:
-                        - claimName
-                        type: object
-                      photonPersistentDisk:
-                        properties:
-                          fsType:
-                            type: string
-                          pdID:
-                            type: string
-                        required:
-                        - pdID
-                        type: object
-                      portworxVolume:
-                        properties:
-                          fsType:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          volumeID:
-                            type: string
-                        required:
-                        - volumeID
-                        type: object
-                      projected:
-                        properties:
-                          defaultMode:
-                            format: int32
-                            type: integer
-                          sources:
-                            items:
-                              properties:
-                                configMap:
-                                  properties:
-                                    items:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          mode:
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            type: string
-                                        required:
-                                        - key
-                                        - path
-                                        type: object
-                                      type: array
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  type: object
-                                downwardAPI:
-                                  properties:
-                                    items:
-                                      items:
-                                        properties:
-                                          fieldRef:
-                                            properties:
-                                              apiVersion:
-                                                type: string
-                                              fieldPath:
-                                                type: string
-                                            required:
-                                            - fieldPath
-                                            type: object
-                                          mode:
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            type: string
-                                          resourceFieldRef:
-                                            properties:
-                                              containerName:
-                                                type: string
-                                              divisor:
-                                                type: string
-                                              resource:
-                                                type: string
-                                            required:
-                                            - resource
-                                            type: object
-                                        required:
-                                        - path
-                                        type: object
-                                      type: array
-                                  type: object
-                                secret:
-                                  properties:
-                                    items:
-                                      items:
-                                        properties:
-                                          key:
-                                            type: string
-                                          mode:
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            type: string
-                                        required:
-                                        - key
-                                        - path
-                                        type: object
-                                      type: array
-                                    name:
-                                      type: string
-                                    optional:
-                                      type: boolean
-                                  type: object
-                                serviceAccountToken:
-                                  properties:
-                                    audience:
-                                      type: string
-                                    expirationSeconds:
-                                      format: int64
-                                      type: integer
-                                    path:
-                                      type: string
-                                  required:
-                                  - path
-                                  type: object
-                              type: object
-                            type: array
-                        required:
-                        - sources
-                        type: object
-                      quobyte:
-                        properties:
-                          group:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          registry:
-                            type: string
-                          tenant:
-                            type: string
-                          user:
-                            type: string
-                          volume:
-                            type: string
-                        required:
-                        - registry
-                        - volume
-                        type: object
-                      rbd:
-                        properties:
-                          fsType:
-                            type: string
-                          image:
-                            type: string
-                          keyring:
-                            type: string
-                          monitors:
-                            items:
-                              type: string
-                            type: array
-                          pool:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          user:
-                            type: string
-                        required:
-                        - image
-                        - monitors
-                        type: object
-                      scaleIO:
-                        properties:
-                          fsType:
-                            type: string
-                          gateway:
-                            type: string
-                          protectionDomain:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          sslEnabled:
-                            type: boolean
-                          storageMode:
-                            type: string
-                          storagePool:
-                            type: string
-                          system:
-                            type: string
-                          volumeName:
-                            type: string
-                        required:
-                        - gateway
-                        - secretRef
-                        - system
-                        type: object
-                      secret:
-                        properties:
-                          defaultMode:
-                            format: int32
-                            type: integer
-                          items:
-                            items:
-                              properties:
-                                key:
-                                  type: string
-                                mode:
-                                  format: int32
-                                  type: integer
-                                path:
-                                  type: string
-                              required:
-                              - key
-                              - path
-                              type: object
-                            type: array
-                          optional:
-                            type: boolean
-                          secretName:
-                            type: string
-                        type: object
-                      storageos:
-                        properties:
-                          fsType:
-                            type: string
-                          readOnly:
-                            type: boolean
-                          secretRef:
-                            properties:
-                              name:
-                                type: string
-                            type: object
-                          volumeName:
-                            type: string
-                          volumeNamespace:
-                            type: string
-                        type: object
-                      vsphereVolume:
-                        properties:
-                          fsType:
-                            type: string
-                          storagePolicyID:
-                            type: string
-                          storagePolicyName:
-                            type: string
-                          volumePath:
-                            type: string
-                        required:
-                        - volumePath
-                        type: object
-                    required:
-                    - name
-                    type: object
-                  type: array
-              type: object
-            processingGuarantee:
-              type: string
-            pulsar:
-              properties:
-                authSecret:
-                  type: string
-                pulsarConfig:
-                  type: string
-                tlsSecret:
-                  type: string
-              type: object
-            python:
-              properties:
-                py:
-                  type: string
-                pyLocation:
-                  type: string
-              type: object
-            replicas:
-              format: int32
-              type: integer
-            resources:
-              properties:
-                limits:
-                  additionalProperties:
-                    type: string
-                  type: object
-                requests:
-                  additionalProperties:
-                    type: string
-                  type: object
-              type: object
-            runtimeFlags:
-              type: string
-            secretsMap:
-              additionalProperties:
-                properties:
-                  key:
-                    type: string
-                  path:
-                    type: string
-                type: object
-              type: object
-            sourceConfig:
-              additionalProperties:
-                type: string
-              type: object
-            sourceType:
-              type: string
-            tenant:
-              type: string
-            volumeMounts:
-              items:
-                properties:
-                  mountPath:
-                    type: string
-                  mountPropagation:
-                    type: string
-                  name:
-                    type: string
-                  readOnly:
-                    type: boolean
-                  subPath:
-                    type: string
-                  subPathExpr:
-                    type: string
-                required:
-                - mountPath
-                - name
-                type: object
-              type: array
-          type: object
-        status:
-          properties:
-            conditions:
-              additionalProperties:
-                properties:
-                  action:
-                    type: string
-                  condition:
-                    type: string
-                  status:
-                    type: string
-                type: object
-              type: object
-            replicas:
-              format: int32
-              type: integer
-            selector:
-              type: string
-          required:
-          - conditions
-          - replicas
-          - selector
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
     served: true
     storage: true
+    subresources:
+      scale:
+        labelSelectorPath: .status.selector
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
+      status: {}
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              className:
+                type: string
+              clusterName:
+                type: string
+              golang:
+                properties:
+                  go:
+                    type: string
+                  goLocation:
+                    type: string
+                type: object
+              image:
+                type: string
+              imagePullPolicy:
+                type: string
+              java:
+                properties:
+                  extraDependenciesDir:
+                    type: string
+                  jar:
+                    type: string
+                  jarLocation:
+                    type: string
+                type: object
+              logTopic:
+                type: string
+              maxReplicas:
+                format: int32
+                type: integer
+              name:
+                type: string
+              output:
+                properties:
+                  customSchemaSinks:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  producerConf:
+                    properties:
+                      batchBuilder:
+                        type: string
+                      cryptoConfig:
+                        properties:
+                          consumerCryptoFailureAction:
+                            type: string
+                          cryptoKeyReaderClassName:
+                            type: string
+                          cryptoKeyReaderConfig:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          cryptoSecrets:
+                            items:
+                              properties:
+                                asVolume:
+                                  type: string
+                                secretKey:
+                                  type: string
+                                secretName:
+                                  type: string
+                              required:
+                              - secretKey
+                              - secretName
+                              type: object
+                            type: array
+                          encryptionKeys:
+                            items:
+                              type: string
+                            type: array
+                          producerCryptoFailureAction:
+                            type: string
+                        type: object
+                      maxPendingMessages:
+                        format: int32
+                        type: integer
+                      maxPendingMessagesAcrossPartitions:
+                        format: int32
+                        type: integer
+                      useThreadLocalProducers:
+                        type: boolean
+                    type: object
+                  sinkSchemaType:
+                    type: string
+                  sinkSerdeClassName:
+                    type: string
+                  topic:
+                    type: string
+                  typeClassName:
+                    type: string
+                type: object
+              pod:
+                properties:
+                  affinity:
+                    properties:
+                      nodeAffinity:
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                preference:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - preference
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            properties:
+                              nodeSelectorTerms:
+                                items:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                            - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                podAffinityTerm:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                podAffinityTerm:
+                                  properties:
+                                    labelSelector:
+                                      properties:
+                                        matchExpressions:
+                                          items:
+                                            properties:
+                                              key:
+                                                type: string
+                                              operator:
+                                                type: string
+                                              values:
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                weight:
+                                  format: int32
+                                  type: integer
+                              required:
+                              - podAffinityTerm
+                              - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            items:
+                              properties:
+                                labelSelector:
+                                  properties:
+                                    matchExpressions:
+                                      items:
+                                        properties:
+                                          key:
+                                            type: string
+                                          operator:
+                                            type: string
+                                          values:
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  imagePullSecrets:
+                    items:
+                      properties:
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  initContainers:
+                    items:
+                      properties:
+                        args:
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                              valueFrom:
+                                properties:
+                                  configMapKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      fieldPath:
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    properties:
+                                      containerName:
+                                        type: string
+                                      divisor:
+                                        type: string
+                                      resource:
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        envFrom:
+                          items:
+                            properties:
+                              configMapRef:
+                                properties:
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                type: object
+                              prefix:
+                                type: string
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          type: string
+                        imagePullPolicy:
+                          type: string
+                        lifecycle:
+                          properties:
+                            postStart:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              format: int32
+                              type: integer
+                            httpGet:
+                              properties:
+                                host:
+                                  type: string
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                        readinessProbe:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              format: int32
+                              type: integer
+                            httpGet:
+                              properties:
+                                host:
+                                  type: string
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        securityContext:
+                          properties:
+                            allowPrivilegeEscalation:
+                              type: boolean
+                            capabilities:
+                              properties:
+                                add:
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              type: boolean
+                            procMount:
+                              type: string
+                            readOnlyRootFilesystem:
+                              type: boolean
+                            runAsGroup:
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                              type: object
+                            windowsOptions:
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              format: int32
+                              type: integer
+                            httpGet:
+                              properties:
+                                host:
+                                  type: string
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          type: boolean
+                        stdinOnce:
+                          type: boolean
+                        terminationMessagePath:
+                          type: string
+                        terminationMessagePolicy:
+                          type: string
+                        tty:
+                          type: boolean
+                        volumeDevices:
+                          items:
+                            properties:
+                              devicePath:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                        volumeMounts:
+                          items:
+                            properties:
+                              mountPath:
+                                type: string
+                              mountPropagation:
+                                type: string
+                              name:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              subPath:
+                                type: string
+                              subPathExpr:
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                        workingDir:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  labels:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  securityContext:
+                    properties:
+                      fsGroup:
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        type: string
+                      runAsGroup:
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        type: boolean
+                      runAsUser:
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        properties:
+                          level:
+                            type: string
+                          role:
+                            type: string
+                          type:
+                            type: string
+                          user:
+                            type: string
+                        type: object
+                      supplementalGroups:
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        items:
+                          properties:
+                            name:
+                              type: string
+                            value:
+                              type: string
+                          required:
+                          - name
+                          - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        properties:
+                          gmsaCredentialSpec:
+                            type: string
+                          gmsaCredentialSpecName:
+                            type: string
+                          runAsUserName:
+                            type: string
+                        type: object
+                    type: object
+                  sidecars:
+                    items:
+                      properties:
+                        args:
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                              valueFrom:
+                                properties:
+                                  configMapKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                  fieldRef:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      fieldPath:
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    properties:
+                                      containerName:
+                                        type: string
+                                      divisor:
+                                        type: string
+                                      resource:
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                  secretKeyRef:
+                                    properties:
+                                      key:
+                                        type: string
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    required:
+                                    - key
+                                    type: object
+                                type: object
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        envFrom:
+                          items:
+                            properties:
+                              configMapRef:
+                                properties:
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                type: object
+                              prefix:
+                                type: string
+                              secretRef:
+                                properties:
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          type: string
+                        imagePullPolicy:
+                          type: string
+                        lifecycle:
+                          properties:
+                            postStart:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                            preStop:
+                              properties:
+                                exec:
+                                  properties:
+                                    command:
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                httpGet:
+                                  properties:
+                                    host:
+                                      type: string
+                                    httpHeaders:
+                                      items:
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      type: string
+                                  required:
+                                  - port
+                                  type: object
+                                tcpSocket:
+                                  properties:
+                                    host:
+                                      type: string
+                                    port:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - port
+                                  type: object
+                              type: object
+                          type: object
+                        livenessProbe:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              format: int32
+                              type: integer
+                            httpGet:
+                              properties:
+                                host:
+                                  type: string
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          type: string
+                        ports:
+                          items:
+                            properties:
+                              containerPort:
+                                format: int32
+                                type: integer
+                              hostIP:
+                                type: string
+                              hostPort:
+                                format: int32
+                                type: integer
+                              name:
+                                type: string
+                              protocol:
+                                type: string
+                            required:
+                            - containerPort
+                            type: object
+                          type: array
+                        readinessProbe:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              format: int32
+                              type: integer
+                            httpGet:
+                              properties:
+                                host:
+                                  type: string
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          properties:
+                            limits:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            requests:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          type: object
+                        securityContext:
+                          properties:
+                            allowPrivilegeEscalation:
+                              type: boolean
+                            capabilities:
+                              properties:
+                                add:
+                                  items:
+                                    type: string
+                                  type: array
+                                drop:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            privileged:
+                              type: boolean
+                            procMount:
+                              type: string
+                            readOnlyRootFilesystem:
+                              type: boolean
+                            runAsGroup:
+                              format: int64
+                              type: integer
+                            runAsNonRoot:
+                              type: boolean
+                            runAsUser:
+                              format: int64
+                              type: integer
+                            seLinuxOptions:
+                              properties:
+                                level:
+                                  type: string
+                                role:
+                                  type: string
+                                type:
+                                  type: string
+                                user:
+                                  type: string
+                              type: object
+                            windowsOptions:
+                              properties:
+                                gmsaCredentialSpec:
+                                  type: string
+                                gmsaCredentialSpecName:
+                                  type: string
+                                runAsUserName:
+                                  type: string
+                              type: object
+                          type: object
+                        startupProbe:
+                          properties:
+                            exec:
+                              properties:
+                                command:
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              format: int32
+                              type: integer
+                            httpGet:
+                              properties:
+                                host:
+                                  type: string
+                                httpHeaders:
+                                  items:
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                path:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  type: string
+                              required:
+                              - port
+                              type: object
+                            initialDelaySeconds:
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              properties:
+                                host:
+                                  type: string
+                                port:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  x-kubernetes-int-or-string: true
+                              required:
+                              - port
+                              type: object
+                            timeoutSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                        stdin:
+                          type: boolean
+                        stdinOnce:
+                          type: boolean
+                        terminationMessagePath:
+                          type: string
+                        terminationMessagePolicy:
+                          type: string
+                        tty:
+                          type: boolean
+                        volumeDevices:
+                          items:
+                            properties:
+                              devicePath:
+                                type: string
+                              name:
+                                type: string
+                            required:
+                            - devicePath
+                            - name
+                            type: object
+                          type: array
+                        volumeMounts:
+                          items:
+                            properties:
+                              mountPath:
+                                type: string
+                              mountPropagation:
+                                type: string
+                              name:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              subPath:
+                                type: string
+                              subPathExpr:
+                                type: string
+                            required:
+                            - mountPath
+                            - name
+                            type: object
+                          type: array
+                        workingDir:
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  terminationGracePeriodSeconds:
+                    format: int64
+                    type: integer
+                  tolerations:
+                    items:
+                      properties:
+                        effect:
+                          type: string
+                        key:
+                          type: string
+                        operator:
+                          type: string
+                        tolerationSeconds:
+                          format: int64
+                          type: integer
+                        value:
+                          type: string
+                      type: object
+                    type: array
+                  volumes:
+                    items:
+                      properties:
+                        awsElasticBlockStore:
+                          properties:
+                            fsType:
+                              type: string
+                            partition:
+                              format: int32
+                              type: integer
+                            readOnly:
+                              type: boolean
+                            volumeID:
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        azureDisk:
+                          properties:
+                            cachingMode:
+                              type: string
+                            diskName:
+                              type: string
+                            diskURI:
+                              type: string
+                            fsType:
+                              type: string
+                            kind:
+                              type: string
+                            readOnly:
+                              type: boolean
+                          required:
+                          - diskName
+                          - diskURI
+                          type: object
+                        azureFile:
+                          properties:
+                            readOnly:
+                              type: boolean
+                            secretName:
+                              type: string
+                            shareName:
+                              type: string
+                          required:
+                          - secretName
+                          - shareName
+                          type: object
+                        cephfs:
+                          properties:
+                            monitors:
+                              items:
+                                type: string
+                              type: array
+                            path:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            secretFile:
+                              type: string
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            user:
+                              type: string
+                          required:
+                          - monitors
+                          type: object
+                        cinder:
+                          properties:
+                            fsType:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            volumeID:
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        configMap:
+                          properties:
+                            defaultMode:
+                              format: int32
+                              type: integer
+                            items:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  mode:
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            name:
+                              type: string
+                            optional:
+                              type: boolean
+                          type: object
+                        csi:
+                          properties:
+                            driver:
+                              type: string
+                            fsType:
+                              type: string
+                            nodePublishSecretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            readOnly:
+                              type: boolean
+                            volumeAttributes:
+                              additionalProperties:
+                                type: string
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        downwardAPI:
+                          properties:
+                            defaultMode:
+                              format: int32
+                              type: integer
+                            items:
+                              items:
+                                properties:
+                                  fieldRef:
+                                    properties:
+                                      apiVersion:
+                                        type: string
+                                      fieldPath:
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                  mode:
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    type: string
+                                  resourceFieldRef:
+                                    properties:
+                                      containerName:
+                                        type: string
+                                      divisor:
+                                        type: string
+                                      resource:
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                required:
+                                - path
+                                type: object
+                              type: array
+                          type: object
+                        emptyDir:
+                          properties:
+                            medium:
+                              type: string
+                            sizeLimit:
+                              type: string
+                          type: object
+                        fc:
+                          properties:
+                            fsType:
+                              type: string
+                            lun:
+                              format: int32
+                              type: integer
+                            readOnly:
+                              type: boolean
+                            targetWWNs:
+                              items:
+                                type: string
+                              type: array
+                            wwids:
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        flexVolume:
+                          properties:
+                            driver:
+                              type: string
+                            fsType:
+                              type: string
+                            options:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            readOnly:
+                              type: boolean
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        flocker:
+                          properties:
+                            datasetName:
+                              type: string
+                            datasetUUID:
+                              type: string
+                          type: object
+                        gcePersistentDisk:
+                          properties:
+                            fsType:
+                              type: string
+                            partition:
+                              format: int32
+                              type: integer
+                            pdName:
+                              type: string
+                            readOnly:
+                              type: boolean
+                          required:
+                          - pdName
+                          type: object
+                        gitRepo:
+                          properties:
+                            directory:
+                              type: string
+                            repository:
+                              type: string
+                            revision:
+                              type: string
+                          required:
+                          - repository
+                          type: object
+                        glusterfs:
+                          properties:
+                            endpoints:
+                              type: string
+                            path:
+                              type: string
+                            readOnly:
+                              type: boolean
+                          required:
+                          - endpoints
+                          - path
+                          type: object
+                        hostPath:
+                          properties:
+                            path:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        iscsi:
+                          properties:
+                            chapAuthDiscovery:
+                              type: boolean
+                            chapAuthSession:
+                              type: boolean
+                            fsType:
+                              type: string
+                            initiatorName:
+                              type: string
+                            iqn:
+                              type: string
+                            iscsiInterface:
+                              type: string
+                            lun:
+                              format: int32
+                              type: integer
+                            portals:
+                              items:
+                                type: string
+                              type: array
+                            readOnly:
+                              type: boolean
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            targetPortal:
+                              type: string
+                          required:
+                          - iqn
+                          - lun
+                          - targetPortal
+                          type: object
+                        name:
+                          type: string
+                        nfs:
+                          properties:
+                            path:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            server:
+                              type: string
+                          required:
+                          - path
+                          - server
+                          type: object
+                        persistentVolumeClaim:
+                          properties:
+                            claimName:
+                              type: string
+                            readOnly:
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        photonPersistentDisk:
+                          properties:
+                            fsType:
+                              type: string
+                            pdID:
+                              type: string
+                          required:
+                          - pdID
+                          type: object
+                        portworxVolume:
+                          properties:
+                            fsType:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            volumeID:
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        projected:
+                          properties:
+                            defaultMode:
+                              format: int32
+                              type: integer
+                            sources:
+                              items:
+                                properties:
+                                  configMap:
+                                    properties:
+                                      items:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            mode:
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                  downwardAPI:
+                                    properties:
+                                      items:
+                                        items:
+                                          properties:
+                                            fieldRef:
+                                              properties:
+                                                apiVersion:
+                                                  type: string
+                                                fieldPath:
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                            mode:
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              type: string
+                                            resourceFieldRef:
+                                              properties:
+                                                containerName:
+                                                  type: string
+                                                divisor:
+                                                  type: string
+                                                resource:
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                          required:
+                                          - path
+                                          type: object
+                                        type: array
+                                    type: object
+                                  secret:
+                                    properties:
+                                      items:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            mode:
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                      name:
+                                        type: string
+                                      optional:
+                                        type: boolean
+                                    type: object
+                                  serviceAccountToken:
+                                    properties:
+                                      audience:
+                                        type: string
+                                      expirationSeconds:
+                                        format: int64
+                                        type: integer
+                                      path:
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                type: object
+                              type: array
+                          required:
+                          - sources
+                          type: object
+                        quobyte:
+                          properties:
+                            group:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            registry:
+                              type: string
+                            tenant:
+                              type: string
+                            user:
+                              type: string
+                            volume:
+                              type: string
+                          required:
+                          - registry
+                          - volume
+                          type: object
+                        rbd:
+                          properties:
+                            fsType:
+                              type: string
+                            image:
+                              type: string
+                            keyring:
+                              type: string
+                            monitors:
+                              items:
+                                type: string
+                              type: array
+                            pool:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            user:
+                              type: string
+                          required:
+                          - image
+                          - monitors
+                          type: object
+                        scaleIO:
+                          properties:
+                            fsType:
+                              type: string
+                            gateway:
+                              type: string
+                            protectionDomain:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            sslEnabled:
+                              type: boolean
+                            storageMode:
+                              type: string
+                            storagePool:
+                              type: string
+                            system:
+                              type: string
+                            volumeName:
+                              type: string
+                          required:
+                          - gateway
+                          - secretRef
+                          - system
+                          type: object
+                        secret:
+                          properties:
+                            defaultMode:
+                              format: int32
+                              type: integer
+                            items:
+                              items:
+                                properties:
+                                  key:
+                                    type: string
+                                  mode:
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                            optional:
+                              type: boolean
+                            secretName:
+                              type: string
+                          type: object
+                        storageos:
+                          properties:
+                            fsType:
+                              type: string
+                            readOnly:
+                              type: boolean
+                            secretRef:
+                              properties:
+                                name:
+                                  type: string
+                              type: object
+                            volumeName:
+                              type: string
+                            volumeNamespace:
+                              type: string
+                          type: object
+                        vsphereVolume:
+                          properties:
+                            fsType:
+                              type: string
+                            storagePolicyID:
+                              type: string
+                            storagePolicyName:
+                              type: string
+                            volumePath:
+                              type: string
+                          required:
+                          - volumePath
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
+              processingGuarantee:
+                type: string
+              pulsar:
+                properties:
+                  authSecret:
+                    type: string
+                  pulsarConfig:
+                    type: string
+                  tlsSecret:
+                    type: string
+                type: object
+              python:
+                properties:
+                  py:
+                    type: string
+                  pyLocation:
+                    type: string
+                type: object
+              replicas:
+                format: int32
+                type: integer
+              resources:
+                properties:
+                  limits:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  requests:
+                    additionalProperties:
+                      type: string
+                    type: object
+                type: object
+              runtimeFlags:
+                type: string
+              secretsMap:
+                additionalProperties:
+                  properties:
+                    key:
+                      type: string
+                    path:
+                      type: string
+                  type: object
+                type: object
+              sourceConfig:
+                additionalProperties:
+                  type: string
+                type: object
+              sourceType:
+                type: string
+              tenant:
+                type: string
+              volumeMounts:
+                items:
+                  properties:
+                    mountPath:
+                      type: string
+                    mountPropagation:
+                      type: string
+                    name:
+                      type: string
+                    readOnly:
+                      type: boolean
+                    subPath:
+                      type: string
+                    subPathExpr:
+                      type: string
+                  required:
+                  - mountPath
+                  - name
+                  type: object
+                type: array
+            type: object
+          status:
+            properties:
+              conditions:
+                additionalProperties:
+                  properties:
+                    action:
+                      type: string
+                    condition:
+                      type: string
+                    status:
+                      type: string
+                  type: object
+                type: object
+              replicas:
+                format: int32
+                type: integer
+              selector:
+                type: string
+            required:
+            - conditions
+            - replicas
+            - selector
+            type: object
+        type: object
 status:
   acceptedNames:
     kind: ""

--- a/charts/pulsar-operator/crds/bookkeeper.streamnative.io_bookkeeperclusters.yaml
+++ b/charts/pulsar-operator/crds/bookkeeper.streamnative.io_bookkeeperclusters.yaml
@@ -1,6 +1,5 @@
-
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -8,22 +7,6 @@ metadata:
   creationTimestamp: null
   name: bookkeeperclusters.bookkeeper.streamnative.io
 spec:
-  additionalPrinterColumns:
-    - JSONPath: .spec.replicas
-      name: Replicas
-      type: integer
-    - JSONPath: .status.replicas
-      name: Ready Replicas
-      type: integer
-    - JSONPath: .spec.zkServers
-      name: ZkServers
-      type: string
-    - JSONPath: .spec.image
-      name: Desired Image
-      type: string
-    - JSONPath: .metadata.creationTimestamp
-      name: Age
-      type: date
   group: bookkeeper.streamnative.io
   names:
     categories:
@@ -35,3267 +18,2299 @@ spec:
       - bk
     singular: bookkeepercluster
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: BookKeeperCluster is the Schema for the bookkeeperclusters API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    additionalPrinterColumns:
+        - jsonPath: .spec.replicas
+          name: Replicas
+          type: integer
+        - jsonPath: .status.replicas
+          name: Ready Replicas
+          type: integer
+        - jsonPath: .spec.zkServers
+          name: ZkServers
           type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+        - jsonPath: .spec.image
+          name: Desired Image
           type: string
-        metadata:
-          type: object
-        spec:
-          description: BookKeeperClusterSpec defines the desired state of BookKeeperCluster
-          properties:
-            apiObjects:
-              description: APIObjects allows precise control over how components (services,
-                statefulset and so on) should be managed
-              properties:
-                autoRecoveryConfigMap:
-                  description: AutoRecoveryConfigMap defines the autoRecovery configmap
-                    resource template.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                  type: object
-                autoRecoveryHeadlessService:
-                  description: AutoRecoveryHeadlessService defines the service resource
-                    template for autoRecovery headless service.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                  type: object
-                autoRecoveryStatefulSet:
-                  description: AutoRecoveryStatefulSet defines the statefulset resource
-                    template for adopting existing autoRecovery statefulset.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        the name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                    volumeClaimTemplates:
-                      description: VolumeClaimTemplates is a list of claims that pods
-                        are allowed to reference. If a non-empty list is specified,
-                        the original values in the desired STS will be replaced.
-                      items:
-                        description: PersistentVolumeClaim is a user's request for
-                          and claim to a persistent volume
-                        properties:
-                          apiVersion:
-                            description: 'APIVersion defines the versioned schema
-                              of this representation of an object. Servers should
-                              convert recognized schemas to the latest internal value,
-                              and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                            type: string
-                          kind:
-                            description: 'Kind is a string value representing the
-                              REST resource this object represents. Servers may infer
-                              this from the endpoint the client submits requests to.
-                              Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          metadata:
-                            description: 'Standard object''s metadata. More info:
-                              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                            type: object
-                          spec:
-                            description: 'Spec defines the desired characteristics
-                              of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                            properties:
-                              accessModes:
-                                description: 'AccessModes contains the desired access
-                                  modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                items:
-                                  type: string
-                                type: array
-                              dataSource:
-                                description: 'This field can be used to specify either:
-                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                                  - Beta) * An existing PVC (PersistentVolumeClaim)
-                                  * An existing custom resource/object that implements
-                                  data population (Alpha) In order to use VolumeSnapshot
-                                  object types, the appropriate feature gate must
-                                  be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
-                                  If the provisioner or an external controller can
-                                  support the specified data source, it will create
-                                  a new volume based on the contents of the specified
-                                  data source. If the specified data source is not
-                                  supported, the volume will not be created and the
-                                  failure will be reported as an event. In the future,
-                                  we plan to support more data source types and the
-                                  behavior of the provisioner may change.'
-                                properties:
-                                  apiGroup:
-                                    description: APIGroup is the group for the resource
-                                      being referenced. If APIGroup is not specified,
-                                      the specified Kind must be in the core API group.
-                                      For any other third-party types, APIGroup is
-                                      required.
-                                    type: string
-                                  kind:
-                                    description: Kind is the type of resource being
-                                      referenced
-                                    type: string
-                                  name:
-                                    description: Name is the name of resource being
-                                      referenced
-                                    type: string
-                                required:
-                                  - kind
-                                  - name
-                                type: object
-                              resources:
-                                description: 'Resources represents the minimum resources
-                                  the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                                properties:
-                                  limits:
-                                    additionalProperties:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    description: 'Limits describes the maximum amount
-                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                    type: object
-                                  requests:
-                                    additionalProperties:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    description: 'Requests describes the minimum amount
-                                      of compute resources required. If Requests is
-                                      omitted for a container, it defaults to Limits
-                                      if that is explicitly specified, otherwise to
-                                      an implementation-defined value. More info:
-                                      https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                    type: object
-                                type: object
-                              selector:
-                                description: A label query over volumes to consider
-                                  for binding.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              storageClassName:
-                                description: 'Name of the StorageClass required by
-                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                                type: string
-                              volumeMode:
-                                description: volumeMode defines what type of volume
-                                  is required by the claim. Value of Filesystem is
-                                  implied when not included in claim spec.
-                                type: string
-                              volumeName:
-                                description: VolumeName is the binding reference to
-                                  the PersistentVolume backing this claim.
-                                type: string
-                            type: object
-                          status:
-                            description: 'Status represents the current information/status
-                              of a persistent volume claim. Read-only. More info:
-                              https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                            properties:
-                              accessModes:
-                                description: 'AccessModes contains the actual access
-                                  modes the volume backing the PVC has. More info:
-                                  https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                items:
-                                  type: string
-                                type: array
-                              capacity:
-                                additionalProperties:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: Represents the actual resources of the
-                                  underlying volume.
-                                type: object
-                              conditions:
-                                description: Current Condition of persistent volume
-                                  claim. If underlying persistent volume is being
-                                  resized then the Condition will be set to 'ResizeStarted'.
-                                items:
-                                  description: PersistentVolumeClaimCondition contails
-                                    details about state of pvc
-                                  properties:
-                                    lastProbeTime:
-                                      description: Last time we probed the condition.
-                                      format: date-time
-                                      type: string
-                                    lastTransitionTime:
-                                      description: Last time the condition transitioned
-                                        from one status to another.
-                                      format: date-time
-                                      type: string
-                                    message:
-                                      description: Human-readable message indicating
-                                        details about last transition.
-                                      type: string
-                                    reason:
-                                      description: Unique, this should be a short,
-                                        machine understandable string that gives the
-                                        reason for condition's last transition. If
-                                        it reports "ResizeStarted" that means the
-                                        underlying persistent volume is being resized.
-                                      type: string
-                                    status:
-                                      type: string
-                                    type:
-                                      description: PersistentVolumeClaimConditionType
-                                        is a valid value of PersistentVolumeClaimCondition.Type
-                                      type: string
-                                  required:
-                                    - status
-                                    - type
-                                  type: object
-                                type: array
-                              phase:
-                                description: Phase represents the current phase of
-                                  PersistentVolumeClaim.
-                                type: string
-                            type: object
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+    schema:
+      openAPIV3Schema:
+        description: BookKeeperCluster is the Schema for the bookkeeperclusters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: BookKeeperClusterSpec defines the desired state of BookKeeperCluster
+            properties:
+              apiObjects:
+                description: APIObjects allows precise control over how components (services,
+                  statefulset and so on) should be managed
+                properties:
+                  autoRecoveryConfigMap:
+                    description: AutoRecoveryConfigMap defines the autoRecovery configmap
+                      resource template.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                         type: object
-                      type: array
-                    volumeMounts:
-                      description: VolumeMounts is a list of volumes to mount into
-                        the container's filesystem. If a non-empty list is specified,
-                        the original values of the main container in the desired STS
-                        will be replaced.
-                      items:
-                        description: VolumeMount describes a mounting of a Volume
-                          within a container.
-                        properties:
-                          mountPath:
-                            description: Path within the container at which the volume
-                              should be mounted.  Must not contain ':'.
-                            type: string
-                          mountPropagation:
-                            description: mountPropagation determines how mounts are
-                              propagated from the host to container and the other
-                              way around. When not set, MountPropagationNone is used.
-                              This field is beta in 1.10.
-                            type: string
-                          name:
-                            description: This must match the Name of a Volume.
-                            type: string
-                          readOnly:
-                            description: Mounted read-only if true, read-write otherwise
-                              (false or unspecified). Defaults to false.
-                            type: boolean
-                          subPath:
-                            description: Path within the volume from which the container's
-                              volume should be mounted. Defaults to "" (volume's root).
-                            type: string
-                          subPathExpr:
-                            description: Expanded path within the volume from which
-                              the container's volume should be mounted. Behaves similarly
-                              to SubPath but environment variable references $(VAR_NAME)
-                              are expanded using the container's environment. Defaults
-                              to "" (volume's root). SubPathExpr and SubPath are mutually
-                              exclusive.
-                            type: string
-                        required:
-                          - mountPath
-                          - name
-                        type: object
-                      type: array
-                  type: object
-                bookieStatefulSet:
-                  description: BookieStatefulSet defines the statefulset resource
-                    template for bookie cluster.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        the name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                    volumeClaimTemplates:
-                      description: VolumeClaimTemplates is a list of claims that pods
-                        are allowed to reference. If a non-empty list is specified,
-                        the original values in the desired STS will be replaced.
-                      items:
-                        description: PersistentVolumeClaim is a user's request for
-                          and claim to a persistent volume
-                        properties:
-                          apiVersion:
-                            description: 'APIVersion defines the versioned schema
-                              of this representation of an object. Servers should
-                              convert recognized schemas to the latest internal value,
-                              and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                            type: string
-                          kind:
-                            description: 'Kind is a string value representing the
-                              REST resource this object represents. Servers may infer
-                              this from the endpoint the client submits requests to.
-                              Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          metadata:
-                            description: 'Standard object''s metadata. More info:
-                              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                            type: object
-                          spec:
-                            description: 'Spec defines the desired characteristics
-                              of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                            properties:
-                              accessModes:
-                                description: 'AccessModes contains the desired access
-                                  modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                items:
-                                  type: string
-                                type: array
-                              dataSource:
-                                description: 'This field can be used to specify either:
-                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                                  - Beta) * An existing PVC (PersistentVolumeClaim)
-                                  * An existing custom resource/object that implements
-                                  data population (Alpha) In order to use VolumeSnapshot
-                                  object types, the appropriate feature gate must
-                                  be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
-                                  If the provisioner or an external controller can
-                                  support the specified data source, it will create
-                                  a new volume based on the contents of the specified
-                                  data source. If the specified data source is not
-                                  supported, the volume will not be created and the
-                                  failure will be reported as an event. In the future,
-                                  we plan to support more data source types and the
-                                  behavior of the provisioner may change.'
-                                properties:
-                                  apiGroup:
-                                    description: APIGroup is the group for the resource
-                                      being referenced. If APIGroup is not specified,
-                                      the specified Kind must be in the core API group.
-                                      For any other third-party types, APIGroup is
-                                      required.
-                                    type: string
-                                  kind:
-                                    description: Kind is the type of resource being
-                                      referenced
-                                    type: string
-                                  name:
-                                    description: Name is the name of resource being
-                                      referenced
-                                    type: string
-                                required:
-                                  - kind
-                                  - name
-                                type: object
-                              resources:
-                                description: 'Resources represents the minimum resources
-                                  the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                                properties:
-                                  limits:
-                                    additionalProperties:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    description: 'Limits describes the maximum amount
-                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                    type: object
-                                  requests:
-                                    additionalProperties:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    description: 'Requests describes the minimum amount
-                                      of compute resources required. If Requests is
-                                      omitted for a container, it defaults to Limits
-                                      if that is explicitly specified, otherwise to
-                                      an implementation-defined value. More info:
-                                      https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                    type: object
-                                type: object
-                              selector:
-                                description: A label query over volumes to consider
-                                  for binding.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              storageClassName:
-                                description: 'Name of the StorageClass required by
-                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                                type: string
-                              volumeMode:
-                                description: volumeMode defines what type of volume
-                                  is required by the claim. Value of Filesystem is
-                                  implied when not included in claim spec.
-                                type: string
-                              volumeName:
-                                description: VolumeName is the binding reference to
-                                  the PersistentVolume backing this claim.
-                                type: string
-                            type: object
-                          status:
-                            description: 'Status represents the current information/status
-                              of a persistent volume claim. Read-only. More info:
-                              https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                            properties:
-                              accessModes:
-                                description: 'AccessModes contains the actual access
-                                  modes the volume backing the PVC has. More info:
-                                  https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                items:
-                                  type: string
-                                type: array
-                              capacity:
-                                additionalProperties:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: Represents the actual resources of the
-                                  underlying volume.
-                                type: object
-                              conditions:
-                                description: Current Condition of persistent volume
-                                  claim. If underlying persistent volume is being
-                                  resized then the Condition will be set to 'ResizeStarted'.
-                                items:
-                                  description: PersistentVolumeClaimCondition contails
-                                    details about state of pvc
-                                  properties:
-                                    lastProbeTime:
-                                      description: Last time we probed the condition.
-                                      format: date-time
-                                      type: string
-                                    lastTransitionTime:
-                                      description: Last time the condition transitioned
-                                        from one status to another.
-                                      format: date-time
-                                      type: string
-                                    message:
-                                      description: Human-readable message indicating
-                                        details about last transition.
-                                      type: string
-                                    reason:
-                                      description: Unique, this should be a short,
-                                        machine understandable string that gives the
-                                        reason for condition's last transition. If
-                                        it reports "ResizeStarted" that means the
-                                        underlying persistent volume is being resized.
-                                      type: string
-                                    status:
-                                      type: string
-                                    type:
-                                      description: PersistentVolumeClaimConditionType
-                                        is a valid value of PersistentVolumeClaimCondition.Type
-                                      type: string
-                                  required:
-                                    - status
-                                    - type
-                                  type: object
-                                type: array
-                              phase:
-                                description: Phase represents the current phase of
-                                  PersistentVolumeClaim.
-                                type: string
-                            type: object
-                        type: object
-                      type: array
-                    volumeMounts:
-                      description: VolumeMounts is a list of volumes to mount into
-                        the container's filesystem. If a non-empty list is specified,
-                        the original values of the main container in the desired STS
-                        will be replaced.
-                      items:
-                        description: VolumeMount describes a mounting of a Volume
-                          within a container.
-                        properties:
-                          mountPath:
-                            description: Path within the container at which the volume
-                              should be mounted.  Must not contain ':'.
-                            type: string
-                          mountPropagation:
-                            description: mountPropagation determines how mounts are
-                              propagated from the host to container and the other
-                              way around. When not set, MountPropagationNone is used.
-                              This field is beta in 1.10.
-                            type: string
-                          name:
-                            description: This must match the Name of a Volume.
-                            type: string
-                          readOnly:
-                            description: Mounted read-only if true, read-write otherwise
-                              (false or unspecified). Defaults to false.
-                            type: boolean
-                          subPath:
-                            description: Path within the volume from which the container's
-                              volume should be mounted. Defaults to "" (volume's root).
-                            type: string
-                          subPathExpr:
-                            description: Expanded path within the volume from which
-                              the container's volume should be mounted. Behaves similarly
-                              to SubPath but environment variable references $(VAR_NAME)
-                              are expanded using the container's environment. Defaults
-                              to "" (volume's root). SubPathExpr and SubPath are mutually
-                              exclusive.
-                            type: string
-                        required:
-                          - mountPath
-                          - name
-                        type: object
-                      type: array
-                  type: object
-                clientService:
-                  description: ClientService defines the Bookkeeper Client Service
-                    resource template.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                  type: object
-                configMap:
-                  description: ConfigMap defines the configmap resource template.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                  type: object
-                headlessService:
-                  description: HeadlessService defines the Bookkeeper Headless Service
-                    resource template.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                  type: object
-                pdb:
-                  description: PDB defines the podDisruptionBudget resource template.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                  type: object
-              type: object
-            autoRecovery:
-              description: AutoRecovery defines configurations of auto recovery
-              properties:
-                conf:
-                  additionalProperties:
-                    type: string
-                  description: Conf defines the configuration of auto recovery bookies
-                  type: object
-                pod:
-                  description: Pod defines the policy for creating an auto recovery
-                    pod for the cluster
-                  properties:
-                    affinity:
-                      description: Affinity specifies the scheduling constraints of
-                        a pod
-                      properties:
-                        nodeAffinity:
-                          description: Describes node affinity scheduling rules for
-                            the pod.
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node matches the corresponding matchExpressions;
-                                the node(s) with the highest sum are the most preferred.
-                              items:
-                                description: An empty preferred scheduling term matches
-                                  all objects with implicit weight 0 (i.e. it's a
-                                  no-op). A null preferred scheduling term matches
-                                  no objects (i.e. is also a no-op).
-                                properties:
-                                  preference:
-                                    description: A node selector term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
-                                          properties:
-                                            key:
-                                              description: The label key that the
-                                                selector applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If
-                                                the operator is Exists or DoesNotExist,
-                                                the values array must be empty. If
-                                                the operator is Gt or Lt, the values
-                                                array must have a single element,
-                                                which will be interpreted as an integer.
-                                                This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
-                                          properties:
-                                            key:
-                                              description: The label key that the
-                                                selector applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If
-                                                the operator is Exists or DoesNotExist,
-                                                the values array must be empty. If
-                                                the operator is Gt or Lt, the values
-                                                array must have a single element,
-                                                which will be interpreted as an integer.
-                                                This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  weight:
-                                    description: Weight associated with matching the
-                                      corresponding nodeSelectorTerm, in the range
-                                      1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - preference
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified
-                                by this field are not met at scheduling time, the
-                                pod will not be scheduled onto the node. If the affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to an
-                                update), the system may or may not try to eventually
-                                evict the pod from its node.
-                              properties:
-                                nodeSelectorTerms:
-                                  description: Required. A list of node selector terms.
-                                    The terms are ORed.
-                                  items:
-                                    description: A null or empty node selector term
-                                      matches no objects. The requirements of them
-                                      are ANDed. The TopologySelectorTerm type implements
-                                      a subset of the NodeSelectorTerm.
-                                    properties:
-                                      matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
-                                        items:
-                                          description: A node selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
-                                          properties:
-                                            key:
-                                              description: The label key that the
-                                                selector applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If
-                                                the operator is Exists or DoesNotExist,
-                                                the values array must be empty. If
-                                                the operator is Gt or Lt, the values
-                                                array must have a single element,
-                                                which will be interpreted as an integer.
-                                                This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
-                                        items:
-                                          description: A node selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
-                                          properties:
-                                            key:
-                                              description: The label key that the
-                                                selector applies to.
-                                              type: string
-                                            operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
-                                              type: string
-                                            values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If
-                                                the operator is Exists or DoesNotExist,
-                                                the values array must be empty. If
-                                                the operator is Gt or Lt, the values
-                                                array must have a single element,
-                                                which will be interpreted as an integer.
-                                                This array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                    type: object
-                                  type: array
-                              required:
-                                - nodeSelectorTerms
-                              type: object
-                          type: object
-                        podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g.
-                            co-locate this pod in the same node, zone, etc. as some
-                            other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the
-                                corresponding podAffinityTerm; the node(s) with the
-                                highest sum are the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The
-                                              requirements are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents
-                                                    a key's relationship to a set
-                                                    of values. Valid operators are
-                                                    In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array
-                                                    of string values. If the operator
-                                                    is In or NotIn, the values array
-                                                    must be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located
-                                          (affinity) or not co-located (anti-affinity)
-                                          with the pods matching the labelSelector
-                                          in the specified namespaces, where co-located
-                                          is defined as running on a node whose value
-                                          of the label with key topologyKey matches
-                                          that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not
-                                          allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range
-                                      1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified
-                                by this field are not met at scheduling time, the
-                                pod will not be scheduled onto the node. If the affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a
-                                pod label update), the system may or may not try to
-                                eventually evict the pod from its node. When there
-                                are multiple elements, the lists of nodes corresponding
-                                to each podAffinityTerm are intersected, i.e. all
-                                terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or
-                                  not co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any
-                                  node on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified
-                                      namespaces, where co-located is defined as running
-                                      on a node whose value of the label with key
-                                      topologyKey matches that of any node on which
-                                      any of the selected pods is running. Empty topologyKey
-                                      is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                        podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules
-                            (e.g. avoid putting this pod in the same node, zone, etc.
-                            as some other pod(s)).
-                          properties:
-                            preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the anti-affinity expressions
-                                specified by this field, but it may choose a node
-                                that violates one or more of the expressions. The
-                                node that is most preferred is the one with the greatest
-                                sum of weights, i.e. for each node that meets all
-                                of the scheduling requirements (resource request,
-                                requiredDuringScheduling anti-affinity expressions,
-                                etc.), compute a sum by iterating through the elements
-                                of this field and adding "weight" to the sum if the
-                                node has pods which matches the corresponding podAffinityTerm;
-                                the node(s) with the highest sum are the most preferred.
-                              items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
-                                properties:
-                                  podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
-                                    properties:
-                                      labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
-                                        properties:
-                                          matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The
-                                              requirements are ANDed.
-                                            items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
-                                              properties:
-                                                key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
-                                                  type: string
-                                                operator:
-                                                  description: operator represents
-                                                    a key's relationship to a set
-                                                    of values. Valid operators are
-                                                    In, NotIn, Exists and DoesNotExist.
-                                                  type: string
-                                                values:
-                                                  description: values is an array
-                                                    of string values. If the operator
-                                                    is In or NotIn, the values array
-                                                    must be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. This
-                                                    array is replaced during a strategic
-                                                    merge patch.
-                                                  items:
-                                                    type: string
-                                                  type: array
-                                              required:
-                                                - key
-                                                - operator
-                                              type: object
-                                            type: array
-                                          matchLabels:
-                                            additionalProperties:
-                                              type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
-                                            type: object
-                                        type: object
-                                      namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
-                                        items:
-                                          type: string
-                                        type: array
-                                      topologyKey:
-                                        description: This pod should be co-located
-                                          (affinity) or not co-located (anti-affinity)
-                                          with the pods matching the labelSelector
-                                          in the specified namespaces, where co-located
-                                          is defined as running on a node whose value
-                                          of the label with key topologyKey matches
-                                          that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not
-                                          allowed.
-                                        type: string
-                                    required:
-                                      - topologyKey
-                                    type: object
-                                  weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range
-                                      1-100.
-                                    format: int32
-                                    type: integer
-                                required:
-                                  - podAffinityTerm
-                                  - weight
-                                type: object
-                              type: array
-                            requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified
-                                by this field are not met at scheduling time, the
-                                pod will not be scheduled onto the node. If the anti-affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a
-                                pod label update), the system may or may not try to
-                                eventually evict the pod from its node. When there
-                                are multiple elements, the lists of nodes corresponding
-                                to each podAffinityTerm are intersected, i.e. all
-                                terms must be satisfied.
-                              items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or
-                                  not co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any
-                                  node on which a pod of the set of pods is running
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified
-                                      namespaces, where co-located is defined as running
-                                      on a node whose value of the label with key
-                                      topologyKey matches that of any node on which
-                                      any of the selected pods is running. Empty topologyKey
-                                      is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              type: array
-                          type: object
-                      type: object
-                    annotations:
-                      additionalProperties:
-                        type: string
-                      description: Annotations specifies the annotations to attach
-                        to pods the operator creates
-                      type: object
-                    initContainers:
-                      description: InitContainers defines init containers of the pod.
-                        A typical use case could be using an init container to download
-                        a remote jar to a local path.
-                      items:
-                        description: A single application container that you want
-                          to run within a pod. The Container API from the core group
-                          is not used directly to avoid unneeded fields and reduce
-                          the size of the CRD. New fields could be added as needed.
-                        properties:
-                          args:
-                            description: Arguments to the entrypoint.
-                            items:
-                              type: string
-                            type: array
-                          command:
-                            description: Entrypoint array. Not executed within a shell.
-                            items:
-                              type: string
-                            type: array
-                          env:
-                            description: List of environment variables to set in the
-                              container.
-                            items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
-                              properties:
-                                name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
-                                  type: string
-                                value:
-                                  description: 'Variable references $(VAR_NAME) are
-                                    expanded using the previous defined environment
-                                    variables in the container and any service environment
-                                    variables. If a variable cannot be resolved, the
-                                    reference in the input string will be unchanged.
-                                    The $(VAR_NAME) syntax can be escaped with a double
-                                    $$, ie: $$(VAR_NAME). Escaped references will
-                                    never be expanded, regardless of whether the variable
-                                    exists or not. Defaults to "".'
-                                  type: string
-                                valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
-                                  properties:
-                                    configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
-                                      properties:
-                                        key:
-                                          description: The key to select.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                        optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                        - key
-                                      type: object
-                                    fieldRef:
-                                      description: 'Selects a field of the pod: supports
-                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                        spec.serviceAccountName, status.hostIP, status.podIP,
-                                        status.podIPs.'
-                                      properties:
-                                        apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
-                                          type: string
-                                        fieldPath:
-                                          description: Path of the field to select
-                                            in the specified API version.
-                                          type: string
-                                      required:
-                                        - fieldPath
-                                      type: object
-                                    resourceFieldRef:
-                                      description: 'Selects a resource of the container:
-                                        only resources limits and requests (limits.cpu,
-                                        limits.memory, limits.ephemeral-storage, requests.cpu,
-                                        requests.memory and requests.ephemeral-storage)
-                                        are currently supported.'
-                                      properties:
-                                        containerName:
-                                          description: 'Container name: required for
-                                            volumes, optional for env vars'
-                                          type: string
-                                        divisor:
-                                          anyOf:
-                                            - type: integer
-                                            - type: string
-                                          description: Specifies the output format
-                                            of the exposed resources, defaults to
-                                            "1"
-                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                          x-kubernetes-int-or-string: true
-                                        resource:
-                                          description: 'Required: resource to select'
-                                          type: string
-                                      required:
-                                        - resource
-                                      type: object
-                                    secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                        - key
-                                      type: object
-                                  type: object
-                              required:
-                                - name
-                              type: object
-                            type: array
-                          envFrom:
-                            description: List of sources to populate environment variables
-                              in the container.
-                            items:
-                              description: EnvFromSource represents the source of
-                                a set of ConfigMaps
-                              properties:
-                                configMapRef:
-                                  description: The ConfigMap to select from
-                                  properties:
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the ConfigMap must
-                                        be defined
-                                      type: boolean
-                                  type: object
-                                prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
-                                  type: string
-                                secretRef:
-                                  description: The Secret to select from
-                                  properties:
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the Secret must
-                                        be defined
-                                      type: boolean
-                                  type: object
-                              type: object
-                            type: array
-                          image:
-                            description: Docker image name.
-                            type: string
-                          imagePullPolicy:
-                            description: Image pull policy.
-                            type: string
-                          livenessProbe:
-                            description: Periodic probe of container liveness.
-                            properties:
-                              exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
-                                properties:
-                                  command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory
-                                      for the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it
-                                      is not run inside a shell, so traditional shell
-                                      instructions ('|', etc) won't work. To use a
-                                      shell, you need to explicitly call out to that
-                                      shell. Exit status of 0 is treated as live/healthy
-                                      and non-zero is unhealthy.
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              failureThreshold:
-                                description: Minimum consecutive failures for the
-                                  probe to be considered failed after having succeeded.
-                                  Defaults to 3. Minimum value is 1.
-                                format: int32
-                                type: integer
-                              httpGet:
-                                description: HTTPGet specifies the http request to
-                                  perform.
-                                properties:
-                                  host:
-                                    description: Host name to connect to, defaults
-                                      to the pod IP. You probably want to set "Host"
-                                      in httpHeaders instead.
-                                    type: string
-                                  httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
-                                    items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
-                                      properties:
-                                        name:
-                                          description: The header field name
-                                          type: string
-                                        value:
-                                          description: The header field value
-                                          type: string
-                                      required:
-                                        - name
-                                        - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    description: Path to access on the HTTP server.
-                                    type: string
-                                  port:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
-                                    type: string
-                                required:
-                                  - port
-                                type: object
-                              initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                  has started before liveness probes are initiated.
-                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                                format: int32
-                                type: integer
-                              periodSeconds:
-                                description: How often (in seconds) to perform the
-                                  probe. Default to 10 seconds. Minimum value is 1.
-                                format: int32
-                                type: integer
-                              successThreshold:
-                                description: Minimum consecutive successes for the
-                                  probe to be considered successful after having failed.
-                                  Defaults to 1. Must be 1 for liveness and startup.
-                                  Minimum value is 1.
-                                format: int32
-                                type: integer
-                              tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                  a TCP port. TCP hooks not yet supported TODO: implement
-                                  a realistic TCP lifecycle hook'
-                                properties:
-                                  host:
-                                    description: 'Optional: Host name to connect to,
-                                      defaults to the pod IP.'
-                                    type: string
-                                  port:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                  - port
-                                type: object
-                              timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                  times out. Defaults to 1 second. Minimum value is
-                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                                format: int32
-                                type: integer
-                            type: object
-                          name:
-                            description: Name of the container specified as a DNS_LABEL.
-                              Each container in a pod must have a unique name (DNS_LABEL).
-                            type: string
-                          ports:
-                            description: List of ports to expose from the container.
-                            items:
-                              description: ContainerPort represents a network port
-                                in a single container.
-                              properties:
-                                containerPort:
-                                  description: Number of port to expose on the pod's
-                                    IP address. This must be a valid port number,
-                                    0 < x < 65536.
-                                  format: int32
-                                  type: integer
-                                hostIP:
-                                  description: What host IP to bind the external port
-                                    to.
-                                  type: string
-                                hostPort:
-                                  description: Number of port to expose on the host.
-                                    If specified, this must be a valid port number,
-                                    0 < x < 65536. If HostNetwork is specified, this
-                                    must match ContainerPort. Most containers do not
-                                    need this.
-                                  format: int32
-                                  type: integer
-                                name:
-                                  description: If specified, this must be an IANA_SVC_NAME
-                                    and unique within the pod. Each named port in
-                                    a pod must have a unique name. Name for the port
-                                    that can be referred to by services.
-                                  type: string
-                                protocol:
-                                  description: Protocol for port. Must be UDP, TCP,
-                                    or SCTP. Defaults to "TCP".
-                                  type: string
-                              required:
-                                - containerPort
-                              type: object
-                            type: array
-                            x-kubernetes-list-map-keys:
-                              - containerPort
-                            x-kubernetes-list-type: map
-                          readinessProbe:
-                            description: 'Periodic probe of container service readiness.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            properties:
-                              exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
-                                properties:
-                                  command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory
-                                      for the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it
-                                      is not run inside a shell, so traditional shell
-                                      instructions ('|', etc) won't work. To use a
-                                      shell, you need to explicitly call out to that
-                                      shell. Exit status of 0 is treated as live/healthy
-                                      and non-zero is unhealthy.
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              failureThreshold:
-                                description: Minimum consecutive failures for the
-                                  probe to be considered failed after having succeeded.
-                                  Defaults to 3. Minimum value is 1.
-                                format: int32
-                                type: integer
-                              httpGet:
-                                description: HTTPGet specifies the http request to
-                                  perform.
-                                properties:
-                                  host:
-                                    description: Host name to connect to, defaults
-                                      to the pod IP. You probably want to set "Host"
-                                      in httpHeaders instead.
-                                    type: string
-                                  httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
-                                    items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
-                                      properties:
-                                        name:
-                                          description: The header field name
-                                          type: string
-                                        value:
-                                          description: The header field value
-                                          type: string
-                                      required:
-                                        - name
-                                        - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    description: Path to access on the HTTP server.
-                                    type: string
-                                  port:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
-                                    type: string
-                                required:
-                                  - port
-                                type: object
-                              initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                  has started before liveness probes are initiated.
-                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                                format: int32
-                                type: integer
-                              periodSeconds:
-                                description: How often (in seconds) to perform the
-                                  probe. Default to 10 seconds. Minimum value is 1.
-                                format: int32
-                                type: integer
-                              successThreshold:
-                                description: Minimum consecutive successes for the
-                                  probe to be considered successful after having failed.
-                                  Defaults to 1. Must be 1 for liveness and startup.
-                                  Minimum value is 1.
-                                format: int32
-                                type: integer
-                              tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                  a TCP port. TCP hooks not yet supported TODO: implement
-                                  a realistic TCP lifecycle hook'
-                                properties:
-                                  host:
-                                    description: 'Optional: Host name to connect to,
-                                      defaults to the pod IP.'
-                                    type: string
-                                  port:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                  - port
-                                type: object
-                              timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                  times out. Defaults to 1 second. Minimum value is
-                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                                format: int32
-                                type: integer
-                            type: object
-                          resources:
-                            description: Compute Resources required by this container.
-                            properties:
-                              limits:
-                                additionalProperties:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount
-                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                type: object
-                              requests:
-                                additionalProperties:
-                                  anyOf:
-                                    - type: integer
-                                    - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                  of compute resources required. If Requests is omitted
-                                  for a container, it defaults to Limits if that is
-                                  explicitly specified, otherwise to an implementation-defined
-                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                type: object
-                            type: object
-                          startupProbe:
-                            description: StartupProbe indicates that the Pod has successfully
-                              initialized.
-                            properties:
-                              exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
-                                properties:
-                                  command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory
-                                      for the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it
-                                      is not run inside a shell, so traditional shell
-                                      instructions ('|', etc) won't work. To use a
-                                      shell, you need to explicitly call out to that
-                                      shell. Exit status of 0 is treated as live/healthy
-                                      and non-zero is unhealthy.
-                                    items:
-                                      type: string
-                                    type: array
-                                type: object
-                              failureThreshold:
-                                description: Minimum consecutive failures for the
-                                  probe to be considered failed after having succeeded.
-                                  Defaults to 3. Minimum value is 1.
-                                format: int32
-                                type: integer
-                              httpGet:
-                                description: HTTPGet specifies the http request to
-                                  perform.
-                                properties:
-                                  host:
-                                    description: Host name to connect to, defaults
-                                      to the pod IP. You probably want to set "Host"
-                                      in httpHeaders instead.
-                                    type: string
-                                  httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
-                                    items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
-                                      properties:
-                                        name:
-                                          description: The header field name
-                                          type: string
-                                        value:
-                                          description: The header field value
-                                          type: string
-                                      required:
-                                        - name
-                                        - value
-                                      type: object
-                                    type: array
-                                  path:
-                                    description: Path to access on the HTTP server.
-                                    type: string
-                                  port:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
-                                  scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
-                                    type: string
-                                required:
-                                  - port
-                                type: object
-                              initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                  has started before liveness probes are initiated.
-                                  More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                                format: int32
-                                type: integer
-                              periodSeconds:
-                                description: How often (in seconds) to perform the
-                                  probe. Default to 10 seconds. Minimum value is 1.
-                                format: int32
-                                type: integer
-                              successThreshold:
-                                description: Minimum consecutive successes for the
-                                  probe to be considered successful after having failed.
-                                  Defaults to 1. Must be 1 for liveness and startup.
-                                  Minimum value is 1.
-                                format: int32
-                                type: integer
-                              tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                  a TCP port. TCP hooks not yet supported TODO: implement
-                                  a realistic TCP lifecycle hook'
-                                properties:
-                                  host:
-                                    description: 'Optional: Host name to connect to,
-                                      defaults to the pod IP.'
-                                    type: string
-                                  port:
-                                    anyOf:
-                                      - type: integer
-                                      - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
-                                    x-kubernetes-int-or-string: true
-                                required:
-                                  - port
-                                type: object
-                              timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                  times out. Defaults to 1 second. Minimum value is
-                                  1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                                format: int32
-                                type: integer
-                            type: object
-                          volumeMounts:
-                            description: Pod volumes to mount into the container's
-                              filesystem.
-                            items:
-                              description: VolumeMount describes a mounting of a Volume
-                                within a container.
-                              properties:
-                                mountPath:
-                                  description: Path within the container at which
-                                    the volume should be mounted.  Must not contain
-                                    ':'.
-                                  type: string
-                                mountPropagation:
-                                  description: mountPropagation determines how mounts
-                                    are propagated from the host to container and
-                                    the other way around. When not set, MountPropagationNone
-                                    is used. This field is beta in 1.10.
-                                  type: string
-                                name:
-                                  description: This must match the Name of a Volume.
-                                  type: string
-                                readOnly:
-                                  description: Mounted read-only if true, read-write
-                                    otherwise (false or unspecified). Defaults to
-                                    false.
-                                  type: boolean
-                                subPath:
-                                  description: Path within the volume from which the
-                                    container's volume should be mounted. Defaults
-                                    to "" (volume's root).
-                                  type: string
-                                subPathExpr:
-                                  description: Expanded path within the volume from
-                                    which the container's volume should be mounted.
-                                    Behaves similarly to SubPath but environment variable
-                                    references $(VAR_NAME) are expanded using the
-                                    container's environment. Defaults to "" (volume's
-                                    root). SubPathExpr and SubPath are mutually exclusive.
-                                  type: string
-                              required:
-                                - mountPath
-                                - name
-                              type: object
-                            type: array
-                          workingDir:
-                            description: Container's working directory.
-                            type: string
-                        required:
-                          - name
-                        type: object
-                      type: array
-                    jvmOptions:
-                      description: JVMOptions defines JVM parameters of Bookies
-                      properties:
-                        extraOptions:
-                          items:
-                            type: string
-                          type: array
-                        gcLoggingOptions:
-                          items:
-                            type: string
-                          type: array
-                        gcOptions:
-                          items:
-                            type: string
-                          type: array
-                        memoryOptions:
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: Labels specifies the labels to attach to pod the
-                        operator creates for the bookkeeper cluster.
-                      type: object
-                    nodeSelector:
-                      additionalProperties:
-                        type: string
-                      description: NodeSelector specifies a map of key-value pairs.
-                        For a pod to be eligible to run on a node, the node must have
-                        each of the indicated key-value pairs as labels.
-                      type: object
-                    resources:
-                      description: Resources specifies the resource requirements of
-                        a pod to run in the cluster
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. More info:
-                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                    securityContext:
-                      description: 'SecurityContext specifies the security context
-                        for the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
-                      properties:
-                        fsGroup:
-                          description: "A special supplemental group that applies
-                            to all containers in a pod. Some volume types allow the
-                            Kubelet to change the ownership of that volume to be owned
-                            by the pod: \n 1. The owning GID will be the FSGroup 2.
-                            The setgid bit is set (new files created in the volume
-                            will be owned by FSGroup) 3. The permission bits are OR'd
-                            with rw-rw---- \n If unset, the Kubelet will not modify
-                            the ownership and permissions of any volume."
-                          format: int64
-                          type: integer
-                        fsGroupChangePolicy:
-                          description: 'fsGroupChangePolicy defines behavior of changing
-                            ownership and permission of the volume before being exposed
-                            inside Pod. This field will only apply to volume types
-                            which support fsGroup based ownership(and permissions).
-                            It will have no effect on ephemeral volume types such
-                            as: secret, configmaps and emptydir. Valid values are
-                            "OnRootMismatch" and "Always". If not specified defaults
-                            to "Always".'
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
                           type: string
-                        runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence for that container.
-                          format: int64
-                          type: integer
-                        runAsNonRoot:
-                          description: Indicates that the container must run as a
-                            non-root user. If true, the Kubelet will validate the
-                            image at runtime to ensure that it does not run as UID
-                            0 (root) and fail to start the container if it does. If
-                            unset or false, no such validation will be performed.
-                            May also be set in SecurityContext.  If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          type: boolean
-                        runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata
-                            if unspecified. May also be set in SecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence for
-                            that container.
-                          format: int64
-                          type: integer
-                        seLinuxOptions:
-                          description: The SELinux context to be applied to all containers.
-                            If unspecified, the container runtime will allocate a
-                            random SELinux context for each container.  May also be
-                            set in SecurityContext.  If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence for that container.
-                          properties:
-                            level:
-                              description: Level is SELinux level label that applies
-                                to the container.
-                              type: string
-                            role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
-                              type: string
-                            type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
-                              type: string
-                            user:
-                              description: User is a SELinux user label that applies
-                                to the container.
-                              type: string
-                          type: object
-                        seccompProfile:
-                          description: The seccomp options to use by the containers
-                            in this pod.
-                          properties:
-                            localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile
-                                must be preconfigured on the node to work. Must be
-                                a descending path, relative to the kubelet's configured
-                                seccomp profile location. Must only be set if type
-                                is "Localhost".
-                              type: string
-                            type:
-                              description: "type indicates which kind of seccomp profile
-                                will be applied. Valid options are: \n Localhost -
-                                a profile defined in a file on the node should be
-                                used. RuntimeDefault - the container runtime default
-                                profile should be used. Unconfined - no profile should
-                                be applied."
-                              type: string
-                          required:
-                            - type
-                          type: object
-                        supplementalGroups:
-                          description: A list of groups applied to the first process
-                            run in each container, in addition to the container's
-                            primary GID.  If unspecified, no groups will be added
-                            to any container.
-                          items:
-                            format: int64
-                            type: integer
-                          type: array
-                        sysctls:
-                          description: Sysctls hold a list of namespaced sysctls used
-                            for the pod. Pods with unsupported sysctls (by the container
-                            runtime) might fail to launch.
-                          items:
-                            description: Sysctl defines a kernel parameter to be set
-                            properties:
-                              name:
-                                description: Name of a property to set
-                                type: string
-                              value:
-                                description: Value of a property to set
-                                type: string
-                            required:
-                              - name
-                              - value
-                            type: object
-                          type: array
-                        windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options within a container's
-                            SecurityContext will be used. If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
-                          properties:
-                            gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
-                              type: string
-                            gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
-                              type: string
-                            runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set
-                                in PodSecurityContext. If set in both SecurityContext
-                                and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
-                              type: string
-                          type: object
-                      type: object
-                    terminationGracePeriodSeconds:
-                      description: TerminationGracePeriodSeconds is the amount of
-                        time that kubernetes will give for a pod before terminating
-                        it.
-                      format: int64
-                      type: integer
-                    tolerations:
-                      description: Tolerations specifies the tolerations of a Pod
-                      items:
-                        description: The pod this Toleration is attached to tolerates
-                          any taint that matches the triple <key,value,effect> using
-                          the matching operator <operator>.
-                        properties:
-                          effect:
-                            description: Effect indicates the taint effect to match.
-                              Empty means match all taint effects. When specified,
-                              allowed values are NoSchedule, PreferNoSchedule and
-                              NoExecute.
-                            type: string
-                          key:
-                            description: Key is the taint key that the toleration
-                              applies to. Empty means match all taint keys. If the
-                              key is empty, operator must be Exists; this combination
-                              means to match all values and all keys.
-                            type: string
-                          operator:
-                            description: Operator represents a key's relationship
-                              to the value. Valid operators are Exists and Equal.
-                              Defaults to Equal. Exists is equivalent to wildcard
-                              for value, so that a pod can tolerate all taints of
-                              a particular category.
-                            type: string
-                          tolerationSeconds:
-                            description: TolerationSeconds represents the period of
-                              time the toleration (which must be of effect NoExecute,
-                              otherwise this field is ignored) tolerates the taint.
-                              By default, it is not set, which means tolerate the
-                              taint forever (do not evict). Zero and negative values
-                              will be treated as 0 (evict immediately) by the system.
-                            format: int64
-                            type: integer
-                          value:
-                            description: Value is the taint value the toleration matches
-                              to. If the operator is Exists, the value should be empty,
-                              otherwise just a regular string.
-                            type: string
+                        type: array
+                    type: object
+                  autoRecoveryHeadlessService:
+                    description: AutoRecoveryHeadlessService defines the service resource
+                      template for autoRecovery headless service.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                         type: object
-                      type: array
-                    vars:
-                      description: Vars specifies the environment variables of a Pod
-                      items:
-                        description: EnvVar represents an environment variable present
-                          in a Container.
-                        properties:
-                          name:
-                            description: Name of the environment variable. Must be
-                              a C_IDENTIFIER.
-                            type: string
-                          value:
-                            description: 'Variable references $(VAR_NAME) are expanded
-                              using the previous defined environment variables in
-                              the container and any service environment variables.
-                              If a variable cannot be resolved, the reference in the
-                              input string will be unchanged. The $(VAR_NAME) syntax
-                              can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
-                              references will never be expanded, regardless of whether
-                              the variable exists or not. Defaults to "".'
-                            type: string
-                          valueFrom:
-                            description: Source for the environment variable's value.
-                              Cannot be used if value is not empty.
-                            properties:
-                              configMapKeyRef:
-                                description: Selects a key of a ConfigMap.
-                                properties:
-                                  key:
-                                    description: The key to select.
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                    type: object
+                  autoRecoveryStatefulSet:
+                    description: AutoRecoveryStatefulSet defines the statefulset resource
+                      template for adopting existing autoRecovery statefulset.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          the name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                      volumeClaimTemplates:
+                        description: VolumeClaimTemplates is a list of claims that pods
+                          are allowed to reference. If a non-empty list is specified,
+                          the original values in the desired STS will be replaced.
+                        items:
+                          description: PersistentVolumeClaim is a user's request for
+                            and claim to a persistent volume
+                          properties:
+                            apiVersion:
+                              description: 'APIVersion defines the versioned schema
+                                of this representation of an object. Servers should
+                                convert recognized schemas to the latest internal value,
+                                and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                              type: string
+                            kind:
+                              description: 'Kind is a string value representing the
+                                REST resource this object represents. Servers may infer
+                                this from the endpoint the client submits requests to.
+                                Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            metadata:
+                              description: 'Standard object''s metadata. More info:
+                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                              type: object
+                            spec:
+                              description: 'Spec defines the desired characteristics
+                                of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              properties:
+                                accessModes:
+                                  description: 'AccessModes contains the desired access
+                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                  items:
                                     type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                  type: array
+                                dataSource:
+                                  description: 'This field can be used to specify either:
+                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                                    - Beta) * An existing PVC (PersistentVolumeClaim)
+                                    * An existing custom resource/object that implements
+                                    data population (Alpha) In order to use VolumeSnapshot
+                                    object types, the appropriate feature gate must
+                                    be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
+                                    If the provisioner or an external controller can
+                                    support the specified data source, it will create
+                                    a new volume based on the contents of the specified
+                                    data source. If the specified data source is not
+                                    supported, the volume will not be created and the
+                                    failure will be reported as an event. In the future,
+                                    we plan to support more data source types and the
+                                    behavior of the provisioner may change.'
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup is the group for the resource
+                                        being referenced. If APIGroup is not specified,
+                                        the specified Kind must be in the core API group.
+                                        For any other third-party types, APIGroup is
+                                        required.
+                                      type: string
+                                    kind:
+                                      description: Kind is the type of resource being
+                                        referenced
+                                      type: string
+                                    name:
+                                      description: Name is the name of resource being
+                                        referenced
+                                      type: string
+                                  required:
+                                    - kind
+                                    - name
+                                  type: object
+                                resources:
+                                  description: 'Resources represents the minimum resources
+                                    the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                  properties:
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: 'Limits describes the maximum amount
+                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: 'Requests describes the minimum amount
+                                        of compute resources required. If Requests is
+                                        omitted for a container, it defaults to Limits
+                                        if that is explicitly specified, otherwise to
+                                        an implementation-defined value. More info:
+                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      type: object
+                                  type: object
+                                selector:
+                                  description: A label query over volumes to consider
+                                    for binding.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If
+                                              the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array
+                                              is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is "In",
+                                        and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                storageClassName:
+                                  description: 'Name of the StorageClass required by
+                                    the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                  type: string
+                                volumeMode:
+                                  description: volumeMode defines what type of volume
+                                    is required by the claim. Value of Filesystem is
+                                    implied when not included in claim spec.
+                                  type: string
+                                volumeName:
+                                  description: VolumeName is the binding reference to
+                                    the PersistentVolume backing this claim.
+                                  type: string
+                              type: object
+                            status:
+                              description: 'Status represents the current information/status
+                                of a persistent volume claim. Read-only. More info:
+                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              properties:
+                                accessModes:
+                                  description: 'AccessModes contains the actual access
+                                    modes the volume backing the PVC has. More info:
+                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                  items:
                                     type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap or
-                                      its key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                              fieldRef:
-                                description: 'Selects a field of the pod: supports
-                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                  spec.serviceAccountName, status.hostIP, status.podIP,
-                                  status.podIPs.'
-                                properties:
-                                  apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
-                                    type: string
-                                  fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
-                                    type: string
-                                required:
-                                  - fieldPath
-                                type: object
-                              resourceFieldRef:
-                                description: 'Selects a resource of the container:
-                                  only resources limits and requests (limits.cpu,
-                                  limits.memory, limits.ephemeral-storage, requests.cpu,
-                                  requests.memory and requests.ephemeral-storage)
-                                  are currently supported.'
-                                properties:
-                                  containerName:
-                                    description: 'Container name: required for volumes,
-                                      optional for env vars'
-                                    type: string
-                                  divisor:
+                                  type: array
+                                capacity:
+                                  additionalProperties:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  resource:
-                                    description: 'Required: resource to select'
-                                    type: string
-                                required:
-                                  - resource
-                                type: object
-                              secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
-                                properties:
-                                  key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
-                                    type: string
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret or its
-                                      key must be defined
-                                    type: boolean
-                                required:
-                                  - key
-                                type: object
-                            type: object
-                        required:
-                          - name
-                        type: object
-                      type: array
-                    volumes:
-                      description: Volumes defines extra volumes of the pod.
-                      items:
-                        description: Volume represents a named volume in a pod that
-                          may be accessed by any container in the pod. The Volume
-                          API from the core group is not used directly to avoid unneeded
-                          fields defined in `VolumeSource` and reduce the size of
-                          the CRD. New fields in VolumeSource could be added as needed.
-                        properties:
-                          configMap:
-                            description: ConfigMap represents a configMap that should
-                              populate this volume
-                            properties:
-                              defaultMode:
-                                description: 'Optional: mode bits used to set permissions
-                                  on created files by default. Must be an octal value
-                                  between 0000 and 0777 or a decimal value between
-                                  0 and 511. YAML accepts both octal and decimal values,
-                                  JSON requires decimal values for mode bits. Defaults
-                                  to 0644. Directories within the path are not affected
-                                  by this setting. This might be in conflict with
-                                  other options that affect the file mode, like fsGroup,
-                                  and the result can be other mode bits set.'
-                                format: int32
-                                type: integer
-                              items:
-                                description: If unspecified, each key-value pair in
-                                  the Data field of the referenced ConfigMap will
-                                  be projected into the volume as a file whose name
-                                  is the key and content is the value. If specified,
-                                  the listed keys will be projected into the specified
-                                  paths, and unlisted keys will not be present. If
-                                  a key is specified which is not present in the ConfigMap,
-                                  the volume setup will error unless it is marked
-                                  optional. Paths must be relative and may not contain
-                                  the '..' path or start with '..'.
-                                items:
-                                  description: Maps a string key to a path within
-                                    a volume.
-                                  properties:
-                                    key:
-                                      description: The key to project.
-                                      type: string
-                                    mode:
-                                      description: 'Optional: mode bits used to set
-                                        permissions on this file. Must be an octal
-                                        value between 0000 and 0777 or a decimal value
-                                        between 0 and 511. YAML accepts both octal
-                                        and decimal values, JSON requires decimal
-                                        values for mode bits. If not specified, the
-                                        volume defaultMode will be used. This might
-                                        be in conflict with other options that affect
-                                        the file mode, like fsGroup, and the result
-                                        can be other mode bits set.'
-                                      format: int32
-                                      type: integer
-                                    path:
-                                      description: The relative path of the file to
-                                        map the key to. May not be an absolute path.
-                                        May not contain the path element '..'. May
-                                        not start with the string '..'.
-                                      type: string
-                                  required:
-                                    - key
-                                    - path
+                                  description: Represents the actual resources of the
+                                    underlying volume.
                                   type: object
-                                type: array
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
-                                type: string
-                              optional:
-                                description: Specify whether the ConfigMap or its
-                                  keys must be defined
-                                type: boolean
-                            type: object
-                          name:
-                            description: 'Volume''s name. Must be a DNS_LABEL and
-                              unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          secret:
-                            description: Secret represents a secret that should populate
-                              this volume.
-                            properties:
-                              defaultMode:
-                                description: 'Optional: mode bits used to set permissions
-                                  on created files by default. Must be an octal value
-                                  between 0000 and 0777 or a decimal value between
-                                  0 and 511. YAML accepts both octal and decimal values,
-                                  JSON requires decimal values for mode bits. Defaults
-                                  to 0644. Directories within the path are not affected
-                                  by this setting. This might be in conflict with
-                                  other options that affect the file mode, like fsGroup,
-                                  and the result can be other mode bits set.'
-                                format: int32
-                                type: integer
-                              items:
-                                description: If unspecified, each key-value pair in
-                                  the Data field of the referenced Secret will be
-                                  projected into the volume as a file whose name is
-                                  the key and content is the value. If specified,
-                                  the listed keys will be projected into the specified
-                                  paths, and unlisted keys will not be present. If
-                                  a key is specified which is not present in the Secret,
-                                  the volume setup will error unless it is marked
-                                  optional. Paths must be relative and may not contain
-                                  the '..' path or start with '..'.
-                                items:
-                                  description: Maps a string key to a path within
-                                    a volume.
-                                  properties:
-                                    key:
-                                      description: The key to project.
-                                      type: string
-                                    mode:
-                                      description: 'Optional: mode bits used to set
-                                        permissions on this file. Must be an octal
-                                        value between 0000 and 0777 or a decimal value
-                                        between 0 and 511. YAML accepts both octal
-                                        and decimal values, JSON requires decimal
-                                        values for mode bits. If not specified, the
-                                        volume defaultMode will be used. This might
-                                        be in conflict with other options that affect
-                                        the file mode, like fsGroup, and the result
-                                        can be other mode bits set.'
-                                      format: int32
-                                      type: integer
-                                    path:
-                                      description: The relative path of the file to
-                                        map the key to. May not be an absolute path.
-                                        May not contain the path element '..'. May
-                                        not start with the string '..'.
-                                      type: string
-                                  required:
-                                    - key
-                                    - path
-                                  type: object
-                                type: array
-                              optional:
-                                description: Specify whether the Secret or its keys
-                                  must be defined
-                                type: boolean
-                              secretName:
-                                description: 'Name of the secret in the pod''s namespace
-                                  to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                                type: string
-                            type: object
-                        required:
-                          - name
-                        type: object
-                      type: array
-                  type: object
-                replicas:
-                  description: Replicas defines the number of replicas of auto recovery
-                    bookies, defaults to 1, a value less or equal to 0 implies auto
-                    recovery is disabled for the cluster
-                  format: int32
-                  minimum: 0
-                  type: integer
-              type: object
-            conf:
-              additionalProperties:
-                type: string
-              description: 'Conf defines the bookkeeper configuration. It will be
-                used for generating the configuration file used by bookie process.
-                Deprecated: use `config`'
-              type: object
-            config:
-              description: Config defines the bookkeeper configuration
-              properties:
-                compactionRateByBytes:
-                  description: "CompactionRateByBytes is the rate at which compaction
-                    will read entries. The unit is adds per second. \n The default
-                    value is 52428800."
-                  format: int64
-                  minimum: 0
-                  type: integer
-                custom:
-                  additionalProperties:
-                    type: string
-                  description: Custom accepts other configurations
-                  type: object
-                fileInfoFormatVersionToWrite:
-                  description: "FileInfoFormatVersionToWrite is the fileinfo format
-                    version to write. Available formats are 0 and 1. \n The default
-                    value is 1"
-                  format: int32
-                  maximum: 1
-                  minimum: 0
-                  type: integer
-                gcWaitTime:
-                  description: "GCWaitTime is the interval to trigger next garbage
-                    collection, in milliseconds. \n The default value is 300000"
-                  format: int32
-                  minimum: 0
-                  type: integer
-                isThrottleByBytes:
-                  description: "IsThrottleByBytes defines the throttle compaction
-                    by bytes or by entries. \n The default value is true."
-                  type: boolean
-                journalFormatVersionToWrite:
-                  description: JournalFormatVersionToWrite is the journal format version
-                    to write. Available value are from 0 to 6. The default value is
-                    6.
-                  format: int32
-                  maximum: 6
-                  minimum: 0
-                  type: integer
-                journalMaxBackups:
-                  description: "JournalMaxBackups is the max number of old journal
-                    file to kept. \n The default value is 0."
-                  format: int32
-                  minimum: 0
-                  type: integer
-                persistBookieStatusEnabled:
-                  description: "PersistBookieStatusEnabled persists the bookie status
-                    locally on the disks. TODO: enable this after https://github.com/apache/bookkeeper/issues/2374
-                    is fixed. \n The default value is false."
-                  type: boolean
-                useTransactionalCompaction:
-                  description: "UseTransactionalCompaction is the flag to enable/disable
-                    transactional compaction. If it is set to true, it will use transactional
-                    compaction, which uses new entry log files to store entries after
-                    compaction. \n The default value is true."
-                  type: boolean
-              type: object
-            image:
-              description: Image is the container image used to run bookie pods. default
-                is apachepulsar/pulsar:latest
-              type: string
-            imagePullPolicy:
-              description: Image pull policy, one of Always, Never, IfNotPresent,
-                default to Always.
-              type: string
-            initialized:
-              description: Initialized determines whether to create the job to initialize
-                the cluster metadata.
-              type: boolean
-            labels:
-              additionalProperties:
-                type: string
-              description: Labels specifies the labels to attach to the stateful set
-                the operator creates for the bookkeeper cluster.
-              type: object
-            pod:
-              description: Pod defines the policy for creating a bookkeeper pod for
-                the cluster
-              properties:
-                affinity:
-                  description: Affinity specifies the scheduling constraints of a
-                    pod
-                  properties:
-                    nodeAffinity:
-                      description: Describes node affinity scheduling rules for the
-                        pod.
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods
-                            to nodes that satisfy the affinity expressions specified
-                            by this field, but it may choose a node that violates
-                            one or more of the expressions. The node that is most
-                            preferred is the one with the greatest sum of weights,
-                            i.e. for each node that meets all of the scheduling requirements
-                            (resource request, requiredDuringScheduling affinity expressions,
-                            etc.), compute a sum by iterating through the elements
-                            of this field and adding "weight" to the sum if the node
-                            matches the corresponding matchExpressions; the node(s)
-                            with the highest sum are the most preferred.
-                          items:
-                            description: An empty preferred scheduling term matches
-                              all objects with implicit weight 0 (i.e. it's a no-op).
-                              A null preferred scheduling term matches no objects
-                              (i.e. is also a no-op).
-                            properties:
-                              preference:
-                                description: A node selector term, associated with
-                                  the corresponding weight.
-                                properties:
-                                  matchExpressions:
-                                    description: A list of node selector requirements
-                                      by node's labels.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    description: A list of node selector requirements
-                                      by node's fields.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              weight:
-                                description: Weight associated with matching the corresponding
-                                  nodeSelectorTerm, in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - preference
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this
-                            field are not met at scheduling time, the pod will not
-                            be scheduled onto the node. If the affinity requirements
-                            specified by this field cease to be met at some point
-                            during pod execution (e.g. due to an update), the system
-                            may or may not try to eventually evict the pod from its
-                            node.
+                                conditions:
+                                  description: Current Condition of persistent volume
+                                    claim. If underlying persistent volume is being
+                                    resized then the Condition will be set to 'ResizeStarted'.
+                                  items:
+                                    description: PersistentVolumeClaimCondition contails
+                                      details about state of pvc
+                                    properties:
+                                      lastProbeTime:
+                                        description: Last time we probed the condition.
+                                        format: date-time
+                                        type: string
+                                      lastTransitionTime:
+                                        description: Last time the condition transitioned
+                                          from one status to another.
+                                        format: date-time
+                                        type: string
+                                      message:
+                                        description: Human-readable message indicating
+                                          details about last transition.
+                                        type: string
+                                      reason:
+                                        description: Unique, this should be a short,
+                                          machine understandable string that gives the
+                                          reason for condition's last transition. If
+                                          it reports "ResizeStarted" that means the
+                                          underlying persistent volume is being resized.
+                                        type: string
+                                      status:
+                                        type: string
+                                      type:
+                                        description: PersistentVolumeClaimConditionType
+                                          is a valid value of PersistentVolumeClaimCondition.Type
+                                        type: string
+                                    required:
+                                      - status
+                                      - type
+                                    type: object
+                                  type: array
+                                phase:
+                                  description: Phase represents the current phase of
+                                    PersistentVolumeClaim.
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
+                      volumeMounts:
+                        description: VolumeMounts is a list of volumes to mount into
+                          the container's filesystem. If a non-empty list is specified,
+                          the original values of the main container in the desired STS
+                          will be replaced.
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
                           properties:
-                            nodeSelectorTerms:
-                              description: Required. A list of node selector terms.
-                                The terms are ORed.
-                              items:
-                                description: A null or empty node selector term matches
-                                  no objects. The requirements of them are ANDed.
-                                  The TopologySelectorTerm type implements a subset
-                                  of the NodeSelectorTerm.
+                            mountPath:
+                              description: Path within the container at which the volume
+                                should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts are
+                                propagated from the host to container and the other
+                                way around. When not set, MountPropagationNone is used.
+                                This field is beta in 1.10.
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise
+                                (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's
+                                volume should be mounted. Defaults to "" (volume's root).
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which
+                                the container's volume should be mounted. Behaves similarly
+                                to SubPath but environment variable references $(VAR_NAME)
+                                are expanded using the container's environment. Defaults
+                                to "" (volume's root). SubPathExpr and SubPath are mutually
+                                exclusive.
+                              type: string
+                          required:
+                            - mountPath
+                            - name
+                          type: object
+                        type: array
+                    type: object
+                  bookieStatefulSet:
+                    description: BookieStatefulSet defines the statefulset resource
+                      template for bookie cluster.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          the name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                      volumeClaimTemplates:
+                        description: VolumeClaimTemplates is a list of claims that pods
+                          are allowed to reference. If a non-empty list is specified,
+                          the original values in the desired STS will be replaced.
+                        items:
+                          description: PersistentVolumeClaim is a user's request for
+                            and claim to a persistent volume
+                          properties:
+                            apiVersion:
+                              description: 'APIVersion defines the versioned schema
+                                of this representation of an object. Servers should
+                                convert recognized schemas to the latest internal value,
+                                and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                              type: string
+                            kind:
+                              description: 'Kind is a string value representing the
+                                REST resource this object represents. Servers may infer
+                                this from the endpoint the client submits requests to.
+                                Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            metadata:
+                              description: 'Standard object''s metadata. More info:
+                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                              type: object
+                            spec:
+                              description: 'Spec defines the desired characteristics
+                                of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              properties:
+                                accessModes:
+                                  description: 'AccessModes contains the desired access
+                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                  items:
+                                    type: string
+                                  type: array
+                                dataSource:
+                                  description: 'This field can be used to specify either:
+                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                                    - Beta) * An existing PVC (PersistentVolumeClaim)
+                                    * An existing custom resource/object that implements
+                                    data population (Alpha) In order to use VolumeSnapshot
+                                    object types, the appropriate feature gate must
+                                    be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
+                                    If the provisioner or an external controller can
+                                    support the specified data source, it will create
+                                    a new volume based on the contents of the specified
+                                    data source. If the specified data source is not
+                                    supported, the volume will not be created and the
+                                    failure will be reported as an event. In the future,
+                                    we plan to support more data source types and the
+                                    behavior of the provisioner may change.'
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup is the group for the resource
+                                        being referenced. If APIGroup is not specified,
+                                        the specified Kind must be in the core API group.
+                                        For any other third-party types, APIGroup is
+                                        required.
+                                      type: string
+                                    kind:
+                                      description: Kind is the type of resource being
+                                        referenced
+                                      type: string
+                                    name:
+                                      description: Name is the name of resource being
+                                        referenced
+                                      type: string
+                                  required:
+                                    - kind
+                                    - name
+                                  type: object
+                                resources:
+                                  description: 'Resources represents the minimum resources
+                                    the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                  properties:
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: 'Limits describes the maximum amount
+                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: 'Requests describes the minimum amount
+                                        of compute resources required. If Requests is
+                                        omitted for a container, it defaults to Limits
+                                        if that is explicitly specified, otherwise to
+                                        an implementation-defined value. More info:
+                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      type: object
+                                  type: object
+                                selector:
+                                  description: A label query over volumes to consider
+                                    for binding.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If
+                                              the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array
+                                              is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is "In",
+                                        and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                storageClassName:
+                                  description: 'Name of the StorageClass required by
+                                    the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                  type: string
+                                volumeMode:
+                                  description: volumeMode defines what type of volume
+                                    is required by the claim. Value of Filesystem is
+                                    implied when not included in claim spec.
+                                  type: string
+                                volumeName:
+                                  description: VolumeName is the binding reference to
+                                    the PersistentVolume backing this claim.
+                                  type: string
+                              type: object
+                            status:
+                              description: 'Status represents the current information/status
+                                of a persistent volume claim. Read-only. More info:
+                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              properties:
+                                accessModes:
+                                  description: 'AccessModes contains the actual access
+                                    modes the volume backing the PVC has. More info:
+                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                  items:
+                                    type: string
+                                  type: array
+                                capacity:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: Represents the actual resources of the
+                                    underlying volume.
+                                  type: object
+                                conditions:
+                                  description: Current Condition of persistent volume
+                                    claim. If underlying persistent volume is being
+                                    resized then the Condition will be set to 'ResizeStarted'.
+                                  items:
+                                    description: PersistentVolumeClaimCondition contails
+                                      details about state of pvc
+                                    properties:
+                                      lastProbeTime:
+                                        description: Last time we probed the condition.
+                                        format: date-time
+                                        type: string
+                                      lastTransitionTime:
+                                        description: Last time the condition transitioned
+                                          from one status to another.
+                                        format: date-time
+                                        type: string
+                                      message:
+                                        description: Human-readable message indicating
+                                          details about last transition.
+                                        type: string
+                                      reason:
+                                        description: Unique, this should be a short,
+                                          machine understandable string that gives the
+                                          reason for condition's last transition. If
+                                          it reports "ResizeStarted" that means the
+                                          underlying persistent volume is being resized.
+                                        type: string
+                                      status:
+                                        type: string
+                                      type:
+                                        description: PersistentVolumeClaimConditionType
+                                          is a valid value of PersistentVolumeClaimCondition.Type
+                                        type: string
+                                    required:
+                                      - status
+                                      - type
+                                    type: object
+                                  type: array
+                                phase:
+                                  description: Phase represents the current phase of
+                                    PersistentVolumeClaim.
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
+                      volumeMounts:
+                        description: VolumeMounts is a list of volumes to mount into
+                          the container's filesystem. If a non-empty list is specified,
+                          the original values of the main container in the desired STS
+                          will be replaced.
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the volume
+                                should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts are
+                                propagated from the host to container and the other
+                                way around. When not set, MountPropagationNone is used.
+                                This field is beta in 1.10.
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise
+                                (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's
+                                volume should be mounted. Defaults to "" (volume's root).
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which
+                                the container's volume should be mounted. Behaves similarly
+                                to SubPath but environment variable references $(VAR_NAME)
+                                are expanded using the container's environment. Defaults
+                                to "" (volume's root). SubPathExpr and SubPath are mutually
+                                exclusive.
+                              type: string
+                          required:
+                            - mountPath
+                            - name
+                          type: object
+                        type: array
+                    type: object
+                  clientService:
+                    description: ClientService defines the Bookkeeper Client Service
+                      resource template.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                    type: object
+                  configMap:
+                    description: ConfigMap defines the configmap resource template.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                    type: object
+                  headlessService:
+                    description: HeadlessService defines the Bookkeeper Headless Service
+                      resource template.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                    type: object
+                  pdb:
+                    description: PDB defines the podDisruptionBudget resource template.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                    type: object
+                type: object
+              autoRecovery:
+                description: AutoRecovery defines configurations of auto recovery
+                properties:
+                  conf:
+                    additionalProperties:
+                      type: string
+                    description: Conf defines the configuration of auto recovery bookies
+                    type: object
+                  pod:
+                    description: Pod defines the policy for creating an auto recovery
+                      pod for the cluster
+                    properties:
+                      affinity:
+                        description: Affinity specifies the scheduling constraints of
+                          a pod
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules for
+                              the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods
+                                  to nodes that satisfy the affinity expressions specified
+                                  by this field, but it may choose a node that violates
+                                  one or more of the expressions. The node that is most
+                                  preferred is the one with the greatest sum of weights,
+                                  i.e. for each node that meets all of the scheduling
+                                  requirements (resource request, requiredDuringScheduling
+                                  affinity expressions, etc.), compute a sum by iterating
+                                  through the elements of this field and adding "weight"
+                                  to the sum if the node matches the corresponding matchExpressions;
+                                  the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term matches
+                                    all objects with implicit weight 0 (i.e. it's a
+                                    no-op). A null preferred scheduling term matches
+                                    no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values, a
+                                              key, and an operator that relates the
+                                              key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn, the
+                                                  values array must be non-empty. If
+                                                  the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If
+                                                  the operator is Gt or Lt, the values
+                                                  array must have a single element,
+                                                  which will be interpreted as an integer.
+                                                  This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values, a
+                                              key, and an operator that relates the
+                                              key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn, the
+                                                  values array must be non-empty. If
+                                                  the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If
+                                                  the operator is Gt or Lt, the values
+                                                  array must have a single element,
+                                                  which will be interpreted as an integer.
+                                                  This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching the
+                                        corresponding nodeSelectorTerm, in the range
+                                        1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - preference
+                                    - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the affinity
+                                  requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to an
+                                  update), the system may or may not try to eventually
+                                  evict the pod from its node.
                                 properties:
-                                  matchExpressions:
-                                    description: A list of node selector requirements
-                                      by node's labels.
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector terms.
+                                      The terms are ORed.
                                     items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
+                                      description: A null or empty node selector term
+                                        matches no objects. The requirements of them
+                                        are ANDed. The TopologySelectorTerm type implements
+                                        a subset of the NodeSelectorTerm.
                                       properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values, a
+                                              key, and an operator that relates the
+                                              key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn, the
+                                                  values array must be non-empty. If
+                                                  the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If
+                                                  the operator is Gt or Lt, the values
+                                                  array must have a single element,
+                                                  which will be interpreted as an integer.
+                                                  This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: A node selector requirement
+                                              is a selector that contains values, a
+                                              key, and an operator that relates the
+                                              key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship
+                                                  to a set of values. Valid operators
+                                                  are In, NotIn, Exists, DoesNotExist.
+                                                  Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values.
+                                                  If the operator is In or NotIn, the
+                                                  values array must be non-empty. If
+                                                  the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If
+                                                  the operator is Gt or Lt, the values
+                                                  array must have a single element,
+                                                  which will be interpreted as an integer.
+                                                  This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                  - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods
+                                  to nodes that satisfy the affinity expressions specified
+                                  by this field, but it may choose a node that violates
+                                  one or more of the expressions. The node that is most
+                                  preferred is the one with the greatest sum of weights,
+                                  i.e. for each node that meets all of the scheduling
+                                  requirements (resource request, requiredDuringScheduling
+                                  affinity expressions, etc.), compute a sum by iterating
+                                  through the elements of this field and adding "weight"
+                                  to the sum if the node has pods which matches the
+                                  corresponding podAffinityTerm; the node(s) with the
+                                  highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources,
+                                            in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key
+                                                      that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty. This
+                                                      array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value}
+                                                pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces
+                                            the labelSelector applies to (matches against);
+                                            null or empty list means "this pod's namespace"
                                           items:
                                             type: string
                                           type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose value
+                                            of the label with key topologyKey matches
+                                            that of any node on which any of the selected
+                                            pods is running. Empty topologyKey is not
+                                            allowed.
+                                          type: string
                                       required:
-                                        - key
-                                        - operator
+                                        - topologyKey
                                       type: object
-                                    type: array
-                                  matchFields:
-                                    description: A list of node selector requirements
-                                      by node's fields.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
+                                    weight:
+                                      description: weight associated with matching the
+                                        corresponding podAffinityTerm, in the range
+                                        1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the affinity
+                                  requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a
+                                  pod label update), the system may or may not try to
+                                  eventually evict the pod from its node. When there
+                                  are multiple elements, the lists of nodes corresponding
+                                  to each podAffinityTerm are intersected, i.e. all
+                                  terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching
+                                    the labelSelector relative to the given namespace(s))
+                                    that this pod should be co-located (affinity) or
+                                    not co-located (anti-affinity) with, where co-located
+                                    is defined as running on a node whose value of the
+                                    label with key <topologyKey> matches that of any
+                                    node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
                                       properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
+                                        matchExpressions:
+                                          description: matchExpressions is a list of
+                                            label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values, a
+                                              key, and an operator that relates the
+                                              key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that
+                                                  the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and
+                                                  DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This
+                                                  array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is
+                                            "In", and the values array contains only
+                                            "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the pods
+                                        matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as running
+                                        on a node whose value of the label with key
+                                        topologyKey matches that of any node on which
+                                        any of the selected pods is running. Empty topologyKey
+                                        is not allowed.
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone, etc.
+                              as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods
+                                  to nodes that satisfy the anti-affinity expressions
+                                  specified by this field, but it may choose a node
+                                  that violates one or more of the expressions. The
+                                  node that is most preferred is the one with the greatest
+                                  sum of weights, i.e. for each node that meets all
+                                  of the scheduling requirements (resource request,
+                                  requiredDuringScheduling anti-affinity expressions,
+                                  etc.), compute a sum by iterating through the elements
+                                  of this field and adding "weight" to the sum if the
+                                  node has pods which matches the corresponding podAffinityTerm;
+                                  the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources,
+                                            in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key
+                                                      that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty. This
+                                                      array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value}
+                                                pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces
+                                            the labelSelector applies to (matches against);
+                                            null or empty list means "this pod's namespace"
                                           items:
                                             type: string
                                           type: array
+                                        topologyKey:
+                                          description: This pod should be co-located
+                                            (affinity) or not co-located (anti-affinity)
+                                            with the pods matching the labelSelector
+                                            in the specified namespaces, where co-located
+                                            is defined as running on a node whose value
+                                            of the label with key topologyKey matches
+                                            that of any node on which any of the selected
+                                            pods is running. Empty topologyKey is not
+                                            allowed.
+                                          type: string
                                       required:
-                                        - key
-                                        - operator
+                                        - topologyKey
                                       type: object
-                                    type: array
+                                    weight:
+                                      description: weight associated with matching the
+                                        corresponding podAffinityTerm, in the range
+                                        1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                    - podAffinityTerm
+                                    - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified
+                                  by this field are not met at scheduling time, the
+                                  pod will not be scheduled onto the node. If the anti-affinity
+                                  requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a
+                                  pod label update), the system may or may not try to
+                                  eventually evict the pod from its node. When there
+                                  are multiple elements, the lists of nodes corresponding
+                                  to each podAffinityTerm are intersected, i.e. all
+                                  terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching
+                                    the labelSelector relative to the given namespace(s))
+                                    that this pod should be co-located (affinity) or
+                                    not co-located (anti-affinity) with, where co-located
+                                    is defined as running on a node whose value of the
+                                    label with key <topologyKey> matches that of any
+                                    node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of
+                                            label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values, a
+                                              key, and an operator that relates the
+                                              key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that
+                                                  the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and
+                                                  DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This
+                                                  array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is
+                                            "In", and the values array contains only
+                                            "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the pods
+                                        matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as running
+                                        on a node whose value of the label with key
+                                        topologyKey matches that of any node on which
+                                        any of the selected pods is running. Empty topologyKey
+                                        is not allowed.
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: Annotations specifies the annotations to attach
+                          to pods the operator creates
+                        type: object
+                      initContainers:
+                        description: InitContainers defines init containers of the pod.
+                          A typical use case could be using an init container to download
+                          a remote jar to a local path.
+                        items:
+                          description: A single application container that you want
+                            to run within a pod. The Container API from the core group
+                            is not used directly to avoid unneeded fields and reduce
+                            the size of the CRD. New fields could be added as needed.
+                          properties:
+                            args:
+                              description: Arguments to the entrypoint.
+                              items:
+                                type: string
+                              type: array
+                            command:
+                              description: Entrypoint array. Not executed within a shell.
+                              items:
+                                type: string
+                              type: array
+                            env:
+                              description: List of environment variables to set in the
+                                container.
+                              items:
+                                description: EnvVar represents an environment variable
+                                  present in a Container.
+                                properties:
+                                  name:
+                                    description: Name of the environment variable. Must
+                                      be a C_IDENTIFIER.
+                                    type: string
+                                  value:
+                                    description: 'Variable references $(VAR_NAME) are
+                                      expanded using the previous defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved, the
+                                      reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a double
+                                      $$, ie: $$(VAR_NAME). Escaped references will
+                                      never be expanded, regardless of whether the variable
+                                      exists or not. Defaults to "".'
+                                    type: string
+                                  valueFrom:
+                                    description: Source for the environment variable's
+                                      value. Cannot be used if value is not empty.
+                                    properties:
+                                      configMapKeyRef:
+                                        description: Selects a key of a ConfigMap.
+                                        properties:
+                                          key:
+                                            description: The key to select.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the ConfigMap
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                      fieldRef:
+                                        description: 'Selects a field of the pod: supports
+                                          metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                          `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                          spec.serviceAccountName, status.hostIP, status.podIP,
+                                          status.podIPs.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the FieldPath
+                                              is written in terms of, defaults to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                          - fieldPath
+                                        type: object
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage, requests.cpu,
+                                          requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required for
+                                              volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                              - type: integer
+                                              - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                          - resource
+                                        type: object
+                                      secretKeyRef:
+                                        description: Selects a key of a secret in the
+                                          pod's namespace
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select
+                                              from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret
+                                              or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                    type: object
+                                required:
+                                  - name
                                 type: object
                               type: array
+                            envFrom:
+                              description: List of sources to populate environment variables
+                                in the container.
+                              items:
+                                description: EnvFromSource represents the source of
+                                  a set of ConfigMaps
+                                properties:
+                                  configMapRef:
+                                    description: The ConfigMap to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                  prefix:
+                                    description: An optional identifier to prepend to
+                                      each key in the ConfigMap. Must be a C_IDENTIFIER.
+                                    type: string
+                                  secretRef:
+                                    description: The Secret to select from
+                                    properties:
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret must
+                                          be defined
+                                        type: boolean
+                                    type: object
+                                type: object
+                              type: array
+                            image:
+                              description: Docker image name.
+                              type: string
+                            imagePullPolicy:
+                              description: Image pull policy.
+                              type: string
+                            livenessProbe:
+                              description: Periodic probe of container liveness.
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to execute
+                                        inside the container, the working directory
+                                        for the command  is root ('/') in the container's
+                                        filesystem. The command is simply exec'd, it
+                                        is not run inside a shell, so traditional shell
+                                        instructions ('|', etc) won't work. To use a
+                                        shell, you need to explicitly call out to that
+                                        shell. Exit status of 0 is treated as live/healthy
+                                        and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request to
+                                    perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom header
+                                          to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to the
+                                        host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO: implement
+                                    a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect to,
+                                        defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the probe
+                                    times out. Defaults to 1 second. Minimum value is
+                                    1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            name:
+                              description: Name of the container specified as a DNS_LABEL.
+                                Each container in a pod must have a unique name (DNS_LABEL).
+                              type: string
+                            ports:
+                              description: List of ports to expose from the container.
+                              items:
+                                description: ContainerPort represents a network port
+                                  in a single container.
+                                properties:
+                                  containerPort:
+                                    description: Number of port to expose on the pod's
+                                      IP address. This must be a valid port number,
+                                      0 < x < 65536.
+                                    format: int32
+                                    type: integer
+                                  hostIP:
+                                    description: What host IP to bind the external port
+                                      to.
+                                    type: string
+                                  hostPort:
+                                    description: Number of port to expose on the host.
+                                      If specified, this must be a valid port number,
+                                      0 < x < 65536. If HostNetwork is specified, this
+                                      must match ContainerPort. Most containers do not
+                                      need this.
+                                    format: int32
+                                    type: integer
+                                  name:
+                                    description: If specified, this must be an IANA_SVC_NAME
+                                      and unique within the pod. Each named port in
+                                      a pod must have a unique name. Name for the port
+                                      that can be referred to by services.
+                                    type: string
+                                  protocol:
+                                    description: Protocol for port. Must be UDP, TCP,
+                                      or SCTP. Defaults to "TCP".
+                                    type: string
+                                required:
+                                  - containerPort
+                                type: object
+                              type: array
+                              x-kubernetes-list-map-keys:
+                                - containerPort
+                              x-kubernetes-list-type: map
+                            readinessProbe:
+                              description: 'Periodic probe of container service readiness.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to execute
+                                        inside the container, the working directory
+                                        for the command  is root ('/') in the container's
+                                        filesystem. The command is simply exec'd, it
+                                        is not run inside a shell, so traditional shell
+                                        instructions ('|', etc) won't work. To use a
+                                        shell, you need to explicitly call out to that
+                                        shell. Exit status of 0 is treated as live/healthy
+                                        and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request to
+                                    perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom header
+                                          to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to the
+                                        host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO: implement
+                                    a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect to,
+                                        defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the probe
+                                    times out. Defaults to 1 second. Minimum value is
+                                    1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            resources:
+                              description: Compute Resources required by this container.
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is omitted
+                                    for a container, it defaults to Limits if that is
+                                    explicitly specified, otherwise to an implementation-defined
+                                    value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                              type: object
+                            startupProbe:
+                              description: StartupProbe indicates that the Pod has successfully
+                                initialized.
+                              properties:
+                                exec:
+                                  description: One and only one of the following should
+                                    be specified. Exec specifies the action to take.
+                                  properties:
+                                    command:
+                                      description: Command is the command line to execute
+                                        inside the container, the working directory
+                                        for the command  is root ('/') in the container's
+                                        filesystem. The command is simply exec'd, it
+                                        is not run inside a shell, so traditional shell
+                                        instructions ('|', etc) won't work. To use a
+                                        shell, you need to explicitly call out to that
+                                        shell. Exit status of 0 is treated as live/healthy
+                                        and non-zero is unhealthy.
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                failureThreshold:
+                                  description: Minimum consecutive failures for the
+                                    probe to be considered failed after having succeeded.
+                                    Defaults to 3. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                httpGet:
+                                  description: HTTPGet specifies the http request to
+                                    perform.
+                                  properties:
+                                    host:
+                                      description: Host name to connect to, defaults
+                                        to the pod IP. You probably want to set "Host"
+                                        in httpHeaders instead.
+                                      type: string
+                                    httpHeaders:
+                                      description: Custom headers to set in the request.
+                                        HTTP allows repeated headers.
+                                      items:
+                                        description: HTTPHeader describes a custom header
+                                          to be used in HTTP probes
+                                        properties:
+                                          name:
+                                            description: The header field name
+                                            type: string
+                                          value:
+                                            description: The header field value
+                                            type: string
+                                        required:
+                                          - name
+                                          - value
+                                        type: object
+                                      type: array
+                                    path:
+                                      description: Path to access on the HTTP server.
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      description: Name or number of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                    scheme:
+                                      description: Scheme to use for connecting to the
+                                        host. Defaults to HTTP.
+                                      type: string
+                                  required:
+                                    - port
+                                  type: object
+                                initialDelaySeconds:
+                                  description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                                periodSeconds:
+                                  description: How often (in seconds) to perform the
+                                    probe. Default to 10 seconds. Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                successThreshold:
+                                  description: Minimum consecutive successes for the
+                                    probe to be considered successful after having failed.
+                                    Defaults to 1. Must be 1 for liveness and startup.
+                                    Minimum value is 1.
+                                  format: int32
+                                  type: integer
+                                tcpSocket:
+                                  description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO: implement
+                                    a realistic TCP lifecycle hook'
+                                  properties:
+                                    host:
+                                      description: 'Optional: Host name to connect to,
+                                        defaults to the pod IP.'
+                                      type: string
+                                    port:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      description: Number or name of the port to access
+                                        on the container. Number must be in the range
+                                        1 to 65535. Name must be an IANA_SVC_NAME.
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                    - port
+                                  type: object
+                                timeoutSeconds:
+                                  description: 'Number of seconds after which the probe
+                                    times out. Defaults to 1 second. Minimum value is
+                                    1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                                  format: int32
+                                  type: integer
+                              type: object
+                            volumeMounts:
+                              description: Pod volumes to mount into the container's
+                                filesystem.
+                              items:
+                                description: VolumeMount describes a mounting of a Volume
+                                  within a container.
+                                properties:
+                                  mountPath:
+                                    description: Path within the container at which
+                                      the volume should be mounted.  Must not contain
+                                      ':'.
+                                    type: string
+                                  mountPropagation:
+                                    description: mountPropagation determines how mounts
+                                      are propagated from the host to container and
+                                      the other way around. When not set, MountPropagationNone
+                                      is used. This field is beta in 1.10.
+                                    type: string
+                                  name:
+                                    description: This must match the Name of a Volume.
+                                    type: string
+                                  readOnly:
+                                    description: Mounted read-only if true, read-write
+                                      otherwise (false or unspecified). Defaults to
+                                      false.
+                                    type: boolean
+                                  subPath:
+                                    description: Path within the volume from which the
+                                      container's volume should be mounted. Defaults
+                                      to "" (volume's root).
+                                    type: string
+                                  subPathExpr:
+                                    description: Expanded path within the volume from
+                                      which the container's volume should be mounted.
+                                      Behaves similarly to SubPath but environment variable
+                                      references $(VAR_NAME) are expanded using the
+                                      container's environment. Defaults to "" (volume's
+                                      root). SubPathExpr and SubPath are mutually exclusive.
+                                    type: string
+                                required:
+                                  - mountPath
+                                  - name
+                                type: object
+                              type: array
+                            workingDir:
+                              description: Container's working directory.
+                              type: string
                           required:
-                            - nodeSelectorTerms
+                            - name
                           type: object
-                      type: object
-                    podAffinity:
-                      description: Describes pod affinity scheduling rules (e.g. co-locate
-                        this pod in the same node, zone, etc. as some other pod(s)).
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods
-                            to nodes that satisfy the affinity expressions specified
-                            by this field, but it may choose a node that violates
-                            one or more of the expressions. The node that is most
-                            preferred is the one with the greatest sum of weights,
-                            i.e. for each node that meets all of the scheduling requirements
-                            (resource request, requiredDuringScheduling affinity expressions,
-                            etc.), compute a sum by iterating through the elements
-                            of this field and adding "weight" to the sum if the node
-                            has pods which matches the corresponding podAffinityTerm;
-                            the node(s) with the highest sum are the most preferred.
-                          items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm
-                              fields are added per-node to find the most preferred
-                              node(s)
-                            properties:
-                              podAffinityTerm:
-                                description: Required. A pod affinity term, associated
-                                  with the corresponding weight.
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified
-                                      namespaces, where co-located is defined as running
-                                      on a node whose value of the label with key
-                                      topologyKey matches that of any node on which
-                                      any of the selected pods is running. Empty topologyKey
-                                      is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              weight:
-                                description: weight associated with matching the corresponding
-                                  podAffinityTerm, in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
+                        type: array
+                      jvmOptions:
+                        description: JVMOptions defines JVM parameters of Bookies
+                        properties:
+                          extraOptions:
+                            items:
+                              type: string
+                            type: array
+                          gcLoggingOptions:
+                            items:
+                              type: string
+                            type: array
+                          gcOptions:
+                            items:
+                              type: string
+                            type: array
+                          memoryOptions:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels specifies the labels to attach to pod the
+                          operator creates for the bookkeeper cluster.
+                        type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: NodeSelector specifies a map of key-value pairs.
+                          For a pod to be eligible to run on a node, the node must have
+                          each of the indicated key-value pairs as labels.
+                        type: object
+                      resources:
+                        description: Resources specifies the resource requirements of
+                          a pod to run in the cluster
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                             type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this
-                            field are not met at scheduling time, the pod will not
-                            be scheduled onto the node. If the affinity requirements
-                            specified by this field cease to be met at some point
-                            during pod execution (e.g. due to a pod label update),
-                            the system may or may not try to eventually evict the
-                            pod from its node. When there are multiple elements, the
-                            lists of nodes corresponding to each podAffinityTerm are
-                            intersected, i.e. all terms must be satisfied.
-                          items:
-                            description: Defines a set of pods (namely those matching
-                              the labelSelector relative to the given namespace(s))
-                              that this pod should be co-located (affinity) or not
-                              co-located (anti-affinity) with, where co-located is
-                              defined as running on a node whose value of the label
-                              with key <topologyKey> matches that of any node on which
-                              a pod of the set of pods is running
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute
+                              resources required. If Requests is omitted for a container,
+                              it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. More info:
+                              https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      securityContext:
+                        description: 'SecurityContext specifies the security context
+                          for the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
+                        properties:
+                          fsGroup:
+                            description: "A special supplemental group that applies
+                              to all containers in a pod. Some volume types allow the
+                              Kubelet to change the ownership of that volume to be owned
+                              by the pod: \n 1. The owning GID will be the FSGroup 2.
+                              The setgid bit is set (new files created in the volume
+                              will be owned by FSGroup) 3. The permission bits are OR'd
+                              with rw-rw---- \n If unset, the Kubelet will not modify
+                              the ownership and permissions of any volume."
+                            format: int64
+                            type: integer
+                          fsGroupChangePolicy:
+                            description: 'fsGroupChangePolicy defines behavior of changing
+                              ownership and permission of the volume before being exposed
+                              inside Pod. This field will only apply to volume types
+                              which support fsGroup based ownership(and permissions).
+                              It will have no effect on ephemeral volume types such
+                              as: secret, configmaps and emptydir. Valid values are
+                              "OnRootMismatch" and "Always". If not specified defaults
+                              to "Always".'
+                            type: string
+                          runAsGroup:
+                            description: The GID to run the entrypoint of the container
+                              process. Uses runtime default if unset. May also be set
+                              in SecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext
+                              takes precedence for that container.
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            description: Indicates that the container must run as a
+                              non-root user. If true, the Kubelet will validate the
+                              image at runtime to ensure that it does not run as UID
+                              0 (root) and fail to start the container if it does. If
+                              unset or false, no such validation will be performed.
+                              May also be set in SecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            type: boolean
+                          runAsUser:
+                            description: The UID to run the entrypoint of the container
+                              process. Defaults to user specified in image metadata
+                              if unspecified. May also be set in SecurityContext.  If
+                              set in both SecurityContext and PodSecurityContext, the
+                              value specified in SecurityContext takes precedence for
+                              that container.
+                            format: int64
+                            type: integer
+                          seLinuxOptions:
+                            description: The SELinux context to be applied to all containers.
+                              If unspecified, the container runtime will allocate a
+                              random SELinux context for each container.  May also be
+                              set in SecurityContext.  If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence for that container.
                             properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
+                              level:
+                                description: Level is SELinux level label that applies
+                                  to the container.
+                                type: string
+                              role:
+                                description: Role is a SELinux role label that applies
+                                  to the container.
+                                type: string
+                              type:
+                                description: Type is a SELinux type label that applies
+                                  to the container.
+                                type: string
+                              user:
+                                description: User is a SELinux user label that applies
+                                  to the container.
+                                type: string
+                            type: object
+                          seccompProfile:
+                            description: The seccomp options to use by the containers
+                              in this pod.
+                            properties:
+                              localhostProfile:
+                                description: localhostProfile indicates a profile defined
+                                  in a file on the node should be used. The profile
+                                  must be preconfigured on the node to work. Must be
+                                  a descending path, relative to the kubelet's configured
+                                  seccomp profile location. Must only be set if type
+                                  is "Localhost".
+                                type: string
+                              type:
+                                description: "type indicates which kind of seccomp profile
+                                  will be applied. Valid options are: \n Localhost -
+                                  a profile defined in a file on the node should be
+                                  used. RuntimeDefault - the container runtime default
+                                  profile should be used. Unconfined - no profile should
+                                  be applied."
                                 type: string
                             required:
-                              - topologyKey
+                              - type
                             type: object
-                          type: array
-                      type: object
-                    podAntiAffinity:
-                      description: Describes pod anti-affinity scheduling rules (e.g.
-                        avoid putting this pod in the same node, zone, etc. as some
-                        other pod(s)).
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods
-                            to nodes that satisfy the anti-affinity expressions specified
-                            by this field, but it may choose a node that violates
-                            one or more of the expressions. The node that is most
-                            preferred is the one with the greatest sum of weights,
-                            i.e. for each node that meets all of the scheduling requirements
-                            (resource request, requiredDuringScheduling anti-affinity
-                            expressions, etc.), compute a sum by iterating through
-                            the elements of this field and adding "weight" to the
-                            sum if the node has pods which matches the corresponding
-                            podAffinityTerm; the node(s) with the highest sum are
-                            the most preferred.
-                          items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm
-                              fields are added per-node to find the most preferred
-                              node(s)
-                            properties:
-                              podAffinityTerm:
-                                description: Required. A pod affinity term, associated
-                                  with the corresponding weight.
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified
-                                      namespaces, where co-located is defined as running
-                                      on a node whose value of the label with key
-                                      topologyKey matches that of any node on which
-                                      any of the selected pods is running. Empty topologyKey
-                                      is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              weight:
-                                description: weight associated with matching the corresponding
-                                  podAffinityTerm, in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the anti-affinity requirements specified
-                            by this field are not met at scheduling time, the pod
-                            will not be scheduled onto the node. If the anti-affinity
-                            requirements specified by this field cease to be met at
-                            some point during pod execution (e.g. due to a pod label
-                            update), the system may or may not try to eventually evict
-                            the pod from its node. When there are multiple elements,
-                            the lists of nodes corresponding to each podAffinityTerm
-                            are intersected, i.e. all terms must be satisfied.
-                          items:
-                            description: Defines a set of pods (namely those matching
-                              the labelSelector relative to the given namespace(s))
-                              that this pod should be co-located (affinity) or not
-                              co-located (anti-affinity) with, where co-located is
-                              defined as running on a node whose value of the label
-                              with key <topologyKey> matches that of any node on which
-                              a pod of the set of pods is running
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
+                          supplementalGroups:
+                            description: A list of groups applied to the first process
+                              run in each container, in addition to the container's
+                              primary GID.  If unspecified, no groups will be added
+                              to any container.
+                            items:
+                              format: int64
+                              type: integer
+                            type: array
+                          sysctls:
+                            description: Sysctls hold a list of namespaced sysctls used
+                              for the pod. Pods with unsupported sysctls (by the container
+                              runtime) might fail to launch.
+                            items:
+                              description: Sysctl defines a kernel parameter to be set
+                              properties:
+                                name:
+                                  description: Name of a property to set
                                   type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
+                                value:
+                                  description: Value of a property to set
+                                  type: string
+                              required:
+                                - name
+                                - value
+                              type: object
+                            type: array
+                          windowsOptions:
+                            description: The Windows specific settings applied to all
+                              containers. If unspecified, the options within a container's
+                              SecurityContext will be used. If set in both SecurityContext
+                              and PodSecurityContext, the value specified in SecurityContext
+                              takes precedence.
+                            properties:
+                              gmsaCredentialSpec:
+                                description: GMSACredentialSpec is where the GMSA admission
+                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                  inlines the contents of the GMSA credential spec named
+                                  by the GMSACredentialSpecName field.
                                 type: string
-                            required:
-                              - topologyKey
+                              gmsaCredentialSpecName:
+                                description: GMSACredentialSpecName is the name of the
+                                  GMSA credential spec to use.
+                                type: string
+                              runAsUserName:
+                                description: The UserName in Windows to run the entrypoint
+                                  of the container process. Defaults to the user specified
+                                  in image metadata if unspecified. May also be set
+                                  in PodSecurityContext. If set in both SecurityContext
+                                  and PodSecurityContext, the value specified in SecurityContext
+                                  takes precedence.
+                                type: string
                             type: object
-                          type: array
-                      type: object
-                  type: object
-                annotations:
-                  additionalProperties:
-                    type: string
-                  description: Annotations specifies the annotations to attach to
-                    pods the operator creates
-                  type: object
-                initContainers:
-                  description: InitContainers defines init containers of the pod.
-                    A typical use case could be using an init container to download
-                    a remote jar to a local path.
-                  items:
-                    description: A single application container that you want to run
-                      within a pod. The Container API from the core group is not used
-                      directly to avoid unneeded fields and reduce the size of the
-                      CRD. New fields could be added as needed.
-                    properties:
-                      args:
-                        description: Arguments to the entrypoint.
+                        type: object
+                      terminationGracePeriodSeconds:
+                        description: TerminationGracePeriodSeconds is the amount of
+                          time that kubernetes will give for a pod before terminating
+                          it.
+                        format: int64
+                        type: integer
+                      tolerations:
+                        description: Tolerations specifies the tolerations of a Pod
                         items:
-                          type: string
+                          description: The pod this Toleration is attached to tolerates
+                            any taint that matches the triple <key,value,effect> using
+                            the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: Effect indicates the taint effect to match.
+                                Empty means match all taint effects. When specified,
+                                allowed values are NoSchedule, PreferNoSchedule and
+                                NoExecute.
+                              type: string
+                            key:
+                              description: Key is the taint key that the toleration
+                                applies to. Empty means match all taint keys. If the
+                                key is empty, operator must be Exists; this combination
+                                means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: Operator represents a key's relationship
+                                to the value. Valid operators are Exists and Equal.
+                                Defaults to Equal. Exists is equivalent to wildcard
+                                for value, so that a pod can tolerate all taints of
+                                a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: TolerationSeconds represents the period of
+                                time the toleration (which must be of effect NoExecute,
+                                otherwise this field is ignored) tolerates the taint.
+                                By default, it is not set, which means tolerate the
+                                taint forever (do not evict). Zero and negative values
+                                will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: Value is the taint value the toleration matches
+                                to. If the operator is Exists, the value should be empty,
+                                otherwise just a regular string.
+                              type: string
+                          type: object
                         type: array
-                      command:
-                        description: Entrypoint array. Not executed within a shell.
-                        items:
-                          type: string
-                        type: array
-                      env:
-                        description: List of environment variables to set in the container.
+                      vars:
+                        description: Vars specifies the environment variables of a Pod
                         items:
                           description: EnvVar represents an environment variable present
                             in a Container.
                           properties:
                             name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
+                              description: Name of the environment variable. Must be
+                                a C_IDENTIFIER.
                               type: string
                             value:
                               description: 'Variable references $(VAR_NAME) are expanded
                                 using the previous defined environment variables in
                                 the container and any service environment variables.
-                                If a variable cannot be resolved, the reference in
-                                the input string will be unchanged. The $(VAR_NAME)
-                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
-                                Escaped references will never be expanded, regardless
-                                of whether the variable exists or not. Defaults to
-                                "".'
+                                If a variable cannot be resolved, the reference in the
+                                input string will be unchanged. The $(VAR_NAME) syntax
+                                can be escaped with a double $$, ie: $$(VAR_NAME). Escaped
+                                references will never be expanded, regardless of whether
+                                the variable exists or not. Defaults to "".'
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value.
@@ -3310,8 +2325,8 @@ spec:
                                     name:
                                       description: 'Name of the referent. More info:
                                         https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                        TODO: Add other useful fields. apiVersion, kind,
+                                        uid?'
                                       type: string
                                     optional:
                                       description: Specify whether the ConfigMap or
@@ -3332,8 +2347,8 @@ spec:
                                         is written in terms of, defaults to "v1".
                                       type: string
                                     fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
+                                      description: Path of the field to select in the
+                                        specified API version.
                                       type: string
                                   required:
                                     - fieldPath
@@ -3353,8 +2368,8 @@ spec:
                                       anyOf:
                                         - type: integer
                                         - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
+                                      description: Specifies the output format of the
+                                        exposed resources, defaults to "1"
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
                                     resource:
@@ -3368,14 +2383,14 @@ spec:
                                     namespace
                                   properties:
                                     key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
+                                      description: The key of the secret to select from.  Must
+                                        be a valid secret key.
                                       type: string
                                     name:
                                       description: 'Name of the referent. More info:
                                         https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
+                                        TODO: Add other useful fields. apiVersion, kind,
+                                        uid?'
                                       type: string
                                     optional:
                                       description: Specify whether the Secret or its
@@ -3389,1410 +2404,2393 @@ spec:
                             - name
                           type: object
                         type: array
-                      envFrom:
-                        description: List of sources to populate environment variables
-                          in the container.
+                      volumes:
+                        description: Volumes defines extra volumes of the pod.
                         items:
-                          description: EnvFromSource represents the source of a set
-                            of ConfigMaps
+                          description: Volume represents a named volume in a pod that
+                            may be accessed by any container in the pod. The Volume
+                            API from the core group is not used directly to avoid unneeded
+                            fields defined in `VolumeSource` and reduce the size of
+                            the CRD. New fields in VolumeSource could be added as needed.
                           properties:
-                            configMapRef:
-                              description: The ConfigMap to select from
+                            configMap:
+                              description: ConfigMap represents a configMap that should
+                                populate this volume
                               properties:
+                                defaultMode:
+                                  description: 'Optional: mode bits used to set permissions
+                                    on created files by default. Must be an octal value
+                                    between 0000 and 0777 or a decimal value between
+                                    0 and 511. YAML accepts both octal and decimal values,
+                                    JSON requires decimal values for mode bits. Defaults
+                                    to 0644. Directories within the path are not affected
+                                    by this setting. This might be in conflict with
+                                    other options that affect the file mode, like fsGroup,
+                                    and the result can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: If unspecified, each key-value pair in
+                                    the Data field of the referenced ConfigMap will
+                                    be projected into the volume as a file whose name
+                                    is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present. If
+                                    a key is specified which is not present in the ConfigMap,
+                                    the volume setup will error unless it is marked
+                                    optional. Paths must be relative and may not contain
+                                    the '..' path or start with '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits used to set
+                                          permissions on this file. Must be an octal
+                                          value between 0000 and 0777 or a decimal value
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. If not specified, the
+                                          volume defaultMode will be used. This might
+                                          be in conflict with other options that affect
+                                          the file mode, like fsGroup, and the result
+                                          can be other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file to
+                                          map the key to. May not be an absolute path.
+                                          May not contain the path element '..'. May
+                                          not start with the string '..'.
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
                                 name:
                                   description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                     TODO: Add other useful fields. apiVersion, kind,
                                     uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap must
-                                    be defined
+                                  description: Specify whether the ConfigMap or its
+                                    keys must be defined
                                   type: boolean
                               type: object
-                            prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
+                            name:
+                              description: 'Volume''s name. Must be a DNS_LABEL and
+                                unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
-                            secretRef:
-                              description: The Secret to select from
+                            secret:
+                              description: Secret represents a secret that should populate
+                                this volume.
                               properties:
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
+                                defaultMode:
+                                  description: 'Optional: mode bits used to set permissions
+                                    on created files by default. Must be an octal value
+                                    between 0000 and 0777 or a decimal value between
+                                    0 and 511. YAML accepts both octal and decimal values,
+                                    JSON requires decimal values for mode bits. Defaults
+                                    to 0644. Directories within the path are not affected
+                                    by this setting. This might be in conflict with
+                                    other options that affect the file mode, like fsGroup,
+                                    and the result can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: If unspecified, each key-value pair in
+                                    the Data field of the referenced Secret will be
+                                    projected into the volume as a file whose name is
+                                    the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present. If
+                                    a key is specified which is not present in the Secret,
+                                    the volume setup will error unless it is marked
+                                    optional. Paths must be relative and may not contain
+                                    the '..' path or start with '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits used to set
+                                          permissions on this file. Must be an octal
+                                          value between 0000 and 0777 or a decimal value
+                                          between 0 and 511. YAML accepts both octal
+                                          and decimal values, JSON requires decimal
+                                          values for mode bits. If not specified, the
+                                          volume defaultMode will be used. This might
+                                          be in conflict with other options that affect
+                                          the file mode, like fsGroup, and the result
+                                          can be other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file to
+                                          map the key to. May not be an absolute path.
+                                          May not contain the path element '..'. May
+                                          not start with the string '..'.
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                    type: object
+                                  type: array
                                 optional:
-                                  description: Specify whether the Secret must be
-                                    defined
+                                  description: Specify whether the Secret or its keys
+                                    must be defined
                                   type: boolean
+                                secretName:
+                                  description: 'Name of the secret in the pod''s namespace
+                                    to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  type: string
                               type: object
-                          type: object
-                        type: array
-                      image:
-                        description: Docker image name.
-                        type: string
-                      imagePullPolicy:
-                        description: Image pull policy.
-                        type: string
-                      livenessProbe:
-                        description: Periodic probe of container liveness.
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      name:
-                        description: Name of the container specified as a DNS_LABEL.
-                          Each container in a pod must have a unique name (DNS_LABEL).
-                        type: string
-                      ports:
-                        description: List of ports to expose from the container.
-                        items:
-                          description: ContainerPort represents a network port in
-                            a single container.
-                          properties:
-                            containerPort:
-                              description: Number of port to expose on the pod's IP
-                                address. This must be a valid port number, 0 < x <
-                                65536.
-                              format: int32
-                              type: integer
-                            hostIP:
-                              description: What host IP to bind the external port
-                                to.
-                              type: string
-                            hostPort:
-                              description: Number of port to expose on the host. If
-                                specified, this must be a valid port number, 0 < x
-                                < 65536. If HostNetwork is specified, this must match
-                                ContainerPort. Most containers do not need this.
-                              format: int32
-                              type: integer
-                            name:
-                              description: If specified, this must be an IANA_SVC_NAME
-                                and unique within the pod. Each named port in a pod
-                                must have a unique name. Name for the port that can
-                                be referred to by services.
-                              type: string
-                            protocol:
-                              description: Protocol for port. Must be UDP, TCP, or
-                                SCTP. Defaults to "TCP".
-                              type: string
                           required:
-                            - containerPort
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                          - containerPort
-                        x-kubernetes-list-type: map
-                      readinessProbe:
-                        description: 'Periodic probe of container service readiness.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      resources:
-                        description: Compute Resources required by this container.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                        type: object
-                      startupProbe:
-                        description: StartupProbe indicates that the Pod has successfully
-                          initialized.
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      volumeMounts:
-                        description: Pod volumes to mount into the container's filesystem.
-                        items:
-                          description: VolumeMount describes a mounting of a Volume
-                            within a container.
-                          properties:
-                            mountPath:
-                              description: Path within the container at which the
-                                volume should be mounted.  Must not contain ':'.
-                              type: string
-                            mountPropagation:
-                              description: mountPropagation determines how mounts
-                                are propagated from the host to container and the
-                                other way around. When not set, MountPropagationNone
-                                is used. This field is beta in 1.10.
-                              type: string
-                            name:
-                              description: This must match the Name of a Volume.
-                              type: string
-                            readOnly:
-                              description: Mounted read-only if true, read-write otherwise
-                                (false or unspecified). Defaults to false.
-                              type: boolean
-                            subPath:
-                              description: Path within the volume from which the container's
-                                volume should be mounted. Defaults to "" (volume's
-                                root).
-                              type: string
-                            subPathExpr:
-                              description: Expanded path within the volume from which
-                                the container's volume should be mounted. Behaves
-                                similarly to SubPath but environment variable references
-                                $(VAR_NAME) are expanded using the container's environment.
-                                Defaults to "" (volume's root). SubPathExpr and SubPath
-                                are mutually exclusive.
-                              type: string
-                          required:
-                            - mountPath
                             - name
                           type: object
                         type: array
-                      workingDir:
-                        description: Container's working directory.
-                        type: string
-                    required:
-                      - name
                     type: object
-                  type: array
-                jvmOptions:
-                  description: JVMOptions defines JVM parameters of Bookies
-                  properties:
-                    extraOptions:
-                      items:
-                        type: string
-                      type: array
-                    gcLoggingOptions:
-                      items:
-                        type: string
-                      type: array
-                    gcOptions:
-                      items:
-                        type: string
-                      type: array
-                    memoryOptions:
-                      items:
-                        type: string
-                      type: array
-                  type: object
-                labels:
-                  additionalProperties:
-                    type: string
-                  description: Labels specifies the labels to attach to pod the operator
-                    creates for the bookkeeper cluster.
-                  type: object
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  description: NodeSelector specifies a map of key-value pairs. For
-                    a pod to be eligible to run on a node, the node must have each
-                    of the indicated key-value pairs as labels.
-                  type: object
-                resources:
-                  description: Resources specifies the resource requirements of a
-                    pod to run in the cluster
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                securityContext:
-                  description: 'SecurityContext specifies the security context for
-                    the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
-                  properties:
-                    fsGroup:
-                      description: "A special supplemental group that applies to all
-                        containers in a pod. Some volume types allow the Kubelet to
-                        change the ownership of that volume to be owned by the pod:
-                        \n 1. The owning GID will be the FSGroup 2. The setgid bit
-                        is set (new files created in the volume will be owned by FSGroup)
-                        3. The permission bits are OR'd with rw-rw---- \n If unset,
-                        the Kubelet will not modify the ownership and permissions
-                        of any volume."
-                      format: int64
-                      type: integer
-                    fsGroupChangePolicy:
-                      description: 'fsGroupChangePolicy defines behavior of changing
-                        ownership and permission of the volume before being exposed
-                        inside Pod. This field will only apply to volume types which
-                        support fsGroup based ownership(and permissions). It will
-                        have no effect on ephemeral volume types such as: secret,
-                        configmaps and emptydir. Valid values are "OnRootMismatch"
-                        and "Always". If not specified defaults to "Always".'
+                  replicas:
+                    description: Replicas defines the number of replicas of auto recovery
+                      bookies, defaults to 1, a value less or equal to 0 implies auto
+                      recovery is disabled for the cluster
+                    format: int32
+                    minimum: 0
+                    type: integer
+                type: object
+              conf:
+                additionalProperties:
+                  type: string
+                description: 'Conf defines the bookkeeper configuration. It will be
+                  used for generating the configuration file used by bookie process.
+                  Deprecated: use `config`'
+                type: object
+              config:
+                description: Config defines the bookkeeper configuration
+                properties:
+                  compactionRateByBytes:
+                    description: "CompactionRateByBytes is the rate at which compaction
+                      will read entries. The unit is adds per second. \n The default
+                      value is 52428800."
+                    format: int64
+                    minimum: 0
+                    type: integer
+                  custom:
+                    additionalProperties:
                       type: string
-                    runAsGroup:
-                      description: The GID to run the entrypoint of the container
-                        process. Uses runtime default if unset. May also be set in
-                        SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence for
-                        that container.
-                      format: int64
-                      type: integer
-                    runAsNonRoot:
-                      description: Indicates that the container must run as a non-root
-                        user. If true, the Kubelet will validate the image at runtime
-                        to ensure that it does not run as UID 0 (root) and fail to
-                        start the container if it does. If unset or false, no such
-                        validation will be performed. May also be set in SecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence.
-                      type: boolean
-                    runAsUser:
-                      description: The UID to run the entrypoint of the container
-                        process. Defaults to user specified in image metadata if unspecified.
-                        May also be set in SecurityContext.  If set in both SecurityContext
-                        and PodSecurityContext, the value specified in SecurityContext
-                        takes precedence for that container.
-                      format: int64
-                      type: integer
-                    seLinuxOptions:
-                      description: The SELinux context to be applied to all containers.
-                        If unspecified, the container runtime will allocate a random
-                        SELinux context for each container.  May also be set in SecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence for that container.
+                    description: Custom accepts other configurations
+                    type: object
+                  fileInfoFormatVersionToWrite:
+                    description: "FileInfoFormatVersionToWrite is the fileinfo format
+                      version to write. Available formats are 0 and 1. \n The default
+                      value is 1"
+                    format: int32
+                    maximum: 1
+                    minimum: 0
+                    type: integer
+                  gcWaitTime:
+                    description: "GCWaitTime is the interval to trigger next garbage
+                      collection, in milliseconds. \n The default value is 300000"
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  isThrottleByBytes:
+                    description: "IsThrottleByBytes defines the throttle compaction
+                      by bytes or by entries. \n The default value is true."
+                    type: boolean
+                  journalFormatVersionToWrite:
+                    description: JournalFormatVersionToWrite is the journal format version
+                      to write. Available value are from 0 to 6. The default value is
+                      6.
+                    format: int32
+                    maximum: 6
+                    minimum: 0
+                    type: integer
+                  journalMaxBackups:
+                    description: "JournalMaxBackups is the max number of old journal
+                      file to kept. \n The default value is 0."
+                    format: int32
+                    minimum: 0
+                    type: integer
+                  persistBookieStatusEnabled:
+                    description: "PersistBookieStatusEnabled persists the bookie status
+                      locally on the disks. TODO: enable this after https://github.com/apache/bookkeeper/issues/2374
+                      is fixed. \n The default value is false."
+                    type: boolean
+                  useTransactionalCompaction:
+                    description: "UseTransactionalCompaction is the flag to enable/disable
+                      transactional compaction. If it is set to true, it will use transactional
+                      compaction, which uses new entry log files to store entries after
+                      compaction. \n The default value is true."
+                    type: boolean
+                type: object
+              image:
+                description: Image is the container image used to run bookie pods. default
+                  is apachepulsar/pulsar:latest
+                type: string
+              imagePullPolicy:
+                description: Image pull policy, one of Always, Never, IfNotPresent,
+                  default to Always.
+                type: string
+              initialized:
+                description: Initialized determines whether to create the job to initialize
+                  the cluster metadata.
+                type: boolean
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels specifies the labels to attach to the stateful set
+                  the operator creates for the bookkeeper cluster.
+                type: object
+              pod:
+                description: Pod defines the policy for creating a bookkeeper pod for
+                  the cluster
+                properties:
+                  affinity:
+                    description: Affinity specifies the scheduling constraints of a
+                      pod
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the
+                          pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling requirements
+                              (resource request, requiredDuringScheduling affinity expressions,
+                              etc.), compute a sum by iterating through the elements
+                              of this field and adding "weight" to the sum if the node
+                              matches the corresponding matchExpressions; the node(s)
+                              with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches
+                                all objects with implicit weight 0 (i.e. it's a no-op).
+                                A null preferred scheduling term matches no objects
+                                (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values
+                                              array must be empty. If the operator is
+                                              Gt or Lt, the values array must have a
+                                              single element, which will be interpreted
+                                              as an integer. This array is replaced
+                                              during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values
+                                              array must be empty. If the operator is
+                                              Gt or Lt, the values array must have a
+                                              single element, which will be interpreted
+                                              as an integer. This array is replaced
+                                              during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding
+                                    nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                                - preference
+                                - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this
+                              field are not met at scheduling time, the pod will not
+                              be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from its
+                              node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches
+                                    no objects. The requirements of them are ANDed.
+                                    The TopologySelectorTerm type implements a subset
+                                    of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values
+                                              array must be empty. If the operator is
+                                              Gt or Lt, the values array must have a
+                                              single element, which will be interpreted
+                                              as an integer. This array is replaced
+                                              during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values
+                                              array must be empty. If the operator is
+                                              Gt or Lt, the values array must have a
+                                              single element, which will be interpreted
+                                              as an integer. This array is replaced
+                                              during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                              - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate
+                          this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling requirements
+                              (resource request, requiredDuringScheduling affinity expressions,
+                              etc.), compute a sum by iterating through the elements
+                              of this field and adding "weight" to the sum if the node
+                              has pods which matches the corresponding podAffinityTerm;
+                              the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of
+                                            label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values, a
+                                              key, and an operator that relates the
+                                              key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that
+                                                  the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and
+                                                  DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This
+                                                  array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is
+                                            "In", and the values array contains only
+                                            "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the pods
+                                        matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as running
+                                        on a node whose value of the label with key
+                                        topologyKey matches that of any node on which
+                                        any of the selected pods is running. Empty topologyKey
+                                        is not allowed.
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding
+                                    podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                                - podAffinityTerm
+                                - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this
+                              field are not met at scheduling time, the pod will not
+                              be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to a pod label update),
+                              the system may or may not try to eventually evict the
+                              pod from its node. When there are multiple elements, the
+                              lists of nodes corresponding to each podAffinityTerm are
+                              intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located is
+                                defined as running on a node whose value of the label
+                                with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If
+                                              the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array
+                                              is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is "In",
+                                        and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches
+                                    that of any node on which any of the selected pods
+                                    is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                                - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g.
+                          avoid putting this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the anti-affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling requirements
+                              (resource request, requiredDuringScheduling anti-affinity
+                              expressions, etc.), compute a sum by iterating through
+                              the elements of this field and adding "weight" to the
+                              sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of
+                                            label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values, a
+                                              key, and an operator that relates the
+                                              key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that
+                                                  the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and
+                                                  DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This
+                                                  array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is
+                                            "In", and the values array contains only
+                                            "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the pods
+                                        matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as running
+                                        on a node whose value of the label with key
+                                        topologyKey matches that of any node on which
+                                        any of the selected pods is running. Empty topologyKey
+                                        is not allowed.
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding
+                                    podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                                - podAffinityTerm
+                                - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified
+                              by this field are not met at scheduling time, the pod
+                              will not be scheduled onto the node. If the anti-affinity
+                              requirements specified by this field cease to be met at
+                              some point during pod execution (e.g. due to a pod label
+                              update), the system may or may not try to eventually evict
+                              the pod from its node. When there are multiple elements,
+                              the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located is
+                                defined as running on a node whose value of the label
+                                with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If
+                                              the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array
+                                              is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is "In",
+                                        and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches
+                                    that of any node on which any of the selected pods
+                                    is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                                - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations specifies the annotations to attach to
+                      pods the operator creates
+                    type: object
+                  initContainers:
+                    description: InitContainers defines init containers of the pod.
+                      A typical use case could be using an init container to download
+                      a remote jar to a local path.
+                    items:
+                      description: A single application container that you want to run
+                        within a pod. The Container API from the core group is not used
+                        directly to avoid unneeded fields and reduce the size of the
+                        CRD. New fields could be added as needed.
                       properties:
-                        level:
-                          description: Level is SELinux level label that applies to
-                            the container.
+                        args:
+                          description: Arguments to the entrypoint.
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: Entrypoint array. Not executed within a shell.
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the container.
+                          items:
+                            description: EnvVar represents an environment variable present
+                              in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are expanded
+                                  using the previous defined environment variables in
+                                  the container and any service environment variables.
+                                  If a variable cannot be resolved, the reference in
+                                  the input string will be unchanged. The $(VAR_NAME)
+                                  syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                  Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's value.
+                                  Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                      - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for volumes,
+                                          optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                      - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the pod's
+                                      namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its
+                                          key must be defined
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                type: object
+                            required:
+                              - name
+                            type: object
+                          type: array
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container.
+                          items:
+                            description: EnvFromSource represents the source of a set
+                              of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to each
+                                  key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: Docker image name.
                           type: string
-                        role:
-                          description: Role is a SELinux role label that applies to
-                            the container.
+                        imagePullPolicy:
+                          description: Image pull policy.
                           type: string
-                        type:
-                          description: Type is a SELinux type label that applies to
-                            the container.
+                        livenessProbe:
+                          description: Periodic probe of container liveness.
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
                           type: string
-                        user:
-                          description: User is a SELinux user label that applies to
-                            the container.
-                          type: string
-                      type: object
-                    seccompProfile:
-                      description: The seccomp options to use by the containers in
-                        this pod.
-                      properties:
-                        localhostProfile:
-                          description: localhostProfile indicates a profile defined
-                            in a file on the node should be used. The profile must
-                            be preconfigured on the node to work. Must be a descending
-                            path, relative to the kubelet's configured seccomp profile
-                            location. Must only be set if type is "Localhost".
-                          type: string
-                        type:
-                          description: "type indicates which kind of seccomp profile
-                            will be applied. Valid options are: \n Localhost - a profile
-                            defined in a file on the node should be used. RuntimeDefault
-                            - the container runtime default profile should be used.
-                            Unconfined - no profile should be applied."
+                        ports:
+                          description: List of ports to expose from the container.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's IP
+                                  address. This must be a valid port number, 0 < x <
+                                  65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host. If
+                                  specified, this must be a valid port number, 0 < x
+                                  < 65536. If HostNetwork is specified, this must match
+                                  ContainerPort. Most containers do not need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a pod
+                                  must have a unique name. Name for the port that can
+                                  be referred to by services.
+                                type: string
+                              protocol:
+                                description: Protocol for port. Must be UDP, TCP, or
+                                  SCTP. Defaults to "TCP".
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - containerPort
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: Compute Resources required by this container.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute
+                                resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of
+                                compute resources required. If Requests is omitted for
+                                a container, it defaults to Limits if that is explicitly
+                                specified, otherwise to an implementation-defined value.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: StartupProbe indicates that the Pod has successfully
+                            initialized.
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write otherwise
+                                  (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the container's
+                                  volume should be mounted. Defaults to "" (volume's
+                                  root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from which
+                                  the container's volume should be mounted. Behaves
+                                  similarly to SubPath but environment variable references
+                                  $(VAR_NAME) are expanded using the container's environment.
+                                  Defaults to "" (volume's root). SubPathExpr and SubPath
+                                  are mutually exclusive.
+                                type: string
+                            required:
+                              - mountPath
+                              - name
+                            type: object
+                          type: array
+                        workingDir:
+                          description: Container's working directory.
                           type: string
                       required:
-                        - type
+                        - name
                       type: object
-                    supplementalGroups:
-                      description: A list of groups applied to the first process run
-                        in each container, in addition to the container's primary
-                        GID.  If unspecified, no groups will be added to any container.
-                      items:
+                    type: array
+                  jvmOptions:
+                    description: JVMOptions defines JVM parameters of Bookies
+                    properties:
+                      extraOptions:
+                        items:
+                          type: string
+                        type: array
+                      gcLoggingOptions:
+                        items:
+                          type: string
+                        type: array
+                      gcOptions:
+                        items:
+                          type: string
+                        type: array
+                      memoryOptions:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels specifies the labels to attach to pod the operator
+                      creates for the bookkeeper cluster.
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector specifies a map of key-value pairs. For
+                      a pod to be eligible to run on a node, the node must have each
+                      of the indicated key-value pairs as labels.
+                    type: object
+                  resources:
+                    description: Resources specifies the resource requirements of a
+                      pod to run in the cluster
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  securityContext:
+                    description: 'SecurityContext specifies the security context for
+                      the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
+                    properties:
+                      fsGroup:
+                        description: "A special supplemental group that applies to all
+                          containers in a pod. Some volume types allow the Kubelet to
+                          change the ownership of that volume to be owned by the pod:
+                          \n 1. The owning GID will be the FSGroup 2. The setgid bit
+                          is set (new files created in the volume will be owned by FSGroup)
+                          3. The permission bits are OR'd with rw-rw---- \n If unset,
+                          the Kubelet will not modify the ownership and permissions
+                          of any volume."
                         format: int64
                         type: integer
-                      type: array
-                    sysctls:
-                      description: Sysctls hold a list of namespaced sysctls used
-                        for the pod. Pods with unsupported sysctls (by the container
-                        runtime) might fail to launch.
-                      items:
-                        description: Sysctl defines a kernel parameter to be set
+                      fsGroupChangePolicy:
+                        description: 'fsGroupChangePolicy defines behavior of changing
+                          ownership and permission of the volume before being exposed
+                          inside Pod. This field will only apply to volume types which
+                          support fsGroup based ownership(and permissions). It will
+                          have no effect on ephemeral volume types such as: secret,
+                          configmaps and emptydir. Valid values are "OnRootMismatch"
+                          and "Always". If not specified defaults to "Always".'
+                        type: string
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set in
+                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence for
+                          that container.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail to
+                          start the container if it does. If unset or false, no such
+                          validation will be performed. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if unspecified.
+                          May also be set in SecurityContext.  If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
                         properties:
-                          name:
-                            description: Name of a property to set
+                          level:
+                            description: Level is SELinux level label that applies to
+                              the container.
                             type: string
-                          value:
-                            description: Value of a property to set
+                          role:
+                            description: Role is a SELinux role label that applies to
+                              the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies to
+                              the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies to
+                              the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by the containers in
+                          this pod.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a profile
+                              defined in a file on the node should be used. RuntimeDefault
+                              - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied."
                             type: string
                         required:
-                          - name
-                          - value
+                          - type
                         type: object
-                      type: array
-                    windowsOptions:
-                      description: The Windows specific settings applied to all containers.
-                        If unspecified, the options within a container's SecurityContext
-                        will be used. If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence.
-                      properties:
-                        gmsaCredentialSpec:
-                          description: GMSACredentialSpec is where the GMSA admission
-                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                            inlines the contents of the GMSA credential spec named
-                            by the GMSACredentialSpecName field.
-                          type: string
-                        gmsaCredentialSpecName:
-                          description: GMSACredentialSpecName is the name of the GMSA
-                            credential spec to use.
-                          type: string
-                        runAsUserName:
-                          description: The UserName in Windows to run the entrypoint
-                            of the container process. Defaults to the user specified
-                            in image metadata if unspecified. May also be set in PodSecurityContext.
-                            If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
-                          type: string
-                      type: object
-                  type: object
-                terminationGracePeriodSeconds:
-                  description: TerminationGracePeriodSeconds is the amount of time
-                    that kubernetes will give for a pod before terminating it.
-                  format: int64
-                  type: integer
-                tolerations:
-                  description: Tolerations specifies the tolerations of a Pod
-                  items:
-                    description: The pod this Toleration is attached to tolerates
-                      any taint that matches the triple <key,value,effect> using the
-                      matching operator <operator>.
-                    properties:
-                      effect:
-                        description: Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match
-                          all values and all keys.
-                        type: string
-                      operator:
-                        description: Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to
-                          Equal. Exists is equivalent to wildcard for value, so that
-                          a pod can tolerate all taints of a particular category.
-                        type: string
-                      tolerationSeconds:
-                        description: TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default,
-                          it is not set, which means tolerate the taint forever (do
-                          not evict). Zero and negative values will be treated as
-                          0 (evict immediately) by the system.
-                        format: int64
-                        type: integer
-                      value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
-                        type: string
-                    type: object
-                  type: array
-                vars:
-                  description: Vars specifies the environment variables of a Pod
-                  items:
-                    description: EnvVar represents an environment variable present
-                      in a Container.
-                    properties:
-                      name:
-                        description: Name of the environment variable. Must be a C_IDENTIFIER.
-                        type: string
-                      value:
-                        description: 'Variable references $(VAR_NAME) are expanded
-                          using the previous defined environment variables in the
-                          container and any service environment variables. If a variable
-                          cannot be resolved, the reference in the input string will
-                          be unchanged. The $(VAR_NAME) syntax can be escaped with
-                          a double $$, ie: $$(VAR_NAME). Escaped references will never
-                          be expanded, regardless of whether the variable exists or
-                          not. Defaults to "".'
-                        type: string
-                      valueFrom:
-                        description: Source for the environment variable's value.
-                          Cannot be used if value is not empty.
-                        properties:
-                          configMapKeyRef:
-                            description: Selects a key of a ConfigMap.
-                            properties:
-                              key:
-                                description: The key to select.
-                                type: string
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
-                                type: string
-                              optional:
-                                description: Specify whether the ConfigMap or its
-                                  key must be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                          fieldRef:
-                            description: 'Selects a field of the pod: supports metadata.name,
-                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                              spec.nodeName, spec.serviceAccountName, status.hostIP,
-                              status.podIP, status.podIPs.'
-                            properties:
-                              apiVersion:
-                                description: Version of the schema the FieldPath is
-                                  written in terms of, defaults to "v1".
-                                type: string
-                              fieldPath:
-                                description: Path of the field to select in the specified
-                                  API version.
-                                type: string
-                            required:
-                              - fieldPath
-                            type: object
-                          resourceFieldRef:
-                            description: 'Selects a resource of the container: only
-                              resources limits and requests (limits.cpu, limits.memory,
-                              limits.ephemeral-storage, requests.cpu, requests.memory
-                              and requests.ephemeral-storage) are currently supported.'
-                            properties:
-                              containerName:
-                                description: 'Container name: required for volumes,
-                                  optional for env vars'
-                                type: string
-                              divisor:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Specifies the output format of the exposed
-                                  resources, defaults to "1"
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              resource:
-                                description: 'Required: resource to select'
-                                type: string
-                            required:
-                              - resource
-                            type: object
-                          secretKeyRef:
-                            description: Selects a key of a secret in the pod's namespace
-                            properties:
-                              key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
-                                type: string
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
-                                type: string
-                              optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                        type: object
-                    required:
-                      - name
-                    type: object
-                  type: array
-                volumes:
-                  description: Volumes defines extra volumes of the pod.
-                  items:
-                    description: Volume represents a named volume in a pod that may
-                      be accessed by any container in the pod. The Volume API from
-                      the core group is not used directly to avoid unneeded fields
-                      defined in `VolumeSource` and reduce the size of the CRD. New
-                      fields in VolumeSource could be added as needed.
-                    properties:
-                      configMap:
-                        description: ConfigMap represents a configMap that should
-                          populate this volume
-                        properties:
-                          defaultMode:
-                            description: 'Optional: mode bits used to set permissions
-                              on created files by default. Must be an octal value
-                              between 0000 and 0777 or a decimal value between 0 and
-                              511. YAML accepts both octal and decimal values, JSON
-                              requires decimal values for mode bits. Defaults to 0644.
-                              Directories within the path are not affected by this
-                              setting. This might be in conflict with other options
-                              that affect the file mode, like fsGroup, and the result
-                              can be other mode bits set.'
-                            format: int32
-                            type: integer
-                          items:
-                            description: If unspecified, each key-value pair in the
-                              Data field of the referenced ConfigMap will be projected
-                              into the volume as a file whose name is the key and
-                              content is the value. If specified, the listed keys
-                              will be projected into the specified paths, and unlisted
-                              keys will not be present. If a key is specified which
-                              is not present in the ConfigMap, the volume setup will
-                              error unless it is marked optional. Paths must be relative
-                              and may not contain the '..' path or start with '..'.
-                            items:
-                              description: Maps a string key to a path within a volume.
-                              properties:
-                                key:
-                                  description: The key to project.
-                                  type: string
-                                mode:
-                                  description: 'Optional: mode bits used to set permissions
-                                    on this file. Must be an octal value between 0000
-                                    and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON
-                                    requires decimal values for mode bits. If not
-                                    specified, the volume defaultMode will be used.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
-                                  format: int32
-                                  type: integer
-                                path:
-                                  description: The relative path of the file to map
-                                    the key to. May not be an absolute path. May not
-                                    contain the path element '..'. May not start with
-                                    the string '..'.
-                                  type: string
-                              required:
-                                - key
-                                - path
-                              type: object
-                            type: array
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                          optional:
-                            description: Specify whether the ConfigMap or its keys
-                              must be defined
-                            type: boolean
-                        type: object
-                      name:
-                        description: 'Volume''s name. Must be a DNS_LABEL and unique
-                          within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      secret:
-                        description: Secret represents a secret that should populate
-                          this volume.
-                        properties:
-                          defaultMode:
-                            description: 'Optional: mode bits used to set permissions
-                              on created files by default. Must be an octal value
-                              between 0000 and 0777 or a decimal value between 0 and
-                              511. YAML accepts both octal and decimal values, JSON
-                              requires decimal values for mode bits. Defaults to 0644.
-                              Directories within the path are not affected by this
-                              setting. This might be in conflict with other options
-                              that affect the file mode, like fsGroup, and the result
-                              can be other mode bits set.'
-                            format: int32
-                            type: integer
-                          items:
-                            description: If unspecified, each key-value pair in the
-                              Data field of the referenced Secret will be projected
-                              into the volume as a file whose name is the key and
-                              content is the value. If specified, the listed keys
-                              will be projected into the specified paths, and unlisted
-                              keys will not be present. If a key is specified which
-                              is not present in the Secret, the volume setup will
-                              error unless it is marked optional. Paths must be relative
-                              and may not contain the '..' path or start with '..'.
-                            items:
-                              description: Maps a string key to a path within a volume.
-                              properties:
-                                key:
-                                  description: The key to project.
-                                  type: string
-                                mode:
-                                  description: 'Optional: mode bits used to set permissions
-                                    on this file. Must be an octal value between 0000
-                                    and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON
-                                    requires decimal values for mode bits. If not
-                                    specified, the volume defaultMode will be used.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
-                                  format: int32
-                                  type: integer
-                                path:
-                                  description: The relative path of the file to map
-                                    the key to. May not be an absolute path. May not
-                                    contain the path element '..'. May not start with
-                                    the string '..'.
-                                  type: string
-                              required:
-                                - key
-                                - path
-                              type: object
-                            type: array
-                          optional:
-                            description: Specify whether the Secret or its keys must
-                              be defined
-                            type: boolean
-                          secretName:
-                            description: 'Name of the secret in the pod''s namespace
-                              to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                            type: string
-                        type: object
-                    required:
-                      - name
-                    type: object
-                  type: array
-              type: object
-            replicas:
-              description: Replicas is the expected size of the bookkeeper cluster.
-                The bookkeeper operator will eventually make the size of the running
-                cluster equal to the expected size. Use a pointer to distinguish between
-                a specified zero or unspecified.
-              format: int32
-              minimum: 0
-              type: integer
-            storage:
-              description: Persistence defines the persistent volume used for the
-                bookie pod
-              properties:
-                journal:
-                  description: Journal is the spec to define journal storage
-                  properties:
-                    numDirsPerVolume:
-                      description: NumDirsPerVolume defines the number of directories
-                        provisioned for this type of storage.
-                      format: int32
-                      type: integer
-                    numVolumes:
-                      description: NumVolumes defines the number of volumes provisioned
-                        for this type of storage.
-                      format: int32
-                      type: integer
-                    volumeClaimTemplate:
-                      description: VolumeClaimSpec is the spec to define PVC for the
-                        storage
-                      properties:
-                        accessModes:
-                          description: 'AccessModes contains the desired access modes
-                            the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                          items:
-                            type: string
-                          type: array
-                        dataSource:
-                          description: 'This field can be used to specify either:
-                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                            - Beta) * An existing PVC (PersistentVolumeClaim) * An
-                            existing custom resource/object that implements data population
-                            (Alpha) In order to use VolumeSnapshot object types, the
-                            appropriate feature gate must be enabled (VolumeSnapshotDataSource
-                            or AnyVolumeDataSource) If the provisioner or an external
-                            controller can support the specified data source, it will
-                            create a new volume based on the contents of the specified
-                            data source. If the specified data source is not supported,
-                            the volume will not be created and the failure will be
-                            reported as an event. In the future, we plan to support
-                            more data source types and the behavior of the provisioner
-                            may change.'
+                      supplementalGroups:
+                        description: A list of groups applied to the first process run
+                          in each container, in addition to the container's primary
+                          GID.  If unspecified, no groups will be added to any container.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used
+                          for the pod. Pods with unsupported sysctls (by the container
+                          runtime) might fail to launch.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
                           properties:
-                            apiGroup:
-                              description: APIGroup is the group for the resource
-                                being referenced. If APIGroup is not specified, the
-                                specified Kind must be in the core API group. For
-                                any other third-party types, APIGroup is required.
-                              type: string
-                            kind:
-                              description: Kind is the type of resource being referenced
-                              type: string
                             name:
-                              description: Name is the name of resource being referenced
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
                               type: string
                           required:
-                            - kind
                             - name
+                            - value
                           type: object
-                        resources:
-                          description: 'Resources represents the minimum resources
-                            the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                          type: object
-                        selector:
-                          description: A label query over volumes to consider for
-                            binding.
-                          properties:
-                            matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
-                              items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
-                                properties:
-                                  key:
-                                    description: key is the label key that the selector
-                                      applies to.
-                                    type: string
-                                  operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
-                                    type: string
-                                  values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
-                                    items:
-                                      type: string
-                                    type: array
-                                required:
-                                  - key
-                                  - operator
-                                type: object
-                              type: array
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
-                              type: object
-                          type: object
-                        storageClassName:
-                          description: 'Name of the StorageClass required by the claim.
-                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                          type: string
-                        volumeMode:
-                          description: volumeMode defines what type of volume is required
-                            by the claim. Value of Filesystem is implied when not
-                            included in claim spec.
-                          type: string
-                        volumeName:
-                          description: VolumeName is the binding reference to the
-                            PersistentVolume backing this claim.
-                          type: string
-                      type: object
-                  required:
-                    - volumeClaimTemplate
-                  type: object
-                ledger:
-                  description: Ledger is the spec to define the ledger storage
-                  properties:
-                    numDirsPerVolume:
-                      description: NumDirsPerVolume defines the number of directories
-                        provisioned for this type of storage.
-                      format: int32
-                      type: integer
-                    numVolumes:
-                      description: NumVolumes defines the number of volumes provisioned
-                        for this type of storage.
-                      format: int32
-                      type: integer
-                    volumeClaimTemplate:
-                      description: VolumeClaimSpec is the spec to define PVC for the
-                        storage
-                      properties:
-                        accessModes:
-                          description: 'AccessModes contains the desired access modes
-                            the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                          items:
+                        type: array
+                      windowsOptions:
+                        description: The Windows specific settings applied to all containers.
+                          If unspecified, the options within a container's SecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
                             type: string
-                          type: array
-                        dataSource:
-                          description: 'This field can be used to specify either:
-                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                            - Beta) * An existing PVC (PersistentVolumeClaim) * An
-                            existing custom resource/object that implements data population
-                            (Alpha) In order to use VolumeSnapshot object types, the
-                            appropriate feature gate must be enabled (VolumeSnapshotDataSource
-                            or AnyVolumeDataSource) If the provisioner or an external
-                            controller can support the specified data source, it will
-                            create a new volume based on the contents of the specified
-                            data source. If the specified data source is not supported,
-                            the volume will not be created and the failure will be
-                            reported as an event. In the future, we plan to support
-                            more data source types and the behavior of the provisioner
-                            may change.'
-                          properties:
-                            apiGroup:
-                              description: APIGroup is the group for the resource
-                                being referenced. If APIGroup is not specified, the
-                                specified Kind must be in the core API group. For
-                                any other third-party types, APIGroup is required.
-                              type: string
-                            kind:
-                              description: Kind is the type of resource being referenced
-                              type: string
-                            name:
-                              description: Name is the name of resource being referenced
-                              type: string
-                          required:
-                            - kind
-                            - name
-                          type: object
-                        resources:
-                          description: 'Resources represents the minimum resources
-                            the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                          type: object
-                        selector:
-                          description: A label query over volumes to consider for
-                            binding.
-                          properties:
-                            matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
-                              items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
-                                properties:
-                                  key:
-                                    description: key is the label key that the selector
-                                      applies to.
-                                    type: string
-                                  operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
-                                    type: string
-                                  values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
-                                    items:
-                                      type: string
-                                    type: array
-                                required:
-                                  - key
-                                  - operator
-                                type: object
-                              type: array
-                            matchLabels:
-                              additionalProperties:
-                                type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
-                              type: object
-                          type: object
-                        storageClassName:
-                          description: 'Name of the StorageClass required by the claim.
-                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the GMSA
+                              credential spec to use.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in PodSecurityContext.
+                              If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  terminationGracePeriodSeconds:
+                    description: TerminationGracePeriodSeconds is the amount of time
+                      that kubernetes will give for a pod before terminating it.
+                    format: int64
+                    type: integer
+                  tolerations:
+                    description: Tolerations specifies the tolerations of a Pod
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using the
+                        matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty
+                            means match all taint effects. When specified, allowed values
+                            are NoSchedule, PreferNoSchedule and NoExecute.
                           type: string
-                        volumeMode:
-                          description: volumeMode defines what type of volume is required
-                            by the claim. Value of Filesystem is implied when not
-                            included in claim spec.
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
                           type: string
-                        volumeName:
-                          description: VolumeName is the binding reference to the
-                            PersistentVolume backing this claim.
+                        operator:
+                          description: Operator represents a key's relationship to the
+                            value. Valid operators are Exists and Equal. Defaults to
+                            Equal. Exists is equivalent to wildcard for value, so that
+                            a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time
+                            the toleration (which must be of effect NoExecute, otherwise
+                            this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do
+                            not evict). Zero and negative values will be treated as
+                            0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
                           type: string
                       type: object
-                  required:
-                    - volumeClaimTemplate
-                  type: object
-                reclaimPolicy:
-                  description: VolumeReclaimPolicy defines how to reclaim PV.
-                  type: string
-              type: object
-            zkServers:
-              description: Zookeeper server list
-              type: string
-          type: object
-        status:
-          description: BookKeeperClusterStatus defines the observed state of BookKeeperCluster
-          properties:
-            conditions:
-              description: Conditions is the current conditions of the cluster
-              items:
-                description: "Condition represents an observation of an object's state.
-                  Conditions are an extension mechanism intended to be used when the
-                  details of an observation are not a priori known or would not apply
-                  to all instances of a given Kind. \n Conditions should be added
-                  to explicitly convey properties that users and components care about
-                  rather than requiring those properties to be inferred from other
-                  observations. Once defined, the meaning of a Condition can not be
-                  changed arbitrarily - it becomes part of the API, and has the same
-                  backwards- and forwards-compatibility concerns of any other part
-                  of the API."
-                properties:
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    description: ConditionReason is intended to be a one-word, CamelCase
-                      representation of the category of cause of the current status.
-                      It is intended to be used in concise output, such as one-line
-                      kubectl get output, and in summarizing occurrences of causes.
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    description: "ConditionType is the type of the condition and is
-                      typically a CamelCased word or short phrase. \n Condition types
-                      should indicate state in the \"abnormal-true\" polarity. For
-                      example, if the condition indicates when a policy is invalid,
-                      the \"is valid\" case is probably the norm, so the condition
-                      should be called \"Invalid\"."
-                    type: string
-                required:
-                  - status
-                  - type
+                    type: array
+                  vars:
+                    description: Vars specifies the environment variables of a Pod
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a variable
+                            cannot be resolved, the reference in the input string will
+                            be unchanged. The $(VAR_NAME) syntax can be escaped with
+                            a double $$, ie: $$(VAR_NAME). Escaped references will never
+                            be expanded, regardless of whether the variable exists or
+                            not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP,
+                                status.podIP, status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath is
+                                    written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the specified
+                                    API version.
+                                  type: string
+                              required:
+                                - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Specifies the output format of the exposed
+                                    resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                                - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                          type: object
+                      required:
+                        - name
+                      type: object
+                    type: array
+                  volumes:
+                    description: Volumes defines extra volumes of the pod.
+                    items:
+                      description: Volume represents a named volume in a pod that may
+                        be accessed by any container in the pod. The Volume API from
+                        the core group is not used directly to avoid unneeded fields
+                        defined in `VolumeSource` and reduce the size of the CRD. New
+                        fields in VolumeSource could be added as needed.
+                      properties:
+                        configMap:
+                          description: ConfigMap represents a configMap that should
+                            populate this volume
+                          properties:
+                            defaultMode:
+                              description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0 and
+                                511. YAML accepts both octal and decimal values, JSON
+                                requires decimal values for mode bits. Defaults to 0644.
+                                Directories within the path are not affected by this
+                                setting. This might be in conflict with other options
+                                that affect the file mode, like fsGroup, and the result
+                                can be other mode bits set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: If unspecified, each key-value pair in the
+                                Data field of the referenced ConfigMap will be projected
+                                into the volume as a file whose name is the key and
+                                content is the value. If specified, the listed keys
+                                will be projected into the specified paths, and unlisted
+                                keys will not be present. If a key is specified which
+                                is not present in the ConfigMap, the volume setup will
+                                error unless it is marked optional. Paths must be relative
+                                and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a volume.
+                                properties:
+                                  key:
+                                    description: The key to project.
+                                    type: string
+                                  mode:
+                                    description: 'Optional: mode bits used to set permissions
+                                      on this file. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON
+                                      requires decimal values for mode bits. If not
+                                      specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that
+                                      affect the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: The relative path of the file to map
+                                      the key to. May not be an absolute path. May not
+                                      contain the path element '..'. May not start with
+                                      the string '..'.
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                type: object
+                              type: array
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its keys
+                                must be defined
+                              type: boolean
+                          type: object
+                        name:
+                          description: 'Volume''s name. Must be a DNS_LABEL and unique
+                            within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        secret:
+                          description: Secret represents a secret that should populate
+                            this volume.
+                          properties:
+                            defaultMode:
+                              description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0 and
+                                511. YAML accepts both octal and decimal values, JSON
+                                requires decimal values for mode bits. Defaults to 0644.
+                                Directories within the path are not affected by this
+                                setting. This might be in conflict with other options
+                                that affect the file mode, like fsGroup, and the result
+                                can be other mode bits set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: If unspecified, each key-value pair in the
+                                Data field of the referenced Secret will be projected
+                                into the volume as a file whose name is the key and
+                                content is the value. If specified, the listed keys
+                                will be projected into the specified paths, and unlisted
+                                keys will not be present. If a key is specified which
+                                is not present in the Secret, the volume setup will
+                                error unless it is marked optional. Paths must be relative
+                                and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a volume.
+                                properties:
+                                  key:
+                                    description: The key to project.
+                                    type: string
+                                  mode:
+                                    description: 'Optional: mode bits used to set permissions
+                                      on this file. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON
+                                      requires decimal values for mode bits. If not
+                                      specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that
+                                      affect the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: The relative path of the file to map
+                                      the key to. May not be an absolute path. May not
+                                      contain the path element '..'. May not start with
+                                      the string '..'.
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                type: object
+                              type: array
+                            optional:
+                              description: Specify whether the Secret or its keys must
+                                be defined
+                              type: boolean
+                            secretName:
+                              description: 'Name of the secret in the pod''s namespace
+                                to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              type: string
+                          type: object
+                      required:
+                        - name
+                      type: object
+                    type: array
                 type: object
-              type: array
-            currentVersion:
-              description: CurrentVersion is the current cluster version
-              type: string
-            labelSelector:
-              description: Label selector
-              type: string
-            observedGeneration:
-              description: ObservedGeneration is the most recent generation observed
-                for this cluster. It corresponds to the metadata generation, which
-                is updated on mutation by the API Server.
-              format: int64
-              type: integer
-            readyReplicas:
-              description: ReadyReplicas is the number of ready servers in the cluster
-              format: int32
-              type: integer
-            replicas:
-              description: Replicas
-              format: int32
-              type: integer
-            updatedReplicas:
-              description: UpdatedReplicas is the number of servers that has been
-                updated to the latest configuration
-              format: int32
-              type: integer
-          required:
-            - conditions
-            - labelSelector
-            - replicas
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+              replicas:
+                description: Replicas is the expected size of the bookkeeper cluster.
+                  The bookkeeper operator will eventually make the size of the running
+                  cluster equal to the expected size. Use a pointer to distinguish between
+                  a specified zero or unspecified.
+                format: int32
+                minimum: 0
+                type: integer
+              storage:
+                description: Persistence defines the persistent volume used for the
+                  bookie pod
+                properties:
+                  journal:
+                    description: Journal is the spec to define journal storage
+                    properties:
+                      numDirsPerVolume:
+                        description: NumDirsPerVolume defines the number of directories
+                          provisioned for this type of storage.
+                        format: int32
+                        type: integer
+                      numVolumes:
+                        description: NumVolumes defines the number of volumes provisioned
+                          for this type of storage.
+                        format: int32
+                        type: integer
+                      volumeClaimTemplate:
+                        description: VolumeClaimSpec is the spec to define PVC for the
+                          storage
+                        properties:
+                          accessModes:
+                            description: 'AccessModes contains the desired access modes
+                              the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                            items:
+                              type: string
+                            type: array
+                          dataSource:
+                            description: 'This field can be used to specify either:
+                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                              - Beta) * An existing PVC (PersistentVolumeClaim) * An
+                              existing custom resource/object that implements data population
+                              (Alpha) In order to use VolumeSnapshot object types, the
+                              appropriate feature gate must be enabled (VolumeSnapshotDataSource
+                              or AnyVolumeDataSource) If the provisioner or an external
+                              controller can support the specified data source, it will
+                              create a new volume based on the contents of the specified
+                              data source. If the specified data source is not supported,
+                              the volume will not be created and the failure will be
+                              reported as an event. In the future, we plan to support
+                              more data source types and the behavior of the provisioner
+                              may change.'
+                            properties:
+                              apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced. If APIGroup is not specified, the
+                                  specified Kind must be in the core API group. For
+                                  any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                            required:
+                              - kind
+                              - name
+                            type: object
+                          resources:
+                            description: 'Resources represents the minimum resources
+                              the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of
+                                  compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                            type: object
+                          selector:
+                            description: A label query over volumes to consider for
+                              binding.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be empty.
+                                        This array is replaced during a strategic merge
+                                        patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          storageClassName:
+                            description: 'Name of the StorageClass required by the claim.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                            type: string
+                          volumeMode:
+                            description: volumeMode defines what type of volume is required
+                              by the claim. Value of Filesystem is implied when not
+                              included in claim spec.
+                            type: string
+                          volumeName:
+                            description: VolumeName is the binding reference to the
+                              PersistentVolume backing this claim.
+                            type: string
+                        type: object
+                    required:
+                      - volumeClaimTemplate
+                    type: object
+                  ledger:
+                    description: Ledger is the spec to define the ledger storage
+                    properties:
+                      numDirsPerVolume:
+                        description: NumDirsPerVolume defines the number of directories
+                          provisioned for this type of storage.
+                        format: int32
+                        type: integer
+                      numVolumes:
+                        description: NumVolumes defines the number of volumes provisioned
+                          for this type of storage.
+                        format: int32
+                        type: integer
+                      volumeClaimTemplate:
+                        description: VolumeClaimSpec is the spec to define PVC for the
+                          storage
+                        properties:
+                          accessModes:
+                            description: 'AccessModes contains the desired access modes
+                              the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                            items:
+                              type: string
+                            type: array
+                          dataSource:
+                            description: 'This field can be used to specify either:
+                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                              - Beta) * An existing PVC (PersistentVolumeClaim) * An
+                              existing custom resource/object that implements data population
+                              (Alpha) In order to use VolumeSnapshot object types, the
+                              appropriate feature gate must be enabled (VolumeSnapshotDataSource
+                              or AnyVolumeDataSource) If the provisioner or an external
+                              controller can support the specified data source, it will
+                              create a new volume based on the contents of the specified
+                              data source. If the specified data source is not supported,
+                              the volume will not be created and the failure will be
+                              reported as an event. In the future, we plan to support
+                              more data source types and the behavior of the provisioner
+                              may change.'
+                            properties:
+                              apiGroup:
+                                description: APIGroup is the group for the resource
+                                  being referenced. If APIGroup is not specified, the
+                                  specified Kind must be in the core API group. For
+                                  any other third-party types, APIGroup is required.
+                                type: string
+                              kind:
+                                description: Kind is the type of resource being referenced
+                                type: string
+                              name:
+                                description: Name is the name of resource being referenced
+                                type: string
+                            required:
+                              - kind
+                              - name
+                            type: object
+                          resources:
+                            description: 'Resources represents the minimum resources
+                              the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of
+                                  compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                type: object
+                            type: object
+                          selector:
+                            description: A label query over volumes to consider for
+                              binding.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector
+                                    that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship
+                                        to a set of values. Valid operators are In,
+                                        NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values.
+                                        If the operator is In or NotIn, the values array
+                                        must be non-empty. If the operator is Exists
+                                        or DoesNotExist, the values array must be empty.
+                                        This array is replaced during a strategic merge
+                                        patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs.
+                                  A single {key,value} in the matchLabels map is equivalent
+                                  to an element of matchExpressions, whose key field
+                                  is "key", the operator is "In", and the values array
+                                  contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                          storageClassName:
+                            description: 'Name of the StorageClass required by the claim.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                            type: string
+                          volumeMode:
+                            description: volumeMode defines what type of volume is required
+                              by the claim. Value of Filesystem is implied when not
+                              included in claim spec.
+                            type: string
+                          volumeName:
+                            description: VolumeName is the binding reference to the
+                              PersistentVolume backing this claim.
+                            type: string
+                        type: object
+                    required:
+                      - volumeClaimTemplate
+                    type: object
+                  reclaimPolicy:
+                    description: VolumeReclaimPolicy defines how to reclaim PV.
+                    type: string
+                type: object
+              zkServers:
+                description: Zookeeper server list
+                type: string
+            type: object
+          status:
+            description: BookKeeperClusterStatus defines the observed state of BookKeeperCluster
+            properties:
+              conditions:
+                description: Conditions is the current conditions of the cluster
+                items:
+                  description: "Condition represents an observation of an object's state.
+                    Conditions are an extension mechanism intended to be used when the
+                    details of an observation are not a priori known or would not apply
+                    to all instances of a given Kind. \n Conditions should be added
+                    to explicitly convey properties that users and components care about
+                    rather than requiring those properties to be inferred from other
+                    observations. Once defined, the meaning of a Condition can not be
+                    changed arbitrarily - it becomes part of the API, and has the same
+                    backwards- and forwards-compatibility concerns of any other part
+                    of the API."
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      description: ConditionReason is intended to be a one-word, CamelCase
+                        representation of the category of cause of the current status.
+                        It is intended to be used in concise output, such as one-line
+                        kubectl get output, and in summarizing occurrences of causes.
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: "ConditionType is the type of the condition and is
+                        typically a CamelCased word or short phrase. \n Condition types
+                        should indicate state in the \"abnormal-true\" polarity. For
+                        example, if the condition indicates when a policy is invalid,
+                        the \"is valid\" case is probably the norm, so the condition
+                        should be called \"Invalid\"."
+                      type: string
+                  required:
+                    - status
+                    - type
+                  type: object
+                type: array
+              currentVersion:
+                description: CurrentVersion is the current cluster version
+                type: string
+              labelSelector:
+                description: Label selector
+                type: string
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  for this cluster. It corresponds to the metadata generation, which
+                  is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: ReadyReplicas is the number of ready servers in the cluster
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: UpdatedReplicas is the number of servers that has been
+                  updated to the latest configuration
+                format: int32
+                type: integer
+            required:
+              - conditions
+              - labelSelector
+              - replicas
+            type: object
+        type: object
 status:
   acceptedNames:
     kind: ""

--- a/charts/pulsar-operator/crds/pulsar.streamnative.io_pulsarbrokers.yaml
+++ b/charts/pulsar-operator/crds/pulsar.streamnative.io_pulsarbrokers.yaml
@@ -1,6 +1,5 @@
-
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -20,5602 +19,5601 @@ spec:
       - broker
     singular: pulsarbroker
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: PulsarBrokerSpec defines the desired state of PulsarBroker
-          properties:
-            apiObjects:
-              description: APIObjects allows precise control over how components (services,
-                statefulset and so on) should be managed
-              properties:
-                brokerConfigMap:
-                  description: BrokerConfigMap defines the broker ConfigMap resource
-                    template.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                  type: object
-                externalService:
-                  description: ExternalService defines the Pulsar External Service
-                    resource template.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                  type: object
-                functionMeshConfigMap:
-                  description: FunctionMeshConfigMap defines the FunctionMesh ConfigMap
-                    resource template.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                  type: object
-                functionWorkerConfigMap:
-                  description: FunctionWorkerConfigMap defines the function worker
-                    ConfigMap resource template.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                  type: object
-                headlessService:
-                  description: HeadlessService defines the Pulsar Headless Service
-                    resource template.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                  type: object
-                interceptorConfigMap:
-                  description: InterceptorConfigMap defines the interceptor ConfigMap
-                    resource template.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                  type: object
-                internalService:
-                  description: InternalService defines the Pulsar Client Service resource
-                    template.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                  type: object
-                pdb:
-                  description: PDB defines the PodDisruptionBudget resource template.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                  type: object
-                statefulSet:
-                  description: StatefulSet defines the broker StatefulSet resource
-                    template.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        the name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                    volumeClaimTemplates:
-                      description: VolumeClaimTemplates is a list of claims that pods
-                        are allowed to reference. If a non-empty list is specified,
-                        the original values in the desired STS will be replaced.
-                      items:
-                        description: PersistentVolumeClaim is a user's request for
-                          and claim to a persistent volume
-                        properties:
-                          apiVersion:
-                            description: 'APIVersion defines the versioned schema
-                              of this representation of an object. Servers should
-                              convert recognized schemas to the latest internal value,
-                              and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                            type: string
-                          kind:
-                            description: 'Kind is a string value representing the
-                              REST resource this object represents. Servers may infer
-                              this from the endpoint the client submits requests to.
-                              Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          metadata:
-                            description: 'Standard object''s metadata. More info:
-                              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                            type: object
-                          spec:
-                            description: 'Spec defines the desired characteristics
-                              of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                            properties:
-                              accessModes:
-                                description: 'AccessModes contains the desired access
-                                  modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                items:
-                                  type: string
-                                type: array
-                              dataSource:
-                                description: 'This field can be used to specify either:
-                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                                  - Beta) * An existing PVC (PersistentVolumeClaim)
-                                  * An existing custom resource/object that implements
-                                  data population (Alpha) In order to use VolumeSnapshot
-                                  object types, the appropriate feature gate must
-                                  be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
-                                  If the provisioner or an external controller can
-                                  support the specified data source, it will create
-                                  a new volume based on the contents of the specified
-                                  data source. If the specified data source is not
-                                  supported, the volume will not be created and the
-                                  failure will be reported as an event. In the future,
-                                  we plan to support more data source types and the
-                                  behavior of the provisioner may change.'
-                                properties:
-                                  apiGroup:
-                                    description: APIGroup is the group for the resource
-                                      being referenced. If APIGroup is not specified,
-                                      the specified Kind must be in the core API group.
-                                      For any other third-party types, APIGroup is
-                                      required.
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PulsarBrokerSpec defines the desired state of PulsarBroker
+            properties:
+              apiObjects:
+                description: APIObjects allows precise control over how components (services,
+                  statefulset and so on) should be managed
+                properties:
+                  brokerConfigMap:
+                    description: BrokerConfigMap defines the broker ConfigMap resource
+                      template.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                    type: object
+                  externalService:
+                    description: ExternalService defines the Pulsar External Service
+                      resource template.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                    type: object
+                  functionMeshConfigMap:
+                    description: FunctionMeshConfigMap defines the FunctionMesh ConfigMap
+                      resource template.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                    type: object
+                  functionWorkerConfigMap:
+                    description: FunctionWorkerConfigMap defines the function worker
+                      ConfigMap resource template.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                    type: object
+                  headlessService:
+                    description: HeadlessService defines the Pulsar Headless Service
+                      resource template.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                    type: object
+                  interceptorConfigMap:
+                    description: InterceptorConfigMap defines the interceptor ConfigMap
+                      resource template.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                    type: object
+                  internalService:
+                    description: InternalService defines the Pulsar Client Service resource
+                      template.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                    type: object
+                  pdb:
+                    description: PDB defines the PodDisruptionBudget resource template.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                    type: object
+                  statefulSet:
+                    description: StatefulSet defines the broker StatefulSet resource
+                      template.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          the name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                      volumeClaimTemplates:
+                        description: VolumeClaimTemplates is a list of claims that pods
+                          are allowed to reference. If a non-empty list is specified,
+                          the original values in the desired STS will be replaced.
+                        items:
+                          description: PersistentVolumeClaim is a user's request for
+                            and claim to a persistent volume
+                          properties:
+                            apiVersion:
+                              description: 'APIVersion defines the versioned schema
+                                of this representation of an object. Servers should
+                                convert recognized schemas to the latest internal value,
+                                and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                              type: string
+                            kind:
+                              description: 'Kind is a string value representing the
+                                REST resource this object represents. Servers may infer
+                                this from the endpoint the client submits requests to.
+                                Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            metadata:
+                              description: 'Standard object''s metadata. More info:
+                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                              type: object
+                            spec:
+                              description: 'Spec defines the desired characteristics
+                                of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              properties:
+                                accessModes:
+                                  description: 'AccessModes contains the desired access
+                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                  items:
                                     type: string
-                                  kind:
-                                    description: Kind is the type of resource being
-                                      referenced
+                                  type: array
+                                dataSource:
+                                  description: 'This field can be used to specify either:
+                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                                    - Beta) * An existing PVC (PersistentVolumeClaim)
+                                    * An existing custom resource/object that implements
+                                    data population (Alpha) In order to use VolumeSnapshot
+                                    object types, the appropriate feature gate must
+                                    be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
+                                    If the provisioner or an external controller can
+                                    support the specified data source, it will create
+                                    a new volume based on the contents of the specified
+                                    data source. If the specified data source is not
+                                    supported, the volume will not be created and the
+                                    failure will be reported as an event. In the future,
+                                    we plan to support more data source types and the
+                                    behavior of the provisioner may change.'
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup is the group for the resource
+                                        being referenced. If APIGroup is not specified,
+                                        the specified Kind must be in the core API group.
+                                        For any other third-party types, APIGroup is
+                                        required.
+                                      type: string
+                                    kind:
+                                      description: Kind is the type of resource being
+                                        referenced
+                                      type: string
+                                    name:
+                                      description: Name is the name of resource being
+                                        referenced
+                                      type: string
+                                  required:
+                                    - kind
+                                    - name
+                                  type: object
+                                resources:
+                                  description: 'Resources represents the minimum resources
+                                    the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                  properties:
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: 'Limits describes the maximum amount
+                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: 'Requests describes the minimum amount
+                                        of compute resources required. If Requests is
+                                        omitted for a container, it defaults to Limits
+                                        if that is explicitly specified, otherwise to
+                                        an implementation-defined value. More info:
+                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      type: object
+                                  type: object
+                                selector:
+                                  description: A label query over volumes to consider
+                                    for binding.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If
+                                              the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array
+                                              is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is "In",
+                                        and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                storageClassName:
+                                  description: 'Name of the StorageClass required by
+                                    the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                  type: string
+                                volumeMode:
+                                  description: volumeMode defines what type of volume
+                                    is required by the claim. Value of Filesystem is
+                                    implied when not included in claim spec.
+                                  type: string
+                                volumeName:
+                                  description: VolumeName is the binding reference to
+                                    the PersistentVolume backing this claim.
+                                  type: string
+                              type: object
+                            status:
+                              description: 'Status represents the current information/status
+                                of a persistent volume claim. Read-only. More info:
+                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              properties:
+                                accessModes:
+                                  description: 'AccessModes contains the actual access
+                                    modes the volume backing the PVC has. More info:
+                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                  items:
+                                    type: string
+                                  type: array
+                                capacity:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: Represents the actual resources of the
+                                    underlying volume.
+                                  type: object
+                                conditions:
+                                  description: Current Condition of persistent volume
+                                    claim. If underlying persistent volume is being
+                                    resized then the Condition will be set to 'ResizeStarted'.
+                                  items:
+                                    description: PersistentVolumeClaimCondition contails
+                                      details about state of pvc
+                                    properties:
+                                      lastProbeTime:
+                                        description: Last time we probed the condition.
+                                        format: date-time
+                                        type: string
+                                      lastTransitionTime:
+                                        description: Last time the condition transitioned
+                                          from one status to another.
+                                        format: date-time
+                                        type: string
+                                      message:
+                                        description: Human-readable message indicating
+                                          details about last transition.
+                                        type: string
+                                      reason:
+                                        description: Unique, this should be a short,
+                                          machine understandable string that gives the
+                                          reason for condition's last transition. If
+                                          it reports "ResizeStarted" that means the
+                                          underlying persistent volume is being resized.
+                                        type: string
+                                      status:
+                                        type: string
+                                      type:
+                                        description: PersistentVolumeClaimConditionType
+                                          is a valid value of PersistentVolumeClaimCondition.Type
+                                        type: string
+                                    required:
+                                      - status
+                                      - type
+                                    type: object
+                                  type: array
+                                phase:
+                                  description: Phase represents the current phase of
+                                    PersistentVolumeClaim.
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
+                      volumeMounts:
+                        description: VolumeMounts is a list of volumes to mount into
+                          the container's filesystem. If a non-empty list is specified,
+                          the original values of the main container in the desired STS
+                          will be replaced.
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the volume
+                                should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts are
+                                propagated from the host to container and the other
+                                way around. When not set, MountPropagationNone is used.
+                                This field is beta in 1.10.
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise
+                                (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's
+                                volume should be mounted. Defaults to "" (volume's root).
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which
+                                the container's volume should be mounted. Behaves similarly
+                                to SubPath but environment variable references $(VAR_NAME)
+                                are expanded using the container's environment. Defaults
+                                to "" (volume's root). SubPathExpr and SubPath are mutually
+                                exclusive.
+                              type: string
+                          required:
+                            - mountPath
+                            - name
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              bkMetadataServiceUri:
+                description: BkMetadataServiceURI defines the metadata service uri that
+                  bookkeeper is used for loading corresponding metadata driver and resolving
+                  its metadata service location.
+                type: string
+              cleanUpPolicy:
+                description: CleanUpPolicy defines the behavior when the object is being
+                  deleted
+                type: string
+              config:
+                description: Config defines configurations for brokers
+                properties:
+                  advertisedDomain:
+                    description: AdvertisedDomain defines a root domain of the services
+                      to advertise to the outside world.
+                    type: string
+                  custom:
+                    additionalProperties:
+                      type: string
+                    description: Custom allows to customize broker configurations directly.
+                    type: object
+                  function:
+                    description: FunctionConfig defines function worker configurations
+                    properties:
+                      custom:
+                        additionalProperties:
+                          type: string
+                        description: Custom allows to custom functions worker's configuration
+                          and will be written to the ConfigMap for `changeConfig`
+                        type: object
+                      enabled:
+                        description: Enabled defines whether to enable function in the
+                          cluster
+                        type: boolean
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: Labels defines custom labels for function pods
+                        type: object
+                      mesh:
+                        description: Mesh defines configurations used in function mesh
+                        properties:
+                          builtinConnectorsRef:
+                            description: BuiltinConnectorsRef defines the reference
+                              to the ConfigMap that contains a list of builtin-connector
+                              definitions
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?'
+                                type: string
+                            type: object
+                          functionEnabled:
+                            description: FunctionEnabled defines whether to enable function
+                              APIs
+                            type: boolean
+                          sinkEnabled:
+                            description: SinkEnabled defines whether to enable sink
+                              APIs
+                            type: boolean
+                          sourceEnabled:
+                            description: SourceEnabled defines whether to enable source
+                              APIs
+                            type: boolean
+                          uploadEnabled:
+                            description: UploadEnabled defines whether to enable user
+                              code upload in APIs
+                            type: boolean
+                        type: object
+                      resourceRequirements:
+                        description: ResourceRequirements describes the resource requirements
+                        properties:
+                          max:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: Max describes maximum compute resource could
+                              request for each replica
+                            type: object
+                          min:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: Min describes minimal compute resource should
+                              request for each replica
+                            type: object
+                        type: object
+                      type:
+                        description: Type defines the type of function worker service
+                          to run functions/sources/sinks Function-mesh worker service
+                          is used if the value of type is FunctionMesh, otherwise the
+                          builtin worker service is used
+                        type: string
+                    type: object
+                  protocolHandlers:
+                    description: ProtocolHandlers defines the configuration of protocol
+                      handlers
+                    properties:
+                      aop:
+                        description: AoP configurations
+                        properties:
+                          enabled:
+                            description: Enabled defines whether to enable AoP
+                            type: boolean
+                          proxyEnabled:
+                            description: Whether to start AMQP proxy.
+                            type: boolean
+                        type: object
+                      kop:
+                        description: KoP defines KoP configurations
+                        properties:
+                          enabled:
+                            description: Enabled defines whether to enable KoP
+                            type: boolean
+                          tls:
+                            description: TLS defines TLS configurations
+                            properties:
+                              certSecretName:
+                                description: CertSecretName defines the name of the
+                                  secret that contains the certificate to use the value
+                                  should be name of the secret that contains a valid
+                                  certificate to use in the proxy
+                                type: string
+                              enabled:
+                                description: Enabled determines whether to enable TLS
+                                  in proxies TODO move other TLS related fields here
+                                type: boolean
+                              passwordSecretRef:
+                                description: PasswordSecretRef is a reference to a key
+                                  in a Secret resource containing the password used
+                                  to encrypt the keystore.
+                                properties:
+                                  key:
+                                    description: The key of the entry in the Secret
+                                      resource's `data` field to be used. Some instances
+                                      of this field may be defaulted, in others it may
+                                      be required.
                                     type: string
                                   name:
-                                    description: Name is the name of resource being
-                                      referenced
+                                    description: 'Name of the resource being referred
+                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                 required:
-                                  - kind
                                   - name
                                 type: object
-                              resources:
-                                description: 'Resources represents the minimum resources
-                                  the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                                properties:
-                                  limits:
-                                    additionalProperties:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    description: 'Limits describes the maximum amount
-                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                    type: object
-                                  requests:
-                                    additionalProperties:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    description: 'Requests describes the minimum amount
-                                      of compute resources required. If Requests is
-                                      omitted for a container, it defaults to Limits
-                                      if that is explicitly specified, otherwise to
-                                      an implementation-defined value. More info:
-                                      https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                    type: object
-                                type: object
-                              selector:
-                                description: A label query over volumes to consider
-                                  for binding.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              storageClassName:
-                                description: 'Name of the StorageClass required by
-                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                                type: string
-                              volumeMode:
-                                description: volumeMode defines what type of volume
-                                  is required by the claim. Value of Filesystem is
-                                  implied when not included in claim spec.
-                                type: string
-                              volumeName:
-                                description: VolumeName is the binding reference to
-                                  the PersistentVolume backing this claim.
-                                type: string
+                              trustCertsEnabled:
+                                description: TrustCertsEnabled defines whether to enable
+                                  trust store
+                                type: boolean
                             type: object
-                          status:
-                            description: 'Status represents the current information/status
-                              of a persistent volume claim. Read-only. More info:
-                              https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        type: object
+                    type: object
+                  transactionEnabled:
+                    description: TransactionEnabled defines whether transaction support
+                      is enabled in the brokers
+                    type: boolean
+                type: object
+              configs:
+                additionalProperties:
+                  type: string
+                description: 'Configs defines custom configurations for brokers Deprecated:
+                  use Config instead'
+                type: object
+              dnsNames:
+                description: A list of service urls this pulsar broker advertise
+                items:
+                  type: string
+                type: array
+              image:
+                description: Image is the container image used to run pulsar broker
+                  pods. default is apachepulsar/pulsar:latest
+                type: string
+              imagePullPolicy:
+                description: Image pull policy, one of Always, Never, IfNotPresent,
+                  default to Always.
+                type: string
+              initJobPod:
+                description: InitJobPod defines the policy for creating a pod for init
+                  job
+                properties:
+                  affinity:
+                    description: Affinity specifies the scheduling constraints of a
+                      pod
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the
+                          pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling requirements
+                              (resource request, requiredDuringScheduling affinity expressions,
+                              etc.), compute a sum by iterating through the elements
+                              of this field and adding "weight" to the sum if the node
+                              matches the corresponding matchExpressions; the node(s)
+                              with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches
+                                all objects with implicit weight 0 (i.e. it's a no-op).
+                                A null preferred scheduling term matches no objects
+                                (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values
+                                              array must be empty. If the operator is
+                                              Gt or Lt, the values array must have a
+                                              single element, which will be interpreted
+                                              as an integer. This array is replaced
+                                              during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values
+                                              array must be empty. If the operator is
+                                              Gt or Lt, the values array must have a
+                                              single element, which will be interpreted
+                                              as an integer. This array is replaced
+                                              during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding
+                                    nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                                - preference
+                                - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this
+                              field are not met at scheduling time, the pod will not
+                              be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from its
+                              node.
                             properties:
-                              accessModes:
-                                description: 'AccessModes contains the actual access
-                                  modes the volume backing the PVC has. More info:
-                                  https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
                                 items:
-                                  type: string
+                                  description: A null or empty node selector term matches
+                                    no objects. The requirements of them are ANDed.
+                                    The TopologySelectorTerm type implements a subset
+                                    of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values
+                                              array must be empty. If the operator is
+                                              Gt or Lt, the values array must have a
+                                              single element, which will be interpreted
+                                              as an integer. This array is replaced
+                                              during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values
+                                              array must be empty. If the operator is
+                                              Gt or Lt, the values array must have a
+                                              single element, which will be interpreted
+                                              as an integer. This array is replaced
+                                              during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                  type: object
                                 type: array
-                              capacity:
-                                additionalProperties:
+                            required:
+                              - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate
+                          this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling requirements
+                              (resource request, requiredDuringScheduling affinity expressions,
+                              etc.), compute a sum by iterating through the elements
+                              of this field and adding "weight" to the sum if the node
+                              has pods which matches the corresponding podAffinityTerm;
+                              the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of
+                                            label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values, a
+                                              key, and an operator that relates the
+                                              key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that
+                                                  the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and
+                                                  DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This
+                                                  array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is
+                                            "In", and the values array contains only
+                                            "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the pods
+                                        matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as running
+                                        on a node whose value of the label with key
+                                        topologyKey matches that of any node on which
+                                        any of the selected pods is running. Empty topologyKey
+                                        is not allowed.
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding
+                                    podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                                - podAffinityTerm
+                                - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this
+                              field are not met at scheduling time, the pod will not
+                              be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to a pod label update),
+                              the system may or may not try to eventually evict the
+                              pod from its node. When there are multiple elements, the
+                              lists of nodes corresponding to each podAffinityTerm are
+                              intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located is
+                                defined as running on a node whose value of the label
+                                with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If
+                                              the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array
+                                              is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is "In",
+                                        and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches
+                                    that of any node on which any of the selected pods
+                                    is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                                - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g.
+                          avoid putting this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the anti-affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling requirements
+                              (resource request, requiredDuringScheduling anti-affinity
+                              expressions, etc.), compute a sum by iterating through
+                              the elements of this field and adding "weight" to the
+                              sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of
+                                            label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values, a
+                                              key, and an operator that relates the
+                                              key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that
+                                                  the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and
+                                                  DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This
+                                                  array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is
+                                            "In", and the values array contains only
+                                            "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the pods
+                                        matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as running
+                                        on a node whose value of the label with key
+                                        topologyKey matches that of any node on which
+                                        any of the selected pods is running. Empty topologyKey
+                                        is not allowed.
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding
+                                    podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                                - podAffinityTerm
+                                - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified
+                              by this field are not met at scheduling time, the pod
+                              will not be scheduled onto the node. If the anti-affinity
+                              requirements specified by this field cease to be met at
+                              some point during pod execution (e.g. due to a pod label
+                              update), the system may or may not try to eventually evict
+                              the pod from its node. When there are multiple elements,
+                              the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located is
+                                defined as running on a node whose value of the label
+                                with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If
+                                              the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array
+                                              is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is "In",
+                                        and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches
+                                    that of any node on which any of the selected pods
+                                    is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                                - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations specifies the annotations to attach to
+                      pods the operator creates
+                    type: object
+                  debug:
+                    description: Debug defines a switch enable debug
+                    type: boolean
+                  initContainers:
+                    description: InitContainers defines init containers of the pod.
+                      A typical use case could be using an init container to download
+                      a remote jar to a local path.
+                    items:
+                      description: A single application container that you want to run
+                        within a pod. The Container API from the core group is not used
+                        directly to avoid unneeded fields and reduce the size of the
+                        CRD. New fields could be added as needed.
+                      properties:
+                        args:
+                          description: Arguments to the entrypoint.
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: Entrypoint array. Not executed within a shell.
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the container.
+                          items:
+                            description: EnvVar represents an environment variable present
+                              in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are expanded
+                                  using the previous defined environment variables in
+                                  the container and any service environment variables.
+                                  If a variable cannot be resolved, the reference in
+                                  the input string will be unchanged. The $(VAR_NAME)
+                                  syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                  Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's value.
+                                  Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                      - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for volumes,
+                                          optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                      - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the pod's
+                                      namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its
+                                          key must be defined
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                type: object
+                            required:
+                              - name
+                            type: object
+                          type: array
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container.
+                          items:
+                            description: EnvFromSource represents the source of a set
+                              of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to each
+                                  key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: Docker image name.
+                          type: string
+                        imagePullPolicy:
+                          description: Image pull policy.
+                          type: string
+                        livenessProbe:
+                          description: Periodic probe of container liveness.
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
-                                description: Represents the actual resources of the
-                                  underlying volume.
-                                type: object
-                              conditions:
-                                description: Current Condition of persistent volume
-                                  claim. If underlying persistent volume is being
-                                  resized then the Condition will be set to 'ResizeStarted'.
-                                items:
-                                  description: PersistentVolumeClaimCondition contails
-                                    details about state of pvc
-                                  properties:
-                                    lastProbeTime:
-                                      description: Last time we probed the condition.
-                                      format: date-time
-                                      type: string
-                                    lastTransitionTime:
-                                      description: Last time the condition transitioned
-                                        from one status to another.
-                                      format: date-time
-                                      type: string
-                                    message:
-                                      description: Human-readable message indicating
-                                        details about last transition.
-                                      type: string
-                                    reason:
-                                      description: Unique, this should be a short,
-                                        machine understandable string that gives the
-                                        reason for condition's last transition. If
-                                        it reports "ResizeStarted" that means the
-                                        underlying persistent volume is being resized.
-                                      type: string
-                                    status:
-                                      type: string
-                                    type:
-                                      description: PersistentVolumeClaimConditionType
-                                        is a valid value of PersistentVolumeClaimCondition.Type
-                                      type: string
-                                  required:
-                                    - status
-                                    - type
-                                  type: object
-                                type: array
-                              phase:
-                                description: Phase represents the current phase of
-                                  PersistentVolumeClaim.
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's IP
+                                  address. This must be a valid port number, 0 < x <
+                                  65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
                                 type: string
+                              hostPort:
+                                description: Number of port to expose on the host. If
+                                  specified, this must be a valid port number, 0 < x
+                                  < 65536. If HostNetwork is specified, this must match
+                                  ContainerPort. Most containers do not need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a pod
+                                  must have a unique name. Name for the port that can
+                                  be referred to by services.
+                                type: string
+                              protocol:
+                                description: Protocol for port. Must be UDP, TCP, or
+                                  SCTP. Defaults to "TCP".
+                                type: string
+                            required:
+                              - containerPort
                             type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - containerPort
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: Compute Resources required by this container.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute
+                                resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of
+                                compute resources required. If Requests is omitted for
+                                a container, it defaults to Limits if that is explicitly
+                                specified, otherwise to an implementation-defined value.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: StartupProbe indicates that the Pod has successfully
+                            initialized.
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write otherwise
+                                  (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the container's
+                                  volume should be mounted. Defaults to "" (volume's
+                                  root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from which
+                                  the container's volume should be mounted. Behaves
+                                  similarly to SubPath but environment variable references
+                                  $(VAR_NAME) are expanded using the container's environment.
+                                  Defaults to "" (volume's root). SubPathExpr and SubPath
+                                  are mutually exclusive.
+                                type: string
+                            required:
+                              - mountPath
+                              - name
+                            type: object
+                          type: array
+                        workingDir:
+                          description: Container's working directory.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    type: array
+                  jvmOptions:
+                    description: JvmOptions defines the Jvm options passed to the proxy
+                    properties:
+                      extraOptions:
+                        items:
+                          type: string
+                        type: array
+                      gcLoggingOptions:
+                        items:
+                          type: string
+                        type: array
+                      gcOptions:
+                        items:
+                          type: string
+                        type: array
+                      memoryOptions:
+                        items:
+                          type: string
+                        type: array
+                    required:
+                      - extraOptions
+                      - gcLoggingOptions
+                      - gcOptions
+                      - memoryOptions
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels specifies the labels to attach to pod the operator
+                      creates for the cluster.
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector specifies a map of key-value pairs. For
+                      a pod to be eligible to run on a node, the node must have each
+                      of the indicated key-value pairs as labels.
+                    type: object
+                  resources:
+                    description: Resources specifies the resource requirements of a
+                      pod to run in the cluster
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
-                      type: array
-                    volumeMounts:
-                      description: VolumeMounts is a list of volumes to mount into
-                        the container's filesystem. If a non-empty list is specified,
-                        the original values of the main container in the desired STS
-                        will be replaced.
-                      items:
-                        description: VolumeMount describes a mounting of a Volume
-                          within a container.
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  secretRefs:
+                    description: SecretRefs defines how to mount required secrets into
+                      containers
+                    items:
+                      properties:
+                        mountPath:
+                          type: string
+                        secretName:
+                          type: string
+                      required:
+                        - mountPath
+                        - secretName
+                      type: object
+                    type: array
+                  securityContext:
+                    description: 'SecurityContext specifies the security context for
+                      the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
+                    properties:
+                      fsGroup:
+                        description: "A special supplemental group that applies to all
+                          containers in a pod. Some volume types allow the Kubelet to
+                          change the ownership of that volume to be owned by the pod:
+                          \n 1. The owning GID will be the FSGroup 2. The setgid bit
+                          is set (new files created in the volume will be owned by FSGroup)
+                          3. The permission bits are OR'd with rw-rw---- \n If unset,
+                          the Kubelet will not modify the ownership and permissions
+                          of any volume."
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        description: 'fsGroupChangePolicy defines behavior of changing
+                          ownership and permission of the volume before being exposed
+                          inside Pod. This field will only apply to volume types which
+                          support fsGroup based ownership(and permissions). It will
+                          have no effect on ephemeral volume types such as: secret,
+                          configmaps and emptydir. Valid values are "OnRootMismatch"
+                          and "Always". If not specified defaults to "Always".'
+                        type: string
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set in
+                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence for
+                          that container.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail to
+                          start the container if it does. If unset or false, no such
+                          validation will be performed. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if unspecified.
+                          May also be set in SecurityContext.  If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
                         properties:
-                          mountPath:
-                            description: Path within the container at which the volume
-                              should be mounted.  Must not contain ':'.
+                          level:
+                            description: Level is SELinux level label that applies to
+                              the container.
                             type: string
-                          mountPropagation:
-                            description: mountPropagation determines how mounts are
-                              propagated from the host to container and the other
-                              way around. When not set, MountPropagationNone is used.
-                              This field is beta in 1.10.
+                          role:
+                            description: Role is a SELinux role label that applies to
+                              the container.
                             type: string
-                          name:
-                            description: This must match the Name of a Volume.
+                          type:
+                            description: Type is a SELinux type label that applies to
+                              the container.
                             type: string
-                          readOnly:
-                            description: Mounted read-only if true, read-write otherwise
-                              (false or unspecified). Defaults to false.
-                            type: boolean
-                          subPath:
-                            description: Path within the volume from which the container's
-                              volume should be mounted. Defaults to "" (volume's root).
+                          user:
+                            description: User is a SELinux user label that applies to
+                              the container.
                             type: string
-                          subPathExpr:
-                            description: Expanded path within the volume from which
-                              the container's volume should be mounted. Behaves similarly
-                              to SubPath but environment variable references $(VAR_NAME)
-                              are expanded using the container's environment. Defaults
-                              to "" (volume's root). SubPathExpr and SubPath are mutually
-                              exclusive.
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by the containers in
+                          this pod.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a profile
+                              defined in a file on the node should be used. RuntimeDefault
+                              - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied."
                             type: string
                         required:
-                          - mountPath
-                          - name
+                          - type
                         type: object
-                      type: array
-                  type: object
-              type: object
-            bkMetadataServiceUri:
-              description: BkMetadataServiceURI defines the metadata service uri that
-                bookkeeper is used for loading corresponding metadata driver and resolving
-                its metadata service location.
-              type: string
-            cleanUpPolicy:
-              description: CleanUpPolicy defines the behavior when the object is being
-                deleted
-              type: string
-            config:
-              description: Config defines configurations for brokers
-              properties:
-                advertisedDomain:
-                  description: AdvertisedDomain defines a root domain of the services
-                    to advertise to the outside world.
-                  type: string
-                custom:
-                  additionalProperties:
-                    type: string
-                  description: Custom allows to customize broker configurations directly.
-                  type: object
-                function:
-                  description: FunctionConfig defines function worker configurations
-                  properties:
-                    custom:
-                      additionalProperties:
-                        type: string
-                      description: Custom allows to custom functions worker's configuration
-                        and will be written to the ConfigMap for `changeConfig`
-                      type: object
-                    enabled:
-                      description: Enabled defines whether to enable function in the
-                        cluster
-                      type: boolean
-                    labels:
-                      additionalProperties:
-                        type: string
-                      description: Labels defines custom labels for function pods
-                      type: object
-                    mesh:
-                      description: Mesh defines configurations used in function mesh
-                      properties:
-                        builtinConnectorsRef:
-                          description: BuiltinConnectorsRef defines the reference
-                            to the ConfigMap that contains a list of builtin-connector
-                            definitions
+                      supplementalGroups:
+                        description: A list of groups applied to the first process run
+                          in each container, in addition to the container's primary
+                          GID.  If unspecified, no groups will be added to any container.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used
+                          for the pod. Pods with unsupported sysctls (by the container
+                          runtime) might fail to launch.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
                           properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                            - name
+                            - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        description: The Windows specific settings applied to all containers.
+                          If unspecified, the options within a container's SecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the GMSA
+                              credential spec to use.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in PodSecurityContext.
+                              If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccountName:
+                    description: ServiceAccountName is the name of the ServiceAccount
+                      to use to run this pod.
+                    type: string
+                  sidecars:
+                    description: Sidecars defines sidecar containers running alongside
+                      with the main function container in the pod.
+                    items:
+                      description: A single application container that you want to run
+                        within a pod. The Container API from the core group is not used
+                        directly to avoid unneeded fields and reduce the size of the
+                        CRD. New fields could be added as needed.
+                      properties:
+                        args:
+                          description: Arguments to the entrypoint.
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: Entrypoint array. Not executed within a shell.
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the container.
+                          items:
+                            description: EnvVar represents an environment variable present
+                              in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are expanded
+                                  using the previous defined environment variables in
+                                  the container and any service environment variables.
+                                  If a variable cannot be resolved, the reference in
+                                  the input string will be unchanged. The $(VAR_NAME)
+                                  syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                  Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's value.
+                                  Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                      - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for volumes,
+                                          optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                      - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the pod's
+                                      namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its
+                                          key must be defined
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                type: object
+                            required:
+                              - name
+                            type: object
+                          type: array
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container.
+                          items:
+                            description: EnvFromSource represents the source of a set
+                              of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to each
+                                  key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: Docker image name.
+                          type: string
+                        imagePullPolicy:
+                          description: Image pull policy.
+                          type: string
+                        livenessProbe:
+                          description: Periodic probe of container liveness.
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's IP
+                                  address. This must be a valid port number, 0 < x <
+                                  65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host. If
+                                  specified, this must be a valid port number, 0 < x
+                                  < 65536. If HostNetwork is specified, this must match
+                                  ContainerPort. Most containers do not need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a pod
+                                  must have a unique name. Name for the port that can
+                                  be referred to by services.
+                                type: string
+                              protocol:
+                                description: Protocol for port. Must be UDP, TCP, or
+                                  SCTP. Defaults to "TCP".
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - containerPort
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: Compute Resources required by this container.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute
+                                resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of
+                                compute resources required. If Requests is omitted for
+                                a container, it defaults to Limits if that is explicitly
+                                specified, otherwise to an implementation-defined value.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: StartupProbe indicates that the Pod has successfully
+                            initialized.
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write otherwise
+                                  (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the container's
+                                  volume should be mounted. Defaults to "" (volume's
+                                  root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from which
+                                  the container's volume should be mounted. Behaves
+                                  similarly to SubPath but environment variable references
+                                  $(VAR_NAME) are expanded using the container's environment.
+                                  Defaults to "" (volume's root). SubPathExpr and SubPath
+                                  are mutually exclusive.
+                                type: string
+                            required:
+                              - mountPath
+                              - name
+                            type: object
+                          type: array
+                        workingDir:
+                          description: Container's working directory.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    type: array
+                  terminationGracePeriodSeconds:
+                    description: TerminationGracePeriodSeconds is the amount of time
+                      that kubernetes will give for a pod before terminating it.
+                    format: int64
+                    type: integer
+                  tolerations:
+                    description: Tolerations specifies the tolerations of a Pod
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using the
+                        matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty
+                            means match all taint effects. When specified, allowed values
+                            are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the
+                            value. Valid operators are Exists and Equal. Defaults to
+                            Equal. Exists is equivalent to wildcard for value, so that
+                            a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time
+                            the toleration (which must be of effect NoExecute, otherwise
+                            this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do
+                            not evict). Zero and negative values will be treated as
+                            0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  vars:
+                    description: Vars specifies the environment variables of a Pod
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a variable
+                            cannot be resolved, the reference in the input string will
+                            be unchanged. The $(VAR_NAME) syntax can be escaped with
+                            a double $$, ie: $$(VAR_NAME). Escaped references will never
+                            be expanded, regardless of whether the variable exists or
+                            not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP,
+                                status.podIP, status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath is
+                                    written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the specified
+                                    API version.
+                                  type: string
+                              required:
+                                - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Specifies the output format of the exposed
+                                    resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                                - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                          type: object
+                      required:
+                        - name
+                      type: object
+                    type: array
+                  volumes:
+                    description: Volumes defines extra volumes of the pod.
+                    items:
+                      description: Volume represents a named volume in a pod that may
+                        be accessed by any container in the pod. The Volume API from
+                        the core group is not used directly to avoid unneeded fields
+                        defined in `VolumeSource` and reduce the size of the CRD. New
+                        fields in VolumeSource could be added as needed.
+                      properties:
+                        configMap:
+                          description: ConfigMap represents a configMap that should
+                            populate this volume
+                          properties:
+                            defaultMode:
+                              description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0 and
+                                511. YAML accepts both octal and decimal values, JSON
+                                requires decimal values for mode bits. Defaults to 0644.
+                                Directories within the path are not affected by this
+                                setting. This might be in conflict with other options
+                                that affect the file mode, like fsGroup, and the result
+                                can be other mode bits set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: If unspecified, each key-value pair in the
+                                Data field of the referenced ConfigMap will be projected
+                                into the volume as a file whose name is the key and
+                                content is the value. If specified, the listed keys
+                                will be projected into the specified paths, and unlisted
+                                keys will not be present. If a key is specified which
+                                is not present in the ConfigMap, the volume setup will
+                                error unless it is marked optional. Paths must be relative
+                                and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a volume.
+                                properties:
+                                  key:
+                                    description: The key to project.
+                                    type: string
+                                  mode:
+                                    description: 'Optional: mode bits used to set permissions
+                                      on this file. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON
+                                      requires decimal values for mode bits. If not
+                                      specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that
+                                      affect the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: The relative path of the file to map
+                                      the key to. May not be an absolute path. May not
+                                      contain the path element '..'. May not start with
+                                      the string '..'.
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                type: object
+                              type: array
                             name:
                               description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
-                          type: object
-                        functionEnabled:
-                          description: FunctionEnabled defines whether to enable function
-                            APIs
-                          type: boolean
-                        sinkEnabled:
-                          description: SinkEnabled defines whether to enable sink
-                            APIs
-                          type: boolean
-                        sourceEnabled:
-                          description: SourceEnabled defines whether to enable source
-                            APIs
-                          type: boolean
-                        uploadEnabled:
-                          description: UploadEnabled defines whether to enable user
-                            code upload in APIs
-                          type: boolean
-                      type: object
-                    resourceRequirements:
-                      description: ResourceRequirements describes the resource requirements
-                      properties:
-                        max:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Max describes maximum compute resource could
-                            request for each replica
-                          type: object
-                        min:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Min describes minimal compute resource should
-                            request for each replica
-                          type: object
-                      type: object
-                    type:
-                      description: Type defines the type of function worker service
-                        to run functions/sources/sinks Function-mesh worker service
-                        is used if the value of type is FunctionMesh, otherwise the
-                        builtin worker service is used
-                      type: string
-                  type: object
-                protocolHandlers:
-                  description: ProtocolHandlers defines the configuration of protocol
-                    handlers
-                  properties:
-                    aop:
-                      description: AoP configurations
-                      properties:
-                        enabled:
-                          description: Enabled defines whether to enable AoP
-                          type: boolean
-                        proxyEnabled:
-                          description: Whether to start AMQP proxy.
-                          type: boolean
-                      type: object
-                    kop:
-                      description: KoP defines KoP configurations
-                      properties:
-                        enabled:
-                          description: Enabled defines whether to enable KoP
-                          type: boolean
-                        tls:
-                          description: TLS defines TLS configurations
-                          properties:
-                            certSecretName:
-                              description: CertSecretName defines the name of the
-                                secret that contains the certificate to use the value
-                                should be name of the secret that contains a valid
-                                certificate to use in the proxy
-                              type: string
-                            enabled:
-                              description: Enabled determines whether to enable TLS
-                                in proxies TODO move other TLS related fields here
-                              type: boolean
-                            passwordSecretRef:
-                              description: PasswordSecretRef is a reference to a key
-                                in a Secret resource containing the password used
-                                to encrypt the keystore.
-                              properties:
-                                key:
-                                  description: The key of the entry in the Secret
-                                    resource's `data` field to be used. Some instances
-                                    of this field may be defaulted, in others it may
-                                    be required.
-                                  type: string
-                                name:
-                                  description: 'Name of the resource being referred
-                                    to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                  type: string
-                              required:
-                                - name
-                              type: object
-                            trustCertsEnabled:
-                              description: TrustCertsEnabled defines whether to enable
-                                trust store
+                            optional:
+                              description: Specify whether the ConfigMap or its keys
+                                must be defined
                               type: boolean
                           type: object
-                      type: object
-                  type: object
-                transactionEnabled:
-                  description: TransactionEnabled defines whether transaction support
-                    is enabled in the brokers
-                  type: boolean
-              type: object
-            configs:
-              additionalProperties:
-                type: string
-              description: 'Configs defines custom configurations for brokers Deprecated:
-                use Config instead'
-              type: object
-            dnsNames:
-              description: A list of service urls this pulsar broker advertise
-              items:
-                type: string
-              type: array
-            image:
-              description: Image is the container image used to run pulsar broker
-                pods. default is apachepulsar/pulsar:latest
-              type: string
-            imagePullPolicy:
-              description: Image pull policy, one of Always, Never, IfNotPresent,
-                default to Always.
-              type: string
-            initJobPod:
-              description: InitJobPod defines the policy for creating a pod for init
-                job
-              properties:
-                affinity:
-                  description: Affinity specifies the scheduling constraints of a
-                    pod
-                  properties:
-                    nodeAffinity:
-                      description: Describes node affinity scheduling rules for the
-                        pod.
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods
-                            to nodes that satisfy the affinity expressions specified
-                            by this field, but it may choose a node that violates
-                            one or more of the expressions. The node that is most
-                            preferred is the one with the greatest sum of weights,
-                            i.e. for each node that meets all of the scheduling requirements
-                            (resource request, requiredDuringScheduling affinity expressions,
-                            etc.), compute a sum by iterating through the elements
-                            of this field and adding "weight" to the sum if the node
-                            matches the corresponding matchExpressions; the node(s)
-                            with the highest sum are the most preferred.
-                          items:
-                            description: An empty preferred scheduling term matches
-                              all objects with implicit weight 0 (i.e. it's a no-op).
-                              A null preferred scheduling term matches no objects
-                              (i.e. is also a no-op).
-                            properties:
-                              preference:
-                                description: A node selector term, associated with
-                                  the corresponding weight.
-                                properties:
-                                  matchExpressions:
-                                    description: A list of node selector requirements
-                                      by node's labels.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    description: A list of node selector requirements
-                                      by node's fields.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              weight:
-                                description: Weight associated with matching the corresponding
-                                  nodeSelectorTerm, in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - preference
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this
-                            field are not met at scheduling time, the pod will not
-                            be scheduled onto the node. If the affinity requirements
-                            specified by this field cease to be met at some point
-                            during pod execution (e.g. due to an update), the system
-                            may or may not try to eventually evict the pod from its
-                            node.
+                        name:
+                          description: 'Volume''s name. Must be a DNS_LABEL and unique
+                            within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        secret:
+                          description: Secret represents a secret that should populate
+                            this volume.
                           properties:
-                            nodeSelectorTerms:
-                              description: Required. A list of node selector terms.
-                                The terms are ORed.
+                            defaultMode:
+                              description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0 and
+                                511. YAML accepts both octal and decimal values, JSON
+                                requires decimal values for mode bits. Defaults to 0644.
+                                Directories within the path are not affected by this
+                                setting. This might be in conflict with other options
+                                that affect the file mode, like fsGroup, and the result
+                                can be other mode bits set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: If unspecified, each key-value pair in the
+                                Data field of the referenced Secret will be projected
+                                into the volume as a file whose name is the key and
+                                content is the value. If specified, the listed keys
+                                will be projected into the specified paths, and unlisted
+                                keys will not be present. If a key is specified which
+                                is not present in the Secret, the volume setup will
+                                error unless it is marked optional. Paths must be relative
+                                and may not contain the '..' path or start with '..'.
                               items:
-                                description: A null or empty node selector term matches
-                                  no objects. The requirements of them are ANDed.
-                                  The TopologySelectorTerm type implements a subset
-                                  of the NodeSelectorTerm.
+                                description: Maps a string key to a path within a volume.
                                 properties:
-                                  matchExpressions:
-                                    description: A list of node selector requirements
-                                      by node's labels.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    description: A list of node selector requirements
-                                      by node's fields.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
+                                  key:
+                                    description: The key to project.
+                                    type: string
+                                  mode:
+                                    description: 'Optional: mode bits used to set permissions
+                                      on this file. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON
+                                      requires decimal values for mode bits. If not
+                                      specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that
+                                      affect the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: The relative path of the file to map
+                                      the key to. May not be an absolute path. May not
+                                      contain the path element '..'. May not start with
+                                      the string '..'.
+                                    type: string
+                                required:
+                                  - key
+                                  - path
                                 type: object
                               type: array
-                          required:
-                            - nodeSelectorTerms
-                          type: object
-                      type: object
-                    podAffinity:
-                      description: Describes pod affinity scheduling rules (e.g. co-locate
-                        this pod in the same node, zone, etc. as some other pod(s)).
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods
-                            to nodes that satisfy the affinity expressions specified
-                            by this field, but it may choose a node that violates
-                            one or more of the expressions. The node that is most
-                            preferred is the one with the greatest sum of weights,
-                            i.e. for each node that meets all of the scheduling requirements
-                            (resource request, requiredDuringScheduling affinity expressions,
-                            etc.), compute a sum by iterating through the elements
-                            of this field and adding "weight" to the sum if the node
-                            has pods which matches the corresponding podAffinityTerm;
-                            the node(s) with the highest sum are the most preferred.
-                          items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm
-                              fields are added per-node to find the most preferred
-                              node(s)
-                            properties:
-                              podAffinityTerm:
-                                description: Required. A pod affinity term, associated
-                                  with the corresponding weight.
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified
-                                      namespaces, where co-located is defined as running
-                                      on a node whose value of the label with key
-                                      topologyKey matches that of any node on which
-                                      any of the selected pods is running. Empty topologyKey
-                                      is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              weight:
-                                description: weight associated with matching the corresponding
-                                  podAffinityTerm, in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this
-                            field are not met at scheduling time, the pod will not
-                            be scheduled onto the node. If the affinity requirements
-                            specified by this field cease to be met at some point
-                            during pod execution (e.g. due to a pod label update),
-                            the system may or may not try to eventually evict the
-                            pod from its node. When there are multiple elements, the
-                            lists of nodes corresponding to each podAffinityTerm are
-                            intersected, i.e. all terms must be satisfied.
-                          items:
-                            description: Defines a set of pods (namely those matching
-                              the labelSelector relative to the given namespace(s))
-                              that this pod should be co-located (affinity) or not
-                              co-located (anti-affinity) with, where co-located is
-                              defined as running on a node whose value of the label
-                              with key <topologyKey> matches that of any node on which
-                              a pod of the set of pods is running
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                              - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                    podAntiAffinity:
-                      description: Describes pod anti-affinity scheduling rules (e.g.
-                        avoid putting this pod in the same node, zone, etc. as some
-                        other pod(s)).
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods
-                            to nodes that satisfy the anti-affinity expressions specified
-                            by this field, but it may choose a node that violates
-                            one or more of the expressions. The node that is most
-                            preferred is the one with the greatest sum of weights,
-                            i.e. for each node that meets all of the scheduling requirements
-                            (resource request, requiredDuringScheduling anti-affinity
-                            expressions, etc.), compute a sum by iterating through
-                            the elements of this field and adding "weight" to the
-                            sum if the node has pods which matches the corresponding
-                            podAffinityTerm; the node(s) with the highest sum are
-                            the most preferred.
-                          items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm
-                              fields are added per-node to find the most preferred
-                              node(s)
-                            properties:
-                              podAffinityTerm:
-                                description: Required. A pod affinity term, associated
-                                  with the corresponding weight.
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified
-                                      namespaces, where co-located is defined as running
-                                      on a node whose value of the label with key
-                                      topologyKey matches that of any node on which
-                                      any of the selected pods is running. Empty topologyKey
-                                      is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              weight:
-                                description: weight associated with matching the corresponding
-                                  podAffinityTerm, in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the anti-affinity requirements specified
-                            by this field are not met at scheduling time, the pod
-                            will not be scheduled onto the node. If the anti-affinity
-                            requirements specified by this field cease to be met at
-                            some point during pod execution (e.g. due to a pod label
-                            update), the system may or may not try to eventually evict
-                            the pod from its node. When there are multiple elements,
-                            the lists of nodes corresponding to each podAffinityTerm
-                            are intersected, i.e. all terms must be satisfied.
-                          items:
-                            description: Defines a set of pods (namely those matching
-                              the labelSelector relative to the given namespace(s))
-                              that this pod should be co-located (affinity) or not
-                              co-located (anti-affinity) with, where co-located is
-                              defined as running on a node whose value of the label
-                              with key <topologyKey> matches that of any node on which
-                              a pod of the set of pods is running
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                              - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                  type: object
-                annotations:
-                  additionalProperties:
-                    type: string
-                  description: Annotations specifies the annotations to attach to
-                    pods the operator creates
-                  type: object
-                debug:
-                  description: Debug defines a switch enable debug
-                  type: boolean
-                initContainers:
-                  description: InitContainers defines init containers of the pod.
-                    A typical use case could be using an init container to download
-                    a remote jar to a local path.
-                  items:
-                    description: A single application container that you want to run
-                      within a pod. The Container API from the core group is not used
-                      directly to avoid unneeded fields and reduce the size of the
-                      CRD. New fields could be added as needed.
-                    properties:
-                      args:
-                        description: Arguments to the entrypoint.
-                        items:
-                          type: string
-                        type: array
-                      command:
-                        description: Entrypoint array. Not executed within a shell.
-                        items:
-                          type: string
-                        type: array
-                      env:
-                        description: List of environment variables to set in the container.
-                        items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
-                          properties:
-                            name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
-                              type: string
-                            value:
-                              description: 'Variable references $(VAR_NAME) are expanded
-                                using the previous defined environment variables in
-                                the container and any service environment variables.
-                                If a variable cannot be resolved, the reference in
-                                the input string will be unchanged. The $(VAR_NAME)
-                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
-                                Escaped references will never be expanded, regardless
-                                of whether the variable exists or not. Defaults to
-                                "".'
-                              type: string
-                            valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
-                              properties:
-                                configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
-                                  properties:
-                                    key:
-                                      description: The key to select.
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
-                                fieldRef:
-                                  description: 'Selects a field of the pod: supports
-                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                    spec.serviceAccountName, status.hostIP, status.podIP,
-                                    status.podIPs.'
-                                  properties:
-                                    apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
-                                      type: string
-                                    fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
-                                      type: string
-                                  required:
-                                    - fieldPath
-                                  type: object
-                                resourceFieldRef:
-                                  description: 'Selects a resource of the container:
-                                    only resources limits and requests (limits.cpu,
-                                    limits.memory, limits.ephemeral-storage, requests.cpu,
-                                    requests.memory and requests.ephemeral-storage)
-                                    are currently supported.'
-                                  properties:
-                                    containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
-                                      type: string
-                                    divisor:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    resource:
-                                      description: 'Required: resource to select'
-                                      type: string
-                                  required:
-                                    - resource
-                                  type: object
-                                secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
-                                  properties:
-                                    key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
-                              type: object
-                          required:
-                            - name
-                          type: object
-                        type: array
-                      envFrom:
-                        description: List of sources to populate environment variables
-                          in the container.
-                        items:
-                          description: EnvFromSource represents the source of a set
-                            of ConfigMaps
-                          properties:
-                            configMapRef:
-                              description: The ConfigMap to select from
-                              properties:
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap must
-                                    be defined
-                                  type: boolean
-                              type: object
-                            prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
-                              type: string
-                            secretRef:
-                              description: The Secret to select from
-                              properties:
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret must be
-                                    defined
-                                  type: boolean
-                              type: object
-                          type: object
-                        type: array
-                      image:
-                        description: Docker image name.
-                        type: string
-                      imagePullPolicy:
-                        description: Image pull policy.
-                        type: string
-                      livenessProbe:
-                        description: Periodic probe of container liveness.
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      name:
-                        description: Name of the container specified as a DNS_LABEL.
-                          Each container in a pod must have a unique name (DNS_LABEL).
-                        type: string
-                      ports:
-                        description: List of ports to expose from the container.
-                        items:
-                          description: ContainerPort represents a network port in
-                            a single container.
-                          properties:
-                            containerPort:
-                              description: Number of port to expose on the pod's IP
-                                address. This must be a valid port number, 0 < x <
-                                65536.
-                              format: int32
-                              type: integer
-                            hostIP:
-                              description: What host IP to bind the external port
-                                to.
-                              type: string
-                            hostPort:
-                              description: Number of port to expose on the host. If
-                                specified, this must be a valid port number, 0 < x
-                                < 65536. If HostNetwork is specified, this must match
-                                ContainerPort. Most containers do not need this.
-                              format: int32
-                              type: integer
-                            name:
-                              description: If specified, this must be an IANA_SVC_NAME
-                                and unique within the pod. Each named port in a pod
-                                must have a unique name. Name for the port that can
-                                be referred to by services.
-                              type: string
-                            protocol:
-                              description: Protocol for port. Must be UDP, TCP, or
-                                SCTP. Defaults to "TCP".
-                              type: string
-                          required:
-                            - containerPort
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                          - containerPort
-                        x-kubernetes-list-type: map
-                      readinessProbe:
-                        description: 'Periodic probe of container service readiness.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      resources:
-                        description: Compute Resources required by this container.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                        type: object
-                      startupProbe:
-                        description: StartupProbe indicates that the Pod has successfully
-                          initialized.
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      volumeMounts:
-                        description: Pod volumes to mount into the container's filesystem.
-                        items:
-                          description: VolumeMount describes a mounting of a Volume
-                            within a container.
-                          properties:
-                            mountPath:
-                              description: Path within the container at which the
-                                volume should be mounted.  Must not contain ':'.
-                              type: string
-                            mountPropagation:
-                              description: mountPropagation determines how mounts
-                                are propagated from the host to container and the
-                                other way around. When not set, MountPropagationNone
-                                is used. This field is beta in 1.10.
-                              type: string
-                            name:
-                              description: This must match the Name of a Volume.
-                              type: string
-                            readOnly:
-                              description: Mounted read-only if true, read-write otherwise
-                                (false or unspecified). Defaults to false.
+                            optional:
+                              description: Specify whether the Secret or its keys must
+                                be defined
                               type: boolean
-                            subPath:
-                              description: Path within the volume from which the container's
-                                volume should be mounted. Defaults to "" (volume's
-                                root).
+                            secretName:
+                              description: 'Name of the secret in the pod''s namespace
+                                to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               type: string
-                            subPathExpr:
-                              description: Expanded path within the volume from which
-                                the container's volume should be mounted. Behaves
-                                similarly to SubPath but environment variable references
-                                $(VAR_NAME) are expanded using the container's environment.
-                                Defaults to "" (volume's root). SubPathExpr and SubPath
-                                are mutually exclusive.
-                              type: string
-                          required:
-                            - mountPath
-                            - name
                           type: object
-                        type: array
-                      workingDir:
-                        description: Container's working directory.
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-                jvmOptions:
-                  description: JvmOptions defines the Jvm options passed to the proxy
-                  properties:
-                    extraOptions:
-                      items:
-                        type: string
-                      type: array
-                    gcLoggingOptions:
-                      items:
-                        type: string
-                      type: array
-                    gcOptions:
-                      items:
-                        type: string
-                      type: array
-                    memoryOptions:
-                      items:
-                        type: string
-                      type: array
-                  required:
-                    - extraOptions
-                    - gcLoggingOptions
-                    - gcOptions
-                    - memoryOptions
-                  type: object
-                labels:
-                  additionalProperties:
-                    type: string
-                  description: Labels specifies the labels to attach to pod the operator
-                    creates for the cluster.
-                  type: object
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  description: NodeSelector specifies a map of key-value pairs. For
-                    a pod to be eligible to run on a node, the node must have each
-                    of the indicated key-value pairs as labels.
-                  type: object
-                resources:
-                  description: Resources specifies the resource requirements of a
-                    pod to run in the cluster
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                secretRefs:
-                  description: SecretRefs defines how to mount required secrets into
-                    containers
-                  items:
-                    properties:
-                      mountPath:
-                        type: string
-                      secretName:
-                        type: string
-                    required:
-                      - mountPath
-                      - secretName
-                    type: object
-                  type: array
-                securityContext:
-                  description: 'SecurityContext specifies the security context for
-                    the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
-                  properties:
-                    fsGroup:
-                      description: "A special supplemental group that applies to all
-                        containers in a pod. Some volume types allow the Kubelet to
-                        change the ownership of that volume to be owned by the pod:
-                        \n 1. The owning GID will be the FSGroup 2. The setgid bit
-                        is set (new files created in the volume will be owned by FSGroup)
-                        3. The permission bits are OR'd with rw-rw---- \n If unset,
-                        the Kubelet will not modify the ownership and permissions
-                        of any volume."
-                      format: int64
-                      type: integer
-                    fsGroupChangePolicy:
-                      description: 'fsGroupChangePolicy defines behavior of changing
-                        ownership and permission of the volume before being exposed
-                        inside Pod. This field will only apply to volume types which
-                        support fsGroup based ownership(and permissions). It will
-                        have no effect on ephemeral volume types such as: secret,
-                        configmaps and emptydir. Valid values are "OnRootMismatch"
-                        and "Always". If not specified defaults to "Always".'
-                      type: string
-                    runAsGroup:
-                      description: The GID to run the entrypoint of the container
-                        process. Uses runtime default if unset. May also be set in
-                        SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence for
-                        that container.
-                      format: int64
-                      type: integer
-                    runAsNonRoot:
-                      description: Indicates that the container must run as a non-root
-                        user. If true, the Kubelet will validate the image at runtime
-                        to ensure that it does not run as UID 0 (root) and fail to
-                        start the container if it does. If unset or false, no such
-                        validation will be performed. May also be set in SecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence.
-                      type: boolean
-                    runAsUser:
-                      description: The UID to run the entrypoint of the container
-                        process. Defaults to user specified in image metadata if unspecified.
-                        May also be set in SecurityContext.  If set in both SecurityContext
-                        and PodSecurityContext, the value specified in SecurityContext
-                        takes precedence for that container.
-                      format: int64
-                      type: integer
-                    seLinuxOptions:
-                      description: The SELinux context to be applied to all containers.
-                        If unspecified, the container runtime will allocate a random
-                        SELinux context for each container.  May also be set in SecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence for that container.
-                      properties:
-                        level:
-                          description: Level is SELinux level label that applies to
-                            the container.
-                          type: string
-                        role:
-                          description: Role is a SELinux role label that applies to
-                            the container.
-                          type: string
-                        type:
-                          description: Type is a SELinux type label that applies to
-                            the container.
-                          type: string
-                        user:
-                          description: User is a SELinux user label that applies to
-                            the container.
-                          type: string
-                      type: object
-                    seccompProfile:
-                      description: The seccomp options to use by the containers in
-                        this pod.
-                      properties:
-                        localhostProfile:
-                          description: localhostProfile indicates a profile defined
-                            in a file on the node should be used. The profile must
-                            be preconfigured on the node to work. Must be a descending
-                            path, relative to the kubelet's configured seccomp profile
-                            location. Must only be set if type is "Localhost".
-                          type: string
-                        type:
-                          description: "type indicates which kind of seccomp profile
-                            will be applied. Valid options are: \n Localhost - a profile
-                            defined in a file on the node should be used. RuntimeDefault
-                            - the container runtime default profile should be used.
-                            Unconfined - no profile should be applied."
-                          type: string
                       required:
-                        - type
-                      type: object
-                    supplementalGroups:
-                      description: A list of groups applied to the first process run
-                        in each container, in addition to the container's primary
-                        GID.  If unspecified, no groups will be added to any container.
-                      items:
-                        format: int64
-                        type: integer
-                      type: array
-                    sysctls:
-                      description: Sysctls hold a list of namespaced sysctls used
-                        for the pod. Pods with unsupported sysctls (by the container
-                        runtime) might fail to launch.
-                      items:
-                        description: Sysctl defines a kernel parameter to be set
-                        properties:
-                          name:
-                            description: Name of a property to set
-                            type: string
-                          value:
-                            description: Value of a property to set
-                            type: string
-                        required:
-                          - name
-                          - value
-                        type: object
-                      type: array
-                    windowsOptions:
-                      description: The Windows specific settings applied to all containers.
-                        If unspecified, the options within a container's SecurityContext
-                        will be used. If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence.
-                      properties:
-                        gmsaCredentialSpec:
-                          description: GMSACredentialSpec is where the GMSA admission
-                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                            inlines the contents of the GMSA credential spec named
-                            by the GMSACredentialSpecName field.
-                          type: string
-                        gmsaCredentialSpecName:
-                          description: GMSACredentialSpecName is the name of the GMSA
-                            credential spec to use.
-                          type: string
-                        runAsUserName:
-                          description: The UserName in Windows to run the entrypoint
-                            of the container process. Defaults to the user specified
-                            in image metadata if unspecified. May also be set in PodSecurityContext.
-                            If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
-                          type: string
-                      type: object
-                  type: object
-                serviceAccountName:
-                  description: ServiceAccountName is the name of the ServiceAccount
-                    to use to run this pod.
-                  type: string
-                sidecars:
-                  description: Sidecars defines sidecar containers running alongside
-                    with the main function container in the pod.
-                  items:
-                    description: A single application container that you want to run
-                      within a pod. The Container API from the core group is not used
-                      directly to avoid unneeded fields and reduce the size of the
-                      CRD. New fields could be added as needed.
-                    properties:
-                      args:
-                        description: Arguments to the entrypoint.
-                        items:
-                          type: string
-                        type: array
-                      command:
-                        description: Entrypoint array. Not executed within a shell.
-                        items:
-                          type: string
-                        type: array
-                      env:
-                        description: List of environment variables to set in the container.
-                        items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
-                          properties:
-                            name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
-                              type: string
-                            value:
-                              description: 'Variable references $(VAR_NAME) are expanded
-                                using the previous defined environment variables in
-                                the container and any service environment variables.
-                                If a variable cannot be resolved, the reference in
-                                the input string will be unchanged. The $(VAR_NAME)
-                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
-                                Escaped references will never be expanded, regardless
-                                of whether the variable exists or not. Defaults to
-                                "".'
-                              type: string
-                            valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
-                              properties:
-                                configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
-                                  properties:
-                                    key:
-                                      description: The key to select.
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
-                                fieldRef:
-                                  description: 'Selects a field of the pod: supports
-                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                    spec.serviceAccountName, status.hostIP, status.podIP,
-                                    status.podIPs.'
-                                  properties:
-                                    apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
-                                      type: string
-                                    fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
-                                      type: string
-                                  required:
-                                    - fieldPath
-                                  type: object
-                                resourceFieldRef:
-                                  description: 'Selects a resource of the container:
-                                    only resources limits and requests (limits.cpu,
-                                    limits.memory, limits.ephemeral-storage, requests.cpu,
-                                    requests.memory and requests.ephemeral-storage)
-                                    are currently supported.'
-                                  properties:
-                                    containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
-                                      type: string
-                                    divisor:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    resource:
-                                      description: 'Required: resource to select'
-                                      type: string
-                                  required:
-                                    - resource
-                                  type: object
-                                secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
-                                  properties:
-                                    key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
-                              type: object
-                          required:
-                            - name
-                          type: object
-                        type: array
-                      envFrom:
-                        description: List of sources to populate environment variables
-                          in the container.
-                        items:
-                          description: EnvFromSource represents the source of a set
-                            of ConfigMaps
-                          properties:
-                            configMapRef:
-                              description: The ConfigMap to select from
-                              properties:
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap must
-                                    be defined
-                                  type: boolean
-                              type: object
-                            prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
-                              type: string
-                            secretRef:
-                              description: The Secret to select from
-                              properties:
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret must be
-                                    defined
-                                  type: boolean
-                              type: object
-                          type: object
-                        type: array
-                      image:
-                        description: Docker image name.
-                        type: string
-                      imagePullPolicy:
-                        description: Image pull policy.
-                        type: string
-                      livenessProbe:
-                        description: Periodic probe of container liveness.
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      name:
-                        description: Name of the container specified as a DNS_LABEL.
-                          Each container in a pod must have a unique name (DNS_LABEL).
-                        type: string
-                      ports:
-                        description: List of ports to expose from the container.
-                        items:
-                          description: ContainerPort represents a network port in
-                            a single container.
-                          properties:
-                            containerPort:
-                              description: Number of port to expose on the pod's IP
-                                address. This must be a valid port number, 0 < x <
-                                65536.
-                              format: int32
-                              type: integer
-                            hostIP:
-                              description: What host IP to bind the external port
-                                to.
-                              type: string
-                            hostPort:
-                              description: Number of port to expose on the host. If
-                                specified, this must be a valid port number, 0 < x
-                                < 65536. If HostNetwork is specified, this must match
-                                ContainerPort. Most containers do not need this.
-                              format: int32
-                              type: integer
-                            name:
-                              description: If specified, this must be an IANA_SVC_NAME
-                                and unique within the pod. Each named port in a pod
-                                must have a unique name. Name for the port that can
-                                be referred to by services.
-                              type: string
-                            protocol:
-                              description: Protocol for port. Must be UDP, TCP, or
-                                SCTP. Defaults to "TCP".
-                              type: string
-                          required:
-                            - containerPort
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                          - containerPort
-                        x-kubernetes-list-type: map
-                      readinessProbe:
-                        description: 'Periodic probe of container service readiness.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      resources:
-                        description: Compute Resources required by this container.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                        type: object
-                      startupProbe:
-                        description: StartupProbe indicates that the Pod has successfully
-                          initialized.
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      volumeMounts:
-                        description: Pod volumes to mount into the container's filesystem.
-                        items:
-                          description: VolumeMount describes a mounting of a Volume
-                            within a container.
-                          properties:
-                            mountPath:
-                              description: Path within the container at which the
-                                volume should be mounted.  Must not contain ':'.
-                              type: string
-                            mountPropagation:
-                              description: mountPropagation determines how mounts
-                                are propagated from the host to container and the
-                                other way around. When not set, MountPropagationNone
-                                is used. This field is beta in 1.10.
-                              type: string
-                            name:
-                              description: This must match the Name of a Volume.
-                              type: string
-                            readOnly:
-                              description: Mounted read-only if true, read-write otherwise
-                                (false or unspecified). Defaults to false.
-                              type: boolean
-                            subPath:
-                              description: Path within the volume from which the container's
-                                volume should be mounted. Defaults to "" (volume's
-                                root).
-                              type: string
-                            subPathExpr:
-                              description: Expanded path within the volume from which
-                                the container's volume should be mounted. Behaves
-                                similarly to SubPath but environment variable references
-                                $(VAR_NAME) are expanded using the container's environment.
-                                Defaults to "" (volume's root). SubPathExpr and SubPath
-                                are mutually exclusive.
-                              type: string
-                          required:
-                            - mountPath
-                            - name
-                          type: object
-                        type: array
-                      workingDir:
-                        description: Container's working directory.
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-                terminationGracePeriodSeconds:
-                  description: TerminationGracePeriodSeconds is the amount of time
-                    that kubernetes will give for a pod before terminating it.
-                  format: int64
-                  type: integer
-                tolerations:
-                  description: Tolerations specifies the tolerations of a Pod
-                  items:
-                    description: The pod this Toleration is attached to tolerates
-                      any taint that matches the triple <key,value,effect> using the
-                      matching operator <operator>.
-                    properties:
-                      effect:
-                        description: Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match
-                          all values and all keys.
-                        type: string
-                      operator:
-                        description: Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to
-                          Equal. Exists is equivalent to wildcard for value, so that
-                          a pod can tolerate all taints of a particular category.
-                        type: string
-                      tolerationSeconds:
-                        description: TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default,
-                          it is not set, which means tolerate the taint forever (do
-                          not evict). Zero and negative values will be treated as
-                          0 (evict immediately) by the system.
-                        format: int64
-                        type: integer
-                      value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
-                        type: string
-                    type: object
-                  type: array
-                vars:
-                  description: Vars specifies the environment variables of a Pod
-                  items:
-                    description: EnvVar represents an environment variable present
-                      in a Container.
-                    properties:
-                      name:
-                        description: Name of the environment variable. Must be a C_IDENTIFIER.
-                        type: string
-                      value:
-                        description: 'Variable references $(VAR_NAME) are expanded
-                          using the previous defined environment variables in the
-                          container and any service environment variables. If a variable
-                          cannot be resolved, the reference in the input string will
-                          be unchanged. The $(VAR_NAME) syntax can be escaped with
-                          a double $$, ie: $$(VAR_NAME). Escaped references will never
-                          be expanded, regardless of whether the variable exists or
-                          not. Defaults to "".'
-                        type: string
-                      valueFrom:
-                        description: Source for the environment variable's value.
-                          Cannot be used if value is not empty.
-                        properties:
-                          configMapKeyRef:
-                            description: Selects a key of a ConfigMap.
-                            properties:
-                              key:
-                                description: The key to select.
-                                type: string
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
-                                type: string
-                              optional:
-                                description: Specify whether the ConfigMap or its
-                                  key must be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                          fieldRef:
-                            description: 'Selects a field of the pod: supports metadata.name,
-                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                              spec.nodeName, spec.serviceAccountName, status.hostIP,
-                              status.podIP, status.podIPs.'
-                            properties:
-                              apiVersion:
-                                description: Version of the schema the FieldPath is
-                                  written in terms of, defaults to "v1".
-                                type: string
-                              fieldPath:
-                                description: Path of the field to select in the specified
-                                  API version.
-                                type: string
-                            required:
-                              - fieldPath
-                            type: object
-                          resourceFieldRef:
-                            description: 'Selects a resource of the container: only
-                              resources limits and requests (limits.cpu, limits.memory,
-                              limits.ephemeral-storage, requests.cpu, requests.memory
-                              and requests.ephemeral-storage) are currently supported.'
-                            properties:
-                              containerName:
-                                description: 'Container name: required for volumes,
-                                  optional for env vars'
-                                type: string
-                              divisor:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Specifies the output format of the exposed
-                                  resources, defaults to "1"
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              resource:
-                                description: 'Required: resource to select'
-                                type: string
-                            required:
-                              - resource
-                            type: object
-                          secretKeyRef:
-                            description: Selects a key of a secret in the pod's namespace
-                            properties:
-                              key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
-                                type: string
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
-                                type: string
-                              optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                        type: object
-                    required:
-                      - name
-                    type: object
-                  type: array
-                volumes:
-                  description: Volumes defines extra volumes of the pod.
-                  items:
-                    description: Volume represents a named volume in a pod that may
-                      be accessed by any container in the pod. The Volume API from
-                      the core group is not used directly to avoid unneeded fields
-                      defined in `VolumeSource` and reduce the size of the CRD. New
-                      fields in VolumeSource could be added as needed.
-                    properties:
-                      configMap:
-                        description: ConfigMap represents a configMap that should
-                          populate this volume
-                        properties:
-                          defaultMode:
-                            description: 'Optional: mode bits used to set permissions
-                              on created files by default. Must be an octal value
-                              between 0000 and 0777 or a decimal value between 0 and
-                              511. YAML accepts both octal and decimal values, JSON
-                              requires decimal values for mode bits. Defaults to 0644.
-                              Directories within the path are not affected by this
-                              setting. This might be in conflict with other options
-                              that affect the file mode, like fsGroup, and the result
-                              can be other mode bits set.'
-                            format: int32
-                            type: integer
-                          items:
-                            description: If unspecified, each key-value pair in the
-                              Data field of the referenced ConfigMap will be projected
-                              into the volume as a file whose name is the key and
-                              content is the value. If specified, the listed keys
-                              will be projected into the specified paths, and unlisted
-                              keys will not be present. If a key is specified which
-                              is not present in the ConfigMap, the volume setup will
-                              error unless it is marked optional. Paths must be relative
-                              and may not contain the '..' path or start with '..'.
-                            items:
-                              description: Maps a string key to a path within a volume.
-                              properties:
-                                key:
-                                  description: The key to project.
-                                  type: string
-                                mode:
-                                  description: 'Optional: mode bits used to set permissions
-                                    on this file. Must be an octal value between 0000
-                                    and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON
-                                    requires decimal values for mode bits. If not
-                                    specified, the volume defaultMode will be used.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
-                                  format: int32
-                                  type: integer
-                                path:
-                                  description: The relative path of the file to map
-                                    the key to. May not be an absolute path. May not
-                                    contain the path element '..'. May not start with
-                                    the string '..'.
-                                  type: string
-                              required:
-                                - key
-                                - path
-                              type: object
-                            type: array
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                          optional:
-                            description: Specify whether the ConfigMap or its keys
-                              must be defined
-                            type: boolean
-                        type: object
-                      name:
-                        description: 'Volume''s name. Must be a DNS_LABEL and unique
-                          within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      secret:
-                        description: Secret represents a secret that should populate
-                          this volume.
-                        properties:
-                          defaultMode:
-                            description: 'Optional: mode bits used to set permissions
-                              on created files by default. Must be an octal value
-                              between 0000 and 0777 or a decimal value between 0 and
-                              511. YAML accepts both octal and decimal values, JSON
-                              requires decimal values for mode bits. Defaults to 0644.
-                              Directories within the path are not affected by this
-                              setting. This might be in conflict with other options
-                              that affect the file mode, like fsGroup, and the result
-                              can be other mode bits set.'
-                            format: int32
-                            type: integer
-                          items:
-                            description: If unspecified, each key-value pair in the
-                              Data field of the referenced Secret will be projected
-                              into the volume as a file whose name is the key and
-                              content is the value. If specified, the listed keys
-                              will be projected into the specified paths, and unlisted
-                              keys will not be present. If a key is specified which
-                              is not present in the Secret, the volume setup will
-                              error unless it is marked optional. Paths must be relative
-                              and may not contain the '..' path or start with '..'.
-                            items:
-                              description: Maps a string key to a path within a volume.
-                              properties:
-                                key:
-                                  description: The key to project.
-                                  type: string
-                                mode:
-                                  description: 'Optional: mode bits used to set permissions
-                                    on this file. Must be an octal value between 0000
-                                    and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON
-                                    requires decimal values for mode bits. If not
-                                    specified, the volume defaultMode will be used.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
-                                  format: int32
-                                  type: integer
-                                path:
-                                  description: The relative path of the file to map
-                                    the key to. May not be an absolute path. May not
-                                    contain the path element '..'. May not start with
-                                    the string '..'.
-                                  type: string
-                              required:
-                                - key
-                                - path
-                              type: object
-                            type: array
-                          optional:
-                            description: Specify whether the Secret or its keys must
-                              be defined
-                            type: boolean
-                          secretName:
-                            description: 'Name of the secret in the pod''s namespace
-                              to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                            type: string
-                        type: object
-                    required:
-                      - name
-                    type: object
-                  type: array
-              type: object
-            interceptors:
-              description: Interceptors defines a list of interceptors to enable
-              items:
-                properties:
-                  configs:
-                    additionalProperties:
-                      type: string
-                    description: Configs defines configs for the interceptor
-                    type: object
-                  mountedConfigs:
-                    description: MountedConfigs defines configs whose value should
-                      be put in a dedicated file
-                    items:
-                      description: The operator generates config files based on the
-                        spec automatically
-                      properties:
-                        configName:
-                          description: ConfigName defines the name of the config
-                          type: string
-                        fileName:
-                          description: FileName defines the name of the file used
-                            to store the value. Defaults to the ConfigName.
-                          type: string
-                        value:
-                          description: Value defines the value of the config
-                          type: string
-                      required:
-                        - configName
-                        - value
+                        - name
                       type: object
                     type: array
-                  name:
-                    description: Name defines the name of the interceptor
-                    type: string
-                required:
-                  - name
                 type: object
-              type: array
-            istio:
-              description: Istio defines the configurations for istio
-              properties:
-                enabled:
-                  description: Enabled defines whether to enable KoP
-                  type: boolean
-                gateway:
-                  description: Gateway defines the gateway configuration The operator
-                    could either create a gateway automatically or use an existing
-                    one
+              interceptors:
+                description: Interceptors defines a list of interceptors to enable
+                items:
                   properties:
-                    create:
-                      description: Create defines whether to create a gateway
-                      type: boolean
-                    gateways:
-                      description: Gateways defines a list of existing gateways
-                      items:
-                        type: string
-                      type: array
-                    selector:
+                    configs:
                       additionalProperties:
                         type: string
-                      description: Selector defines the selector for the gateway to
-                        create
+                      description: Configs defines configs for the interceptor
                       type: object
-                  type: object
-              type: object
-            labels:
-              additionalProperties:
-                type: string
-              description: Labels specifies the labels to attach to the stateful set
-                created by operator for pulsar broker
-              type: object
-            pod:
-              description: Pod defines the policy for creating a broker pod
-              properties:
-                affinity:
-                  description: Affinity specifies the scheduling constraints of a
-                    pod
-                  properties:
-                    nodeAffinity:
-                      description: Describes node affinity scheduling rules for the
-                        pod.
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods
-                            to nodes that satisfy the affinity expressions specified
-                            by this field, but it may choose a node that violates
-                            one or more of the expressions. The node that is most
-                            preferred is the one with the greatest sum of weights,
-                            i.e. for each node that meets all of the scheduling requirements
-                            (resource request, requiredDuringScheduling affinity expressions,
-                            etc.), compute a sum by iterating through the elements
-                            of this field and adding "weight" to the sum if the node
-                            matches the corresponding matchExpressions; the node(s)
-                            with the highest sum are the most preferred.
-                          items:
-                            description: An empty preferred scheduling term matches
-                              all objects with implicit weight 0 (i.e. it's a no-op).
-                              A null preferred scheduling term matches no objects
-                              (i.e. is also a no-op).
-                            properties:
-                              preference:
-                                description: A node selector term, associated with
-                                  the corresponding weight.
-                                properties:
-                                  matchExpressions:
-                                    description: A list of node selector requirements
-                                      by node's labels.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    description: A list of node selector requirements
-                                      by node's fields.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              weight:
-                                description: Weight associated with matching the corresponding
-                                  nodeSelectorTerm, in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - preference
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this
-                            field are not met at scheduling time, the pod will not
-                            be scheduled onto the node. If the affinity requirements
-                            specified by this field cease to be met at some point
-                            during pod execution (e.g. due to an update), the system
-                            may or may not try to eventually evict the pod from its
-                            node.
-                          properties:
-                            nodeSelectorTerms:
-                              description: Required. A list of node selector terms.
-                                The terms are ORed.
-                              items:
-                                description: A null or empty node selector term matches
-                                  no objects. The requirements of them are ANDed.
-                                  The TopologySelectorTerm type implements a subset
-                                  of the NodeSelectorTerm.
-                                properties:
-                                  matchExpressions:
-                                    description: A list of node selector requirements
-                                      by node's labels.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    description: A list of node selector requirements
-                                      by node's fields.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              type: array
-                          required:
-                            - nodeSelectorTerms
-                          type: object
-                      type: object
-                    podAffinity:
-                      description: Describes pod affinity scheduling rules (e.g. co-locate
-                        this pod in the same node, zone, etc. as some other pod(s)).
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods
-                            to nodes that satisfy the affinity expressions specified
-                            by this field, but it may choose a node that violates
-                            one or more of the expressions. The node that is most
-                            preferred is the one with the greatest sum of weights,
-                            i.e. for each node that meets all of the scheduling requirements
-                            (resource request, requiredDuringScheduling affinity expressions,
-                            etc.), compute a sum by iterating through the elements
-                            of this field and adding "weight" to the sum if the node
-                            has pods which matches the corresponding podAffinityTerm;
-                            the node(s) with the highest sum are the most preferred.
-                          items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm
-                              fields are added per-node to find the most preferred
-                              node(s)
-                            properties:
-                              podAffinityTerm:
-                                description: Required. A pod affinity term, associated
-                                  with the corresponding weight.
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified
-                                      namespaces, where co-located is defined as running
-                                      on a node whose value of the label with key
-                                      topologyKey matches that of any node on which
-                                      any of the selected pods is running. Empty topologyKey
-                                      is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              weight:
-                                description: weight associated with matching the corresponding
-                                  podAffinityTerm, in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this
-                            field are not met at scheduling time, the pod will not
-                            be scheduled onto the node. If the affinity requirements
-                            specified by this field cease to be met at some point
-                            during pod execution (e.g. due to a pod label update),
-                            the system may or may not try to eventually evict the
-                            pod from its node. When there are multiple elements, the
-                            lists of nodes corresponding to each podAffinityTerm are
-                            intersected, i.e. all terms must be satisfied.
-                          items:
-                            description: Defines a set of pods (namely those matching
-                              the labelSelector relative to the given namespace(s))
-                              that this pod should be co-located (affinity) or not
-                              co-located (anti-affinity) with, where co-located is
-                              defined as running on a node whose value of the label
-                              with key <topologyKey> matches that of any node on which
-                              a pod of the set of pods is running
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                              - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                    podAntiAffinity:
-                      description: Describes pod anti-affinity scheduling rules (e.g.
-                        avoid putting this pod in the same node, zone, etc. as some
-                        other pod(s)).
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods
-                            to nodes that satisfy the anti-affinity expressions specified
-                            by this field, but it may choose a node that violates
-                            one or more of the expressions. The node that is most
-                            preferred is the one with the greatest sum of weights,
-                            i.e. for each node that meets all of the scheduling requirements
-                            (resource request, requiredDuringScheduling anti-affinity
-                            expressions, etc.), compute a sum by iterating through
-                            the elements of this field and adding "weight" to the
-                            sum if the node has pods which matches the corresponding
-                            podAffinityTerm; the node(s) with the highest sum are
-                            the most preferred.
-                          items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm
-                              fields are added per-node to find the most preferred
-                              node(s)
-                            properties:
-                              podAffinityTerm:
-                                description: Required. A pod affinity term, associated
-                                  with the corresponding weight.
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified
-                                      namespaces, where co-located is defined as running
-                                      on a node whose value of the label with key
-                                      topologyKey matches that of any node on which
-                                      any of the selected pods is running. Empty topologyKey
-                                      is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              weight:
-                                description: weight associated with matching the corresponding
-                                  podAffinityTerm, in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the anti-affinity requirements specified
-                            by this field are not met at scheduling time, the pod
-                            will not be scheduled onto the node. If the anti-affinity
-                            requirements specified by this field cease to be met at
-                            some point during pod execution (e.g. due to a pod label
-                            update), the system may or may not try to eventually evict
-                            the pod from its node. When there are multiple elements,
-                            the lists of nodes corresponding to each podAffinityTerm
-                            are intersected, i.e. all terms must be satisfied.
-                          items:
-                            description: Defines a set of pods (namely those matching
-                              the labelSelector relative to the given namespace(s))
-                              that this pod should be co-located (affinity) or not
-                              co-located (anti-affinity) with, where co-located is
-                              defined as running on a node whose value of the label
-                              with key <topologyKey> matches that of any node on which
-                              a pod of the set of pods is running
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                              - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                  type: object
-                annotations:
-                  additionalProperties:
-                    type: string
-                  description: Annotations specifies the annotations to attach to
-                    pods the operator creates
-                  type: object
-                debug:
-                  description: Debug defines a switch enable debug
-                  type: boolean
-                initContainers:
-                  description: InitContainers defines init containers of the pod.
-                    A typical use case could be using an init container to download
-                    a remote jar to a local path.
-                  items:
-                    description: A single application container that you want to run
-                      within a pod. The Container API from the core group is not used
-                      directly to avoid unneeded fields and reduce the size of the
-                      CRD. New fields could be added as needed.
-                    properties:
-                      args:
-                        description: Arguments to the entrypoint.
-                        items:
-                          type: string
-                        type: array
-                      command:
-                        description: Entrypoint array. Not executed within a shell.
-                        items:
-                          type: string
-                        type: array
-                      env:
-                        description: List of environment variables to set in the container.
-                        items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
-                          properties:
-                            name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
-                              type: string
-                            value:
-                              description: 'Variable references $(VAR_NAME) are expanded
-                                using the previous defined environment variables in
-                                the container and any service environment variables.
-                                If a variable cannot be resolved, the reference in
-                                the input string will be unchanged. The $(VAR_NAME)
-                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
-                                Escaped references will never be expanded, regardless
-                                of whether the variable exists or not. Defaults to
-                                "".'
-                              type: string
-                            valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
-                              properties:
-                                configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
-                                  properties:
-                                    key:
-                                      description: The key to select.
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
-                                fieldRef:
-                                  description: 'Selects a field of the pod: supports
-                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                    spec.serviceAccountName, status.hostIP, status.podIP,
-                                    status.podIPs.'
-                                  properties:
-                                    apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
-                                      type: string
-                                    fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
-                                      type: string
-                                  required:
-                                    - fieldPath
-                                  type: object
-                                resourceFieldRef:
-                                  description: 'Selects a resource of the container:
-                                    only resources limits and requests (limits.cpu,
-                                    limits.memory, limits.ephemeral-storage, requests.cpu,
-                                    requests.memory and requests.ephemeral-storage)
-                                    are currently supported.'
-                                  properties:
-                                    containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
-                                      type: string
-                                    divisor:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    resource:
-                                      description: 'Required: resource to select'
-                                      type: string
-                                  required:
-                                    - resource
-                                  type: object
-                                secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
-                                  properties:
-                                    key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
-                              type: object
-                          required:
-                            - name
-                          type: object
-                        type: array
-                      envFrom:
-                        description: List of sources to populate environment variables
-                          in the container.
-                        items:
-                          description: EnvFromSource represents the source of a set
-                            of ConfigMaps
-                          properties:
-                            configMapRef:
-                              description: The ConfigMap to select from
-                              properties:
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap must
-                                    be defined
-                                  type: boolean
-                              type: object
-                            prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
-                              type: string
-                            secretRef:
-                              description: The Secret to select from
-                              properties:
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret must be
-                                    defined
-                                  type: boolean
-                              type: object
-                          type: object
-                        type: array
-                      image:
-                        description: Docker image name.
-                        type: string
-                      imagePullPolicy:
-                        description: Image pull policy.
-                        type: string
-                      livenessProbe:
-                        description: Periodic probe of container liveness.
+                    mountedConfigs:
+                      description: MountedConfigs defines configs whose value should
+                        be put in a dedicated file
+                      items:
+                        description: The operator generates config files based on the
+                          spec automatically
                         properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      name:
-                        description: Name of the container specified as a DNS_LABEL.
-                          Each container in a pod must have a unique name (DNS_LABEL).
-                        type: string
-                      ports:
-                        description: List of ports to expose from the container.
-                        items:
-                          description: ContainerPort represents a network port in
-                            a single container.
-                          properties:
-                            containerPort:
-                              description: Number of port to expose on the pod's IP
-                                address. This must be a valid port number, 0 < x <
-                                65536.
-                              format: int32
-                              type: integer
-                            hostIP:
-                              description: What host IP to bind the external port
-                                to.
-                              type: string
-                            hostPort:
-                              description: Number of port to expose on the host. If
-                                specified, this must be a valid port number, 0 < x
-                                < 65536. If HostNetwork is specified, this must match
-                                ContainerPort. Most containers do not need this.
-                              format: int32
-                              type: integer
-                            name:
-                              description: If specified, this must be an IANA_SVC_NAME
-                                and unique within the pod. Each named port in a pod
-                                must have a unique name. Name for the port that can
-                                be referred to by services.
-                              type: string
-                            protocol:
-                              description: Protocol for port. Must be UDP, TCP, or
-                                SCTP. Defaults to "TCP".
-                              type: string
-                          required:
-                            - containerPort
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                          - containerPort
-                        x-kubernetes-list-type: map
-                      readinessProbe:
-                        description: 'Periodic probe of container service readiness.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      resources:
-                        description: Compute Resources required by this container.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                        type: object
-                      startupProbe:
-                        description: StartupProbe indicates that the Pod has successfully
-                          initialized.
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      volumeMounts:
-                        description: Pod volumes to mount into the container's filesystem.
-                        items:
-                          description: VolumeMount describes a mounting of a Volume
-                            within a container.
-                          properties:
-                            mountPath:
-                              description: Path within the container at which the
-                                volume should be mounted.  Must not contain ':'.
-                              type: string
-                            mountPropagation:
-                              description: mountPropagation determines how mounts
-                                are propagated from the host to container and the
-                                other way around. When not set, MountPropagationNone
-                                is used. This field is beta in 1.10.
-                              type: string
-                            name:
-                              description: This must match the Name of a Volume.
-                              type: string
-                            readOnly:
-                              description: Mounted read-only if true, read-write otherwise
-                                (false or unspecified). Defaults to false.
-                              type: boolean
-                            subPath:
-                              description: Path within the volume from which the container's
-                                volume should be mounted. Defaults to "" (volume's
-                                root).
-                              type: string
-                            subPathExpr:
-                              description: Expanded path within the volume from which
-                                the container's volume should be mounted. Behaves
-                                similarly to SubPath but environment variable references
-                                $(VAR_NAME) are expanded using the container's environment.
-                                Defaults to "" (volume's root). SubPathExpr and SubPath
-                                are mutually exclusive.
-                              type: string
-                          required:
-                            - mountPath
-                            - name
-                          type: object
-                        type: array
-                      workingDir:
-                        description: Container's working directory.
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-                jvmOptions:
-                  description: JvmOptions defines the Jvm options passed to the proxy
-                  properties:
-                    extraOptions:
-                      items:
-                        type: string
-                      type: array
-                    gcLoggingOptions:
-                      items:
-                        type: string
-                      type: array
-                    gcOptions:
-                      items:
-                        type: string
-                      type: array
-                    memoryOptions:
-                      items:
-                        type: string
-                      type: array
-                  required:
-                    - extraOptions
-                    - gcLoggingOptions
-                    - gcOptions
-                    - memoryOptions
-                  type: object
-                labels:
-                  additionalProperties:
-                    type: string
-                  description: Labels specifies the labels to attach to pod the operator
-                    creates for the cluster.
-                  type: object
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  description: NodeSelector specifies a map of key-value pairs. For
-                    a pod to be eligible to run on a node, the node must have each
-                    of the indicated key-value pairs as labels.
-                  type: object
-                resources:
-                  description: Resources specifies the resource requirements of a
-                    pod to run in the cluster
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                secretRefs:
-                  description: SecretRefs defines how to mount required secrets into
-                    containers
-                  items:
-                    properties:
-                      mountPath:
-                        type: string
-                      secretName:
-                        type: string
-                    required:
-                      - mountPath
-                      - secretName
-                    type: object
-                  type: array
-                securityContext:
-                  description: 'SecurityContext specifies the security context for
-                    the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
-                  properties:
-                    fsGroup:
-                      description: "A special supplemental group that applies to all
-                        containers in a pod. Some volume types allow the Kubelet to
-                        change the ownership of that volume to be owned by the pod:
-                        \n 1. The owning GID will be the FSGroup 2. The setgid bit
-                        is set (new files created in the volume will be owned by FSGroup)
-                        3. The permission bits are OR'd with rw-rw---- \n If unset,
-                        the Kubelet will not modify the ownership and permissions
-                        of any volume."
-                      format: int64
-                      type: integer
-                    fsGroupChangePolicy:
-                      description: 'fsGroupChangePolicy defines behavior of changing
-                        ownership and permission of the volume before being exposed
-                        inside Pod. This field will only apply to volume types which
-                        support fsGroup based ownership(and permissions). It will
-                        have no effect on ephemeral volume types such as: secret,
-                        configmaps and emptydir. Valid values are "OnRootMismatch"
-                        and "Always". If not specified defaults to "Always".'
-                      type: string
-                    runAsGroup:
-                      description: The GID to run the entrypoint of the container
-                        process. Uses runtime default if unset. May also be set in
-                        SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence for
-                        that container.
-                      format: int64
-                      type: integer
-                    runAsNonRoot:
-                      description: Indicates that the container must run as a non-root
-                        user. If true, the Kubelet will validate the image at runtime
-                        to ensure that it does not run as UID 0 (root) and fail to
-                        start the container if it does. If unset or false, no such
-                        validation will be performed. May also be set in SecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence.
-                      type: boolean
-                    runAsUser:
-                      description: The UID to run the entrypoint of the container
-                        process. Defaults to user specified in image metadata if unspecified.
-                        May also be set in SecurityContext.  If set in both SecurityContext
-                        and PodSecurityContext, the value specified in SecurityContext
-                        takes precedence for that container.
-                      format: int64
-                      type: integer
-                    seLinuxOptions:
-                      description: The SELinux context to be applied to all containers.
-                        If unspecified, the container runtime will allocate a random
-                        SELinux context for each container.  May also be set in SecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence for that container.
-                      properties:
-                        level:
-                          description: Level is SELinux level label that applies to
-                            the container.
-                          type: string
-                        role:
-                          description: Role is a SELinux role label that applies to
-                            the container.
-                          type: string
-                        type:
-                          description: Type is a SELinux type label that applies to
-                            the container.
-                          type: string
-                        user:
-                          description: User is a SELinux user label that applies to
-                            the container.
-                          type: string
-                      type: object
-                    seccompProfile:
-                      description: The seccomp options to use by the containers in
-                        this pod.
-                      properties:
-                        localhostProfile:
-                          description: localhostProfile indicates a profile defined
-                            in a file on the node should be used. The profile must
-                            be preconfigured on the node to work. Must be a descending
-                            path, relative to the kubelet's configured seccomp profile
-                            location. Must only be set if type is "Localhost".
-                          type: string
-                        type:
-                          description: "type indicates which kind of seccomp profile
-                            will be applied. Valid options are: \n Localhost - a profile
-                            defined in a file on the node should be used. RuntimeDefault
-                            - the container runtime default profile should be used.
-                            Unconfined - no profile should be applied."
-                          type: string
-                      required:
-                        - type
-                      type: object
-                    supplementalGroups:
-                      description: A list of groups applied to the first process run
-                        in each container, in addition to the container's primary
-                        GID.  If unspecified, no groups will be added to any container.
-                      items:
-                        format: int64
-                        type: integer
-                      type: array
-                    sysctls:
-                      description: Sysctls hold a list of namespaced sysctls used
-                        for the pod. Pods with unsupported sysctls (by the container
-                        runtime) might fail to launch.
-                      items:
-                        description: Sysctl defines a kernel parameter to be set
-                        properties:
-                          name:
-                            description: Name of a property to set
+                          configName:
+                            description: ConfigName defines the name of the config
+                            type: string
+                          fileName:
+                            description: FileName defines the name of the file used
+                              to store the value. Defaults to the ConfigName.
                             type: string
                           value:
-                            description: Value of a property to set
+                            description: Value defines the value of the config
                             type: string
                         required:
-                          - name
+                          - configName
                           - value
                         type: object
                       type: array
-                    windowsOptions:
-                      description: The Windows specific settings applied to all containers.
-                        If unspecified, the options within a container's SecurityContext
-                        will be used. If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence.
-                      properties:
-                        gmsaCredentialSpec:
-                          description: GMSACredentialSpec is where the GMSA admission
-                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                            inlines the contents of the GMSA credential spec named
-                            by the GMSACredentialSpecName field.
-                          type: string
-                        gmsaCredentialSpecName:
-                          description: GMSACredentialSpecName is the name of the GMSA
-                            credential spec to use.
-                          type: string
-                        runAsUserName:
-                          description: The UserName in Windows to run the entrypoint
-                            of the container process. Defaults to the user specified
-                            in image metadata if unspecified. May also be set in PodSecurityContext.
-                            If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
-                          type: string
-                      type: object
+                    name:
+                      description: Name defines the name of the interceptor
+                      type: string
+                  required:
+                    - name
                   type: object
-                serviceAccountName:
-                  description: ServiceAccountName is the name of the ServiceAccount
-                    to use to run this pod.
+                type: array
+              istio:
+                description: Istio defines the configurations for istio
+                properties:
+                  enabled:
+                    description: Enabled defines whether to enable KoP
+                    type: boolean
+                  gateway:
+                    description: Gateway defines the gateway configuration The operator
+                      could either create a gateway automatically or use an existing
+                      one
+                    properties:
+                      create:
+                        description: Create defines whether to create a gateway
+                        type: boolean
+                      gateways:
+                        description: Gateways defines a list of existing gateways
+                        items:
+                          type: string
+                        type: array
+                      selector:
+                        additionalProperties:
+                          type: string
+                        description: Selector defines the selector for the gateway to
+                          create
+                        type: object
+                    type: object
+                type: object
+              labels:
+                additionalProperties:
                   type: string
-                sidecars:
-                  description: Sidecars defines sidecar containers running alongside
-                    with the main function container in the pod.
-                  items:
-                    description: A single application container that you want to run
-                      within a pod. The Container API from the core group is not used
-                      directly to avoid unneeded fields and reduce the size of the
-                      CRD. New fields could be added as needed.
+                description: Labels specifies the labels to attach to the stateful set
+                  created by operator for pulsar broker
+                type: object
+              pod:
+                description: Pod defines the policy for creating a broker pod
+                properties:
+                  affinity:
+                    description: Affinity specifies the scheduling constraints of a
+                      pod
                     properties:
-                      args:
-                        description: Arguments to the entrypoint.
-                        items:
-                          type: string
-                        type: array
-                      command:
-                        description: Entrypoint array. Not executed within a shell.
-                        items:
-                          type: string
-                        type: array
-                      env:
-                        description: List of environment variables to set in the container.
-                        items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
-                          properties:
-                            name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
-                              type: string
-                            value:
-                              description: 'Variable references $(VAR_NAME) are expanded
-                                using the previous defined environment variables in
-                                the container and any service environment variables.
-                                If a variable cannot be resolved, the reference in
-                                the input string will be unchanged. The $(VAR_NAME)
-                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
-                                Escaped references will never be expanded, regardless
-                                of whether the variable exists or not. Defaults to
-                                "".'
-                              type: string
-                            valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the
+                          pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling requirements
+                              (resource request, requiredDuringScheduling affinity expressions,
+                              etc.), compute a sum by iterating through the elements
+                              of this field and adding "weight" to the sum if the node
+                              matches the corresponding matchExpressions; the node(s)
+                              with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches
+                                all objects with implicit weight 0 (i.e. it's a no-op).
+                                A null preferred scheduling term matches no objects
+                                (i.e. is also a no-op).
                               properties:
-                                configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
                                   properties:
-                                    key:
-                                      description: The key to select.
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
-                                      type: boolean
-                                  required:
-                                    - key
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values
+                                              array must be empty. If the operator is
+                                              Gt or Lt, the values array must have a
+                                              single element, which will be interpreted
+                                              as an integer. This array is replaced
+                                              during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values
+                                              array must be empty. If the operator is
+                                              Gt or Lt, the values array must have a
+                                              single element, which will be interpreted
+                                              as an integer. This array is replaced
+                                              during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
                                   type: object
-                                fieldRef:
-                                  description: 'Selects a field of the pod: supports
-                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                    spec.serviceAccountName, status.hostIP, status.podIP,
-                                    status.podIPs.'
-                                  properties:
-                                    apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
-                                      type: string
-                                    fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
-                                      type: string
-                                  required:
-                                    - fieldPath
-                                  type: object
-                                resourceFieldRef:
-                                  description: 'Selects a resource of the container:
-                                    only resources limits and requests (limits.cpu,
-                                    limits.memory, limits.ephemeral-storage, requests.cpu,
-                                    requests.memory and requests.ephemeral-storage)
-                                    are currently supported.'
-                                  properties:
-                                    containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
-                                      type: string
-                                    divisor:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    resource:
-                                      description: 'Required: resource to select'
-                                      type: string
-                                  required:
-                                    - resource
-                                  type: object
-                                secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
-                                  properties:
-                                    key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding
+                                    nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                                - preference
+                                - weight
                               type: object
-                          required:
-                            - name
-                          type: object
-                        type: array
-                      envFrom:
-                        description: List of sources to populate environment variables
-                          in the container.
-                        items:
-                          description: EnvFromSource represents the source of a set
-                            of ConfigMaps
-                          properties:
-                            configMapRef:
-                              description: The ConfigMap to select from
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this
+                              field are not met at scheduling time, the pod will not
+                              be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from its
+                              node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches
+                                    no objects. The requirements of them are ANDed.
+                                    The TopologySelectorTerm type implements a subset
+                                    of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values
+                                              array must be empty. If the operator is
+                                              Gt or Lt, the values array must have a
+                                              single element, which will be interpreted
+                                              as an integer. This array is replaced
+                                              during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values
+                                              array must be empty. If the operator is
+                                              Gt or Lt, the values array must have a
+                                              single element, which will be interpreted
+                                              as an integer. This array is replaced
+                                              during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                              - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate
+                          this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling requirements
+                              (resource request, requiredDuringScheduling affinity expressions,
+                              etc.), compute a sum by iterating through the elements
+                              of this field and adding "weight" to the sum if the node
+                              has pods which matches the corresponding podAffinityTerm;
+                              the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
                               properties:
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap must
-                                    be defined
-                                  type: boolean
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of
+                                            label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values, a
+                                              key, and an operator that relates the
+                                              key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that
+                                                  the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and
+                                                  DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This
+                                                  array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is
+                                            "In", and the values array contains only
+                                            "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the pods
+                                        matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as running
+                                        on a node whose value of the label with key
+                                        topologyKey matches that of any node on which
+                                        any of the selected pods is running. Empty topologyKey
+                                        is not allowed.
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding
+                                    podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                                - podAffinityTerm
+                                - weight
                               type: object
-                            prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
-                              type: string
-                            secretRef:
-                              description: The Secret to select from
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this
+                              field are not met at scheduling time, the pod will not
+                              be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to a pod label update),
+                              the system may or may not try to eventually evict the
+                              pod from its node. When there are multiple elements, the
+                              lists of nodes corresponding to each podAffinityTerm are
+                              intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located is
+                                defined as running on a node whose value of the label
+                                with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
                               properties:
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If
+                                              the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array
+                                              is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is "In",
+                                        and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches
+                                    that of any node on which any of the selected pods
+                                    is running. Empty topologyKey is not allowed.
                                   type: string
-                                optional:
-                                  description: Specify whether the Secret must be
-                                    defined
-                                  type: boolean
+                              required:
+                                - topologyKey
                               type: object
-                          type: object
-                        type: array
-                      image:
-                        description: Docker image name.
-                        type: string
-                      imagePullPolicy:
-                        description: Image pull policy.
-                        type: string
-                      livenessProbe:
-                        description: Periodic probe of container liveness.
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g.
+                          avoid putting this pod in the same node, zone, etc. as some
+                          other pod(s)).
                         properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the anti-affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling requirements
+                              (resource request, requiredDuringScheduling anti-affinity
+                              expressions, etc.), compute a sum by iterating through
+                              the elements of this field and adding "weight" to the
+                              sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
                                   properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of
+                                            label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values, a
+                                              key, and an operator that relates the
+                                              key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that
+                                                  the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and
+                                                  DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This
+                                                  array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is
+                                            "In", and the values array contains only
+                                            "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the pods
+                                        matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as running
+                                        on a node whose value of the label with key
+                                        topologyKey matches that of any node on which
+                                        any of the selected pods is running. Empty topologyKey
+                                        is not allowed.
                                       type: string
                                   required:
-                                    - name
-                                    - value
+                                    - topologyKey
                                   type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      name:
-                        description: Name of the container specified as a DNS_LABEL.
-                          Each container in a pod must have a unique name (DNS_LABEL).
-                        type: string
-                      ports:
-                        description: List of ports to expose from the container.
-                        items:
-                          description: ContainerPort represents a network port in
-                            a single container.
-                          properties:
-                            containerPort:
-                              description: Number of port to expose on the pod's IP
-                                address. This must be a valid port number, 0 < x <
-                                65536.
-                              format: int32
-                              type: integer
-                            hostIP:
-                              description: What host IP to bind the external port
-                                to.
-                              type: string
-                            hostPort:
-                              description: Number of port to expose on the host. If
-                                specified, this must be a valid port number, 0 < x
-                                < 65536. If HostNetwork is specified, this must match
-                                ContainerPort. Most containers do not need this.
-                              format: int32
-                              type: integer
-                            name:
-                              description: If specified, this must be an IANA_SVC_NAME
-                                and unique within the pod. Each named port in a pod
-                                must have a unique name. Name for the port that can
-                                be referred to by services.
-                              type: string
-                            protocol:
-                              description: Protocol for port. Must be UDP, TCP, or
-                                SCTP. Defaults to "TCP".
-                              type: string
-                          required:
-                            - containerPort
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                          - containerPort
-                        x-kubernetes-list-type: map
-                      readinessProbe:
-                        description: 'Periodic probe of container service readiness.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
+                                weight:
+                                  description: weight associated with matching the corresponding
+                                    podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                                - podAffinityTerm
+                                - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified
+                              by this field are not met at scheduling time, the pod
+                              will not be scheduled onto the node. If the anti-affinity
+                              requirements specified by this field cease to be met at
+                              some point during pod execution (e.g. due to a pod label
+                              update), the system may or may not try to eventually evict
+                              the pod from its node. When there are multiple elements,
+                              the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located is
+                                defined as running on a node whose value of the label
+                                with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
                                   properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If
+                                              the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array
+                                              is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is "In",
+                                        and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
                                   type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      resources:
-                        description: Compute Resources required by this container.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                        type: object
-                      startupProbe:
-                        description: StartupProbe indicates that the Pod has successfully
-                          initialized.
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches
+                                    that of any node on which any of the selected pods
+                                    is running. Empty topologyKey is not allowed.
                                   type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
+                              required:
+                                - topologyKey
+                              type: object
+                            type: array
                         type: object
-                      volumeMounts:
-                        description: Pod volumes to mount into the container's filesystem.
-                        items:
-                          description: VolumeMount describes a mounting of a Volume
-                            within a container.
-                          properties:
-                            mountPath:
-                              description: Path within the container at which the
-                                volume should be mounted.  Must not contain ':'.
-                              type: string
-                            mountPropagation:
-                              description: mountPropagation determines how mounts
-                                are propagated from the host to container and the
-                                other way around. When not set, MountPropagationNone
-                                is used. This field is beta in 1.10.
-                              type: string
-                            name:
-                              description: This must match the Name of a Volume.
-                              type: string
-                            readOnly:
-                              description: Mounted read-only if true, read-write otherwise
-                                (false or unspecified). Defaults to false.
-                              type: boolean
-                            subPath:
-                              description: Path within the volume from which the container's
-                                volume should be mounted. Defaults to "" (volume's
-                                root).
-                              type: string
-                            subPathExpr:
-                              description: Expanded path within the volume from which
-                                the container's volume should be mounted. Behaves
-                                similarly to SubPath but environment variable references
-                                $(VAR_NAME) are expanded using the container's environment.
-                                Defaults to "" (volume's root). SubPathExpr and SubPath
-                                are mutually exclusive.
-                              type: string
-                          required:
-                            - mountPath
-                            - name
-                          type: object
-                        type: array
-                      workingDir:
-                        description: Container's working directory.
-                        type: string
-                    required:
-                      - name
                     type: object
-                  type: array
-                terminationGracePeriodSeconds:
-                  description: TerminationGracePeriodSeconds is the amount of time
-                    that kubernetes will give for a pod before terminating it.
-                  format: int64
-                  type: integer
-                tolerations:
-                  description: Tolerations specifies the tolerations of a Pod
-                  items:
-                    description: The pod this Toleration is attached to tolerates
-                      any taint that matches the triple <key,value,effect> using the
-                      matching operator <operator>.
-                    properties:
-                      effect:
-                        description: Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match
-                          all values and all keys.
-                        type: string
-                      operator:
-                        description: Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to
-                          Equal. Exists is equivalent to wildcard for value, so that
-                          a pod can tolerate all taints of a particular category.
-                        type: string
-                      tolerationSeconds:
-                        description: TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default,
-                          it is not set, which means tolerate the taint forever (do
-                          not evict). Zero and negative values will be treated as
-                          0 (evict immediately) by the system.
-                        format: int64
-                        type: integer
-                      value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
-                        type: string
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations specifies the annotations to attach to
+                      pods the operator creates
                     type: object
-                  type: array
-                vars:
-                  description: Vars specifies the environment variables of a Pod
-                  items:
-                    description: EnvVar represents an environment variable present
-                      in a Container.
-                    properties:
-                      name:
-                        description: Name of the environment variable. Must be a C_IDENTIFIER.
-                        type: string
-                      value:
-                        description: 'Variable references $(VAR_NAME) are expanded
-                          using the previous defined environment variables in the
-                          container and any service environment variables. If a variable
-                          cannot be resolved, the reference in the input string will
-                          be unchanged. The $(VAR_NAME) syntax can be escaped with
-                          a double $$, ie: $$(VAR_NAME). Escaped references will never
-                          be expanded, regardless of whether the variable exists or
-                          not. Defaults to "".'
-                        type: string
-                      valueFrom:
-                        description: Source for the environment variable's value.
-                          Cannot be used if value is not empty.
-                        properties:
-                          configMapKeyRef:
-                            description: Selects a key of a ConfigMap.
+                  debug:
+                    description: Debug defines a switch enable debug
+                    type: boolean
+                  initContainers:
+                    description: InitContainers defines init containers of the pod.
+                      A typical use case could be using an init container to download
+                      a remote jar to a local path.
+                    items:
+                      description: A single application container that you want to run
+                        within a pod. The Container API from the core group is not used
+                        directly to avoid unneeded fields and reduce the size of the
+                        CRD. New fields could be added as needed.
+                      properties:
+                        args:
+                          description: Arguments to the entrypoint.
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: Entrypoint array. Not executed within a shell.
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the container.
+                          items:
+                            description: EnvVar represents an environment variable present
+                              in a Container.
                             properties:
-                              key:
-                                description: The key to select.
-                                type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
                                 type: string
-                              optional:
-                                description: Specify whether the ConfigMap or its
-                                  key must be defined
-                                type: boolean
+                              value:
+                                description: 'Variable references $(VAR_NAME) are expanded
+                                  using the previous defined environment variables in
+                                  the container and any service environment variables.
+                                  If a variable cannot be resolved, the reference in
+                                  the input string will be unchanged. The $(VAR_NAME)
+                                  syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                  Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's value.
+                                  Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                      - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for volumes,
+                                          optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                      - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the pod's
+                                      namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its
+                                          key must be defined
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                type: object
                             required:
-                              - key
+                              - name
                             type: object
-                          fieldRef:
-                            description: 'Selects a field of the pod: supports metadata.name,
-                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                              spec.nodeName, spec.serviceAccountName, status.hostIP,
-                              status.podIP, status.podIPs.'
+                          type: array
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container.
+                          items:
+                            description: EnvFromSource represents the source of a set
+                              of ConfigMaps
                             properties:
-                              apiVersion:
-                                description: Version of the schema the FieldPath is
-                                  written in terms of, defaults to "v1".
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to each
+                                  key in the ConfigMap. Must be a C_IDENTIFIER.
                                 type: string
-                              fieldPath:
-                                description: Path of the field to select in the specified
-                                  API version.
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: Docker image name.
+                          type: string
+                        imagePullPolicy:
+                          description: Image pull policy.
+                          type: string
+                        livenessProbe:
+                          description: Periodic probe of container liveness.
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's IP
+                                  address. This must be a valid port number, 0 < x <
+                                  65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host. If
+                                  specified, this must be a valid port number, 0 < x
+                                  < 65536. If HostNetwork is specified, this must match
+                                  ContainerPort. Most containers do not need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a pod
+                                  must have a unique name. Name for the port that can
+                                  be referred to by services.
+                                type: string
+                              protocol:
+                                description: Protocol for port. Must be UDP, TCP, or
+                                  SCTP. Defaults to "TCP".
                                 type: string
                             required:
-                              - fieldPath
+                              - containerPort
                             type: object
-                          resourceFieldRef:
-                            description: 'Selects a resource of the container: only
-                              resources limits and requests (limits.cpu, limits.memory,
-                              limits.ephemeral-storage, requests.cpu, requests.memory
-                              and requests.ephemeral-storage) are currently supported.'
-                            properties:
-                              containerName:
-                                description: 'Container name: required for volumes,
-                                  optional for env vars'
-                                type: string
-                              divisor:
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - containerPort
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: Compute Resources required by this container.
+                          properties:
+                            limits:
+                              additionalProperties:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Specifies the output format of the exposed
-                                  resources, defaults to "1"
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              resource:
-                                description: 'Required: resource to select'
-                                type: string
-                            required:
-                              - resource
-                            type: object
-                          secretKeyRef:
-                            description: Selects a key of a secret in the pod's namespace
+                              description: 'Limits describes the maximum amount of compute
+                                resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of
+                                compute resources required. If Requests is omitted for
+                                a container, it defaults to Limits if that is explicitly
+                                specified, otherwise to an implementation-defined value.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: StartupProbe indicates that the Pod has successfully
+                            initialized.
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
                             properties:
-                              key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: This must match the Name of a Volume.
                                 type: string
-                              optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
+                              readOnly:
+                                description: Mounted read-only if true, read-write otherwise
+                                  (false or unspecified). Defaults to false.
                                 type: boolean
+                              subPath:
+                                description: Path within the volume from which the container's
+                                  volume should be mounted. Defaults to "" (volume's
+                                  root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from which
+                                  the container's volume should be mounted. Behaves
+                                  similarly to SubPath but environment variable references
+                                  $(VAR_NAME) are expanded using the container's environment.
+                                  Defaults to "" (volume's root). SubPathExpr and SubPath
+                                  are mutually exclusive.
+                                type: string
                             required:
-                              - key
+                              - mountPath
+                              - name
                             type: object
-                        type: object
-                    required:
-                      - name
-                    type: object
-                  type: array
-                volumes:
-                  description: Volumes defines extra volumes of the pod.
-                  items:
-                    description: Volume represents a named volume in a pod that may
-                      be accessed by any container in the pod. The Volume API from
-                      the core group is not used directly to avoid unneeded fields
-                      defined in `VolumeSource` and reduce the size of the CRD. New
-                      fields in VolumeSource could be added as needed.
+                          type: array
+                        workingDir:
+                          description: Container's working directory.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    type: array
+                  jvmOptions:
+                    description: JvmOptions defines the Jvm options passed to the proxy
                     properties:
-                      configMap:
-                        description: ConfigMap represents a configMap that should
-                          populate this volume
-                        properties:
-                          defaultMode:
-                            description: 'Optional: mode bits used to set permissions
-                              on created files by default. Must be an octal value
-                              between 0000 and 0777 or a decimal value between 0 and
-                              511. YAML accepts both octal and decimal values, JSON
-                              requires decimal values for mode bits. Defaults to 0644.
-                              Directories within the path are not affected by this
-                              setting. This might be in conflict with other options
-                              that affect the file mode, like fsGroup, and the result
-                              can be other mode bits set.'
-                            format: int32
-                            type: integer
-                          items:
-                            description: If unspecified, each key-value pair in the
-                              Data field of the referenced ConfigMap will be projected
-                              into the volume as a file whose name is the key and
-                              content is the value. If specified, the listed keys
-                              will be projected into the specified paths, and unlisted
-                              keys will not be present. If a key is specified which
-                              is not present in the ConfigMap, the volume setup will
-                              error unless it is marked optional. Paths must be relative
-                              and may not contain the '..' path or start with '..'.
-                            items:
-                              description: Maps a string key to a path within a volume.
-                              properties:
-                                key:
-                                  description: The key to project.
-                                  type: string
-                                mode:
-                                  description: 'Optional: mode bits used to set permissions
-                                    on this file. Must be an octal value between 0000
-                                    and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON
-                                    requires decimal values for mode bits. If not
-                                    specified, the volume defaultMode will be used.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
-                                  format: int32
-                                  type: integer
-                                path:
-                                  description: The relative path of the file to map
-                                    the key to. May not be an absolute path. May not
-                                    contain the path element '..'. May not start with
-                                    the string '..'.
-                                  type: string
-                              required:
-                                - key
-                                - path
-                              type: object
-                            type: array
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                          optional:
-                            description: Specify whether the ConfigMap or its keys
-                              must be defined
-                            type: boolean
-                        type: object
-                      name:
-                        description: 'Volume''s name. Must be a DNS_LABEL and unique
-                          within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      secret:
-                        description: Secret represents a secret that should populate
-                          this volume.
-                        properties:
-                          defaultMode:
-                            description: 'Optional: mode bits used to set permissions
-                              on created files by default. Must be an octal value
-                              between 0000 and 0777 or a decimal value between 0 and
-                              511. YAML accepts both octal and decimal values, JSON
-                              requires decimal values for mode bits. Defaults to 0644.
-                              Directories within the path are not affected by this
-                              setting. This might be in conflict with other options
-                              that affect the file mode, like fsGroup, and the result
-                              can be other mode bits set.'
-                            format: int32
-                            type: integer
-                          items:
-                            description: If unspecified, each key-value pair in the
-                              Data field of the referenced Secret will be projected
-                              into the volume as a file whose name is the key and
-                              content is the value. If specified, the listed keys
-                              will be projected into the specified paths, and unlisted
-                              keys will not be present. If a key is specified which
-                              is not present in the Secret, the volume setup will
-                              error unless it is marked optional. Paths must be relative
-                              and may not contain the '..' path or start with '..'.
-                            items:
-                              description: Maps a string key to a path within a volume.
-                              properties:
-                                key:
-                                  description: The key to project.
-                                  type: string
-                                mode:
-                                  description: 'Optional: mode bits used to set permissions
-                                    on this file. Must be an octal value between 0000
-                                    and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON
-                                    requires decimal values for mode bits. If not
-                                    specified, the volume defaultMode will be used.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
-                                  format: int32
-                                  type: integer
-                                path:
-                                  description: The relative path of the file to map
-                                    the key to. May not be an absolute path. May not
-                                    contain the path element '..'. May not start with
-                                    the string '..'.
-                                  type: string
-                              required:
-                                - key
-                                - path
-                              type: object
-                            type: array
-                          optional:
-                            description: Specify whether the Secret or its keys must
-                              be defined
-                            type: boolean
-                          secretName:
-                            description: 'Name of the secret in the pod''s namespace
-                              to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                            type: string
-                        type: object
+                      extraOptions:
+                        items:
+                          type: string
+                        type: array
+                      gcLoggingOptions:
+                        items:
+                          type: string
+                        type: array
+                      gcOptions:
+                        items:
+                          type: string
+                        type: array
+                      memoryOptions:
+                        items:
+                          type: string
+                        type: array
                     required:
-                      - name
+                      - extraOptions
+                      - gcLoggingOptions
+                      - gcOptions
+                      - memoryOptions
                     type: object
-                  type: array
-              type: object
-            replicas:
-              description: Replicas is the expected size of the pulsar broker
-              format: int32
-              type: integer
-            zkServers:
-              description: Zookeeper server list
-              type: string
-          required:
-            - zkServers
-          type: object
-        status:
-          description: PulsarBrokerStatus defines the observed state of PulsarBroker
-          properties:
-            conditions:
-              additionalProperties:
-                description: The `Status` of a given `Condition` and the `Action`
-                  needed to reach the `Status`
-                properties:
-                  action:
-                    description: The action needed to advance components to ready
-                      status
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels specifies the labels to attach to pod the operator
+                      creates for the cluster.
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector specifies a map of key-value pairs. For
+                      a pod to be eligible to run on a node, the node must have each
+                      of the indicated key-value pairs as labels.
+                    type: object
+                  resources:
+                    description: Resources specifies the resource requirements of a
+                      pod to run in the cluster
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  secretRefs:
+                    description: SecretRefs defines how to mount required secrets into
+                      containers
+                    items:
+                      properties:
+                        mountPath:
+                          type: string
+                        secretName:
+                          type: string
+                      required:
+                        - mountPath
+                        - secretName
+                      type: object
+                    type: array
+                  securityContext:
+                    description: 'SecurityContext specifies the security context for
+                      the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
+                    properties:
+                      fsGroup:
+                        description: "A special supplemental group that applies to all
+                          containers in a pod. Some volume types allow the Kubelet to
+                          change the ownership of that volume to be owned by the pod:
+                          \n 1. The owning GID will be the FSGroup 2. The setgid bit
+                          is set (new files created in the volume will be owned by FSGroup)
+                          3. The permission bits are OR'd with rw-rw---- \n If unset,
+                          the Kubelet will not modify the ownership and permissions
+                          of any volume."
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        description: 'fsGroupChangePolicy defines behavior of changing
+                          ownership and permission of the volume before being exposed
+                          inside Pod. This field will only apply to volume types which
+                          support fsGroup based ownership(and permissions). It will
+                          have no effect on ephemeral volume types such as: secret,
+                          configmaps and emptydir. Valid values are "OnRootMismatch"
+                          and "Always". If not specified defaults to "Always".'
+                        type: string
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set in
+                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence for
+                          that container.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail to
+                          start the container if it does. If unset or false, no such
+                          validation will be performed. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if unspecified.
+                          May also be set in SecurityContext.  If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies to
+                              the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies to
+                              the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies to
+                              the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies to
+                              the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by the containers in
+                          this pod.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a profile
+                              defined in a file on the node should be used. RuntimeDefault
+                              - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied."
+                            type: string
+                        required:
+                          - type
+                        type: object
+                      supplementalGroups:
+                        description: A list of groups applied to the first process run
+                          in each container, in addition to the container's primary
+                          GID.  If unspecified, no groups will be added to any container.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used
+                          for the pod. Pods with unsupported sysctls (by the container
+                          runtime) might fail to launch.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                            - name
+                            - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        description: The Windows specific settings applied to all containers.
+                          If unspecified, the options within a container's SecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the GMSA
+                              credential spec to use.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in PodSecurityContext.
+                              If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccountName:
+                    description: ServiceAccountName is the name of the ServiceAccount
+                      to use to run this pod.
                     type: string
-                  condition:
-                    type: string
-                  status:
-                    type: string
-                required:
-                  - action
-                  - condition
-                  - status
+                  sidecars:
+                    description: Sidecars defines sidecar containers running alongside
+                      with the main function container in the pod.
+                    items:
+                      description: A single application container that you want to run
+                        within a pod. The Container API from the core group is not used
+                        directly to avoid unneeded fields and reduce the size of the
+                        CRD. New fields could be added as needed.
+                      properties:
+                        args:
+                          description: Arguments to the entrypoint.
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: Entrypoint array. Not executed within a shell.
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the container.
+                          items:
+                            description: EnvVar represents an environment variable present
+                              in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are expanded
+                                  using the previous defined environment variables in
+                                  the container and any service environment variables.
+                                  If a variable cannot be resolved, the reference in
+                                  the input string will be unchanged. The $(VAR_NAME)
+                                  syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                  Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's value.
+                                  Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                      - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for volumes,
+                                          optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                      - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the pod's
+                                      namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its
+                                          key must be defined
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                type: object
+                            required:
+                              - name
+                            type: object
+                          type: array
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container.
+                          items:
+                            description: EnvFromSource represents the source of a set
+                              of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to each
+                                  key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: Docker image name.
+                          type: string
+                        imagePullPolicy:
+                          description: Image pull policy.
+                          type: string
+                        livenessProbe:
+                          description: Periodic probe of container liveness.
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's IP
+                                  address. This must be a valid port number, 0 < x <
+                                  65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host. If
+                                  specified, this must be a valid port number, 0 < x
+                                  < 65536. If HostNetwork is specified, this must match
+                                  ContainerPort. Most containers do not need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a pod
+                                  must have a unique name. Name for the port that can
+                                  be referred to by services.
+                                type: string
+                              protocol:
+                                description: Protocol for port. Must be UDP, TCP, or
+                                  SCTP. Defaults to "TCP".
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - containerPort
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: Compute Resources required by this container.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute
+                                resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of
+                                compute resources required. If Requests is omitted for
+                                a container, it defaults to Limits if that is explicitly
+                                specified, otherwise to an implementation-defined value.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: StartupProbe indicates that the Pod has successfully
+                            initialized.
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write otherwise
+                                  (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the container's
+                                  volume should be mounted. Defaults to "" (volume's
+                                  root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from which
+                                  the container's volume should be mounted. Behaves
+                                  similarly to SubPath but environment variable references
+                                  $(VAR_NAME) are expanded using the container's environment.
+                                  Defaults to "" (volume's root). SubPathExpr and SubPath
+                                  are mutually exclusive.
+                                type: string
+                            required:
+                              - mountPath
+                              - name
+                            type: object
+                          type: array
+                        workingDir:
+                          description: Container's working directory.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    type: array
+                  terminationGracePeriodSeconds:
+                    description: TerminationGracePeriodSeconds is the amount of time
+                      that kubernetes will give for a pod before terminating it.
+                    format: int64
+                    type: integer
+                  tolerations:
+                    description: Tolerations specifies the tolerations of a Pod
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using the
+                        matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty
+                            means match all taint effects. When specified, allowed values
+                            are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the
+                            value. Valid operators are Exists and Equal. Defaults to
+                            Equal. Exists is equivalent to wildcard for value, so that
+                            a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time
+                            the toleration (which must be of effect NoExecute, otherwise
+                            this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do
+                            not evict). Zero and negative values will be treated as
+                            0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  vars:
+                    description: Vars specifies the environment variables of a Pod
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a variable
+                            cannot be resolved, the reference in the input string will
+                            be unchanged. The $(VAR_NAME) syntax can be escaped with
+                            a double $$, ie: $$(VAR_NAME). Escaped references will never
+                            be expanded, regardless of whether the variable exists or
+                            not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP,
+                                status.podIP, status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath is
+                                    written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the specified
+                                    API version.
+                                  type: string
+                              required:
+                                - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Specifies the output format of the exposed
+                                    resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                                - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                          type: object
+                      required:
+                        - name
+                      type: object
+                    type: array
+                  volumes:
+                    description: Volumes defines extra volumes of the pod.
+                    items:
+                      description: Volume represents a named volume in a pod that may
+                        be accessed by any container in the pod. The Volume API from
+                        the core group is not used directly to avoid unneeded fields
+                        defined in `VolumeSource` and reduce the size of the CRD. New
+                        fields in VolumeSource could be added as needed.
+                      properties:
+                        configMap:
+                          description: ConfigMap represents a configMap that should
+                            populate this volume
+                          properties:
+                            defaultMode:
+                              description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0 and
+                                511. YAML accepts both octal and decimal values, JSON
+                                requires decimal values for mode bits. Defaults to 0644.
+                                Directories within the path are not affected by this
+                                setting. This might be in conflict with other options
+                                that affect the file mode, like fsGroup, and the result
+                                can be other mode bits set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: If unspecified, each key-value pair in the
+                                Data field of the referenced ConfigMap will be projected
+                                into the volume as a file whose name is the key and
+                                content is the value. If specified, the listed keys
+                                will be projected into the specified paths, and unlisted
+                                keys will not be present. If a key is specified which
+                                is not present in the ConfigMap, the volume setup will
+                                error unless it is marked optional. Paths must be relative
+                                and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a volume.
+                                properties:
+                                  key:
+                                    description: The key to project.
+                                    type: string
+                                  mode:
+                                    description: 'Optional: mode bits used to set permissions
+                                      on this file. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON
+                                      requires decimal values for mode bits. If not
+                                      specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that
+                                      affect the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: The relative path of the file to map
+                                      the key to. May not be an absolute path. May not
+                                      contain the path element '..'. May not start with
+                                      the string '..'.
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                type: object
+                              type: array
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its keys
+                                must be defined
+                              type: boolean
+                          type: object
+                        name:
+                          description: 'Volume''s name. Must be a DNS_LABEL and unique
+                            within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        secret:
+                          description: Secret represents a secret that should populate
+                            this volume.
+                          properties:
+                            defaultMode:
+                              description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0 and
+                                511. YAML accepts both octal and decimal values, JSON
+                                requires decimal values for mode bits. Defaults to 0644.
+                                Directories within the path are not affected by this
+                                setting. This might be in conflict with other options
+                                that affect the file mode, like fsGroup, and the result
+                                can be other mode bits set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: If unspecified, each key-value pair in the
+                                Data field of the referenced Secret will be projected
+                                into the volume as a file whose name is the key and
+                                content is the value. If specified, the listed keys
+                                will be projected into the specified paths, and unlisted
+                                keys will not be present. If a key is specified which
+                                is not present in the Secret, the volume setup will
+                                error unless it is marked optional. Paths must be relative
+                                and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a volume.
+                                properties:
+                                  key:
+                                    description: The key to project.
+                                    type: string
+                                  mode:
+                                    description: 'Optional: mode bits used to set permissions
+                                      on this file. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON
+                                      requires decimal values for mode bits. If not
+                                      specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that
+                                      affect the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: The relative path of the file to map
+                                      the key to. May not be an absolute path. May not
+                                      contain the path element '..'. May not start with
+                                      the string '..'.
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                type: object
+                              type: array
+                            optional:
+                              description: Specify whether the Secret or its keys must
+                                be defined
+                              type: boolean
+                            secretName:
+                              description: 'Name of the secret in the pod''s namespace
+                                to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              type: string
+                          type: object
+                      required:
+                        - name
+                      type: object
+                    type: array
                 type: object
-              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                of Broker Important: Run "make" to regenerate code after modifying
-                this file'
-              type: object
-            observedGeneration:
-              description: ObservedGeneration is the most recent generation observed
-                for this cluster. It corresponds to the metadata generation, which
-                is updated on mutation by the API Server.
-              format: int64
-              type: integer
-            readyReplicas:
-              description: ReadyReplicas is the number of ready servers in the cluster
-              format: int32
-              type: integer
-            replicas:
-              description: Replicas is the number of servers in the cluster
-              format: int32
-              type: integer
-            updatedReplicas:
-              description: UpdatedReplicas is the number of servers that has been
-                updated to the latest configuration
-              format: int32
-              type: integer
-          required:
-            - conditions
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+              replicas:
+                description: Replicas is the expected size of the pulsar broker
+                format: int32
+                type: integer
+              zkServers:
+                description: Zookeeper server list
+                type: string
+            required:
+              - zkServers
+            type: object
+          status:
+            description: PulsarBrokerStatus defines the observed state of PulsarBroker
+            properties:
+              conditions:
+                additionalProperties:
+                  description: The `Status` of a given `Condition` and the `Action`
+                    needed to reach the `Status`
+                  properties:
+                    action:
+                      description: The action needed to advance components to ready
+                        status
+                      type: string
+                    condition:
+                      type: string
+                    status:
+                      type: string
+                  required:
+                    - action
+                    - condition
+                    - status
+                  type: object
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of Broker Important: Run "make" to regenerate code after modifying
+                  this file'
+                type: object
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  for this cluster. It corresponds to the metadata generation, which
+                  is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: ReadyReplicas is the number of ready servers in the cluster
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the number of servers in the cluster
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: UpdatedReplicas is the number of servers that has been
+                  updated to the latest configuration
+                format: int32
+                type: integer
+            required:
+              - conditions
+            type: object
+        type: object
 status:
   acceptedNames:
     kind: ""

--- a/charts/pulsar-operator/crds/pulsar.streamnative.io_pulsarproxies.yaml
+++ b/charts/pulsar-operator/crds/pulsar.streamnative.io_pulsarproxies.yaml
@@ -1,6 +1,5 @@
-
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -20,2962 +19,2961 @@ spec:
       - proxy
     singular: pulsarproxy
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: PulsarProxy is the Schema for the pulsarproxies API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: PulsarProxySpec defines the desired state of PulsarProxy
-          properties:
-            apiObjects:
-              description: APIObjects allows precise control over how components (services,
-                statefulset and so on) should be managed
-              properties:
-                externalService:
-                  description: ExternalService defines the Pulsar Proxy external service
-                    resource template.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                  type: object
-                headlessService:
-                  description: HeadlessService defines the Pulsar Proxy headless service
-                    resource template.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                  type: object
-                proxyConfigMap:
-                  description: ProxyConfigMap defines the Pulsar proxy ConfigMap resource
-                    template.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                  type: object
-                statefulSet:
-                  description: StatefulSet defines the StatefulSet resource template
-                    for broker.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        the name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                    volumeClaimTemplates:
-                      description: VolumeClaimTemplates is a list of claims that pods
-                        are allowed to reference. If a non-empty list is specified,
-                        the original values in the desired STS will be replaced.
-                      items:
-                        description: PersistentVolumeClaim is a user's request for
-                          and claim to a persistent volume
-                        properties:
-                          apiVersion:
-                            description: 'APIVersion defines the versioned schema
-                              of this representation of an object. Servers should
-                              convert recognized schemas to the latest internal value,
-                              and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                            type: string
-                          kind:
-                            description: 'Kind is a string value representing the
-                              REST resource this object represents. Servers may infer
-                              this from the endpoint the client submits requests to.
-                              Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          metadata:
-                            description: 'Standard object''s metadata. More info:
-                              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                            type: object
-                          spec:
-                            description: 'Spec defines the desired characteristics
-                              of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                            properties:
-                              accessModes:
-                                description: 'AccessModes contains the desired access
-                                  modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                items:
-                                  type: string
-                                type: array
-                              dataSource:
-                                description: 'This field can be used to specify either:
-                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                                  - Beta) * An existing PVC (PersistentVolumeClaim)
-                                  * An existing custom resource/object that implements
-                                  data population (Alpha) In order to use VolumeSnapshot
-                                  object types, the appropriate feature gate must
-                                  be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
-                                  If the provisioner or an external controller can
-                                  support the specified data source, it will create
-                                  a new volume based on the contents of the specified
-                                  data source. If the specified data source is not
-                                  supported, the volume will not be created and the
-                                  failure will be reported as an event. In the future,
-                                  we plan to support more data source types and the
-                                  behavior of the provisioner may change.'
-                                properties:
-                                  apiGroup:
-                                    description: APIGroup is the group for the resource
-                                      being referenced. If APIGroup is not specified,
-                                      the specified Kind must be in the core API group.
-                                      For any other third-party types, APIGroup is
-                                      required.
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: PulsarProxy is the Schema for the pulsarproxies API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PulsarProxySpec defines the desired state of PulsarProxy
+            properties:
+              apiObjects:
+                description: APIObjects allows precise control over how components (services,
+                  statefulset and so on) should be managed
+                properties:
+                  externalService:
+                    description: ExternalService defines the Pulsar Proxy external service
+                      resource template.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                    type: object
+                  headlessService:
+                    description: HeadlessService defines the Pulsar Proxy headless service
+                      resource template.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                    type: object
+                  proxyConfigMap:
+                    description: ProxyConfigMap defines the Pulsar proxy ConfigMap resource
+                      template.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                    type: object
+                  statefulSet:
+                    description: StatefulSet defines the StatefulSet resource template
+                      for broker.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          the name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                      volumeClaimTemplates:
+                        description: VolumeClaimTemplates is a list of claims that pods
+                          are allowed to reference. If a non-empty list is specified,
+                          the original values in the desired STS will be replaced.
+                        items:
+                          description: PersistentVolumeClaim is a user's request for
+                            and claim to a persistent volume
+                          properties:
+                            apiVersion:
+                              description: 'APIVersion defines the versioned schema
+                                of this representation of an object. Servers should
+                                convert recognized schemas to the latest internal value,
+                                and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                              type: string
+                            kind:
+                              description: 'Kind is a string value representing the
+                                REST resource this object represents. Servers may infer
+                                this from the endpoint the client submits requests to.
+                                Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            metadata:
+                              description: 'Standard object''s metadata. More info:
+                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                              type: object
+                            spec:
+                              description: 'Spec defines the desired characteristics
+                                of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              properties:
+                                accessModes:
+                                  description: 'AccessModes contains the desired access
+                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                  items:
                                     type: string
-                                  kind:
-                                    description: Kind is the type of resource being
-                                      referenced
-                                    type: string
-                                  name:
-                                    description: Name is the name of resource being
-                                      referenced
-                                    type: string
-                                required:
-                                  - kind
-                                  - name
-                                type: object
-                              resources:
-                                description: 'Resources represents the minimum resources
-                                  the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                                properties:
-                                  limits:
-                                    additionalProperties:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    description: 'Limits describes the maximum amount
-                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                    type: object
-                                  requests:
-                                    additionalProperties:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    description: 'Requests describes the minimum amount
-                                      of compute resources required. If Requests is
-                                      omitted for a container, it defaults to Limits
-                                      if that is explicitly specified, otherwise to
-                                      an implementation-defined value. More info:
-                                      https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                    type: object
-                                type: object
-                              selector:
-                                description: A label query over volumes to consider
-                                  for binding.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
+                                  type: array
+                                dataSource:
+                                  description: 'This field can be used to specify either:
+                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                                    - Beta) * An existing PVC (PersistentVolumeClaim)
+                                    * An existing custom resource/object that implements
+                                    data population (Alpha) In order to use VolumeSnapshot
+                                    object types, the appropriate feature gate must
+                                    be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
+                                    If the provisioner or an external controller can
+                                    support the specified data source, it will create
+                                    a new volume based on the contents of the specified
+                                    data source. If the specified data source is not
+                                    supported, the volume will not be created and the
+                                    failure will be reported as an event. In the future,
+                                    we plan to support more data source types and the
+                                    behavior of the provisioner may change.'
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup is the group for the resource
+                                        being referenced. If APIGroup is not specified,
+                                        the specified Kind must be in the core API group.
+                                        For any other third-party types, APIGroup is
+                                        required.
                                       type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
+                                    kind:
+                                      description: Kind is the type of resource being
+                                        referenced
+                                      type: string
+                                    name:
+                                      description: Name is the name of resource being
+                                        referenced
+                                      type: string
+                                  required:
+                                    - kind
+                                    - name
+                                  type: object
+                                resources:
+                                  description: 'Resources represents the minimum resources
+                                    the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                  properties:
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: 'Limits describes the maximum amount
+                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: 'Requests describes the minimum amount
+                                        of compute resources required. If Requests is
+                                        omitted for a container, it defaults to Limits
+                                        if that is explicitly specified, otherwise to
+                                        an implementation-defined value. More info:
+                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      type: object
+                                  type: object
+                                selector:
+                                  description: A label query over volumes to consider
+                                    for binding.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If
+                                              the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array
+                                              is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is "In",
+                                        and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                storageClassName:
+                                  description: 'Name of the StorageClass required by
+                                    the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                  type: string
+                                volumeMode:
+                                  description: volumeMode defines what type of volume
+                                    is required by the claim. Value of Filesystem is
+                                    implied when not included in claim spec.
+                                  type: string
+                                volumeName:
+                                  description: VolumeName is the binding reference to
+                                    the PersistentVolume backing this claim.
+                                  type: string
+                              type: object
+                            status:
+                              description: 'Status represents the current information/status
+                                of a persistent volume claim. Read-only. More info:
+                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              properties:
+                                accessModes:
+                                  description: 'AccessModes contains the actual access
+                                    modes the volume backing the PVC has. More info:
+                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                  items:
+                                    type: string
+                                  type: array
+                                capacity:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: Represents the actual resources of the
+                                    underlying volume.
+                                  type: object
+                                conditions:
+                                  description: Current Condition of persistent volume
+                                    claim. If underlying persistent volume is being
+                                    resized then the Condition will be set to 'ResizeStarted'.
+                                  items:
+                                    description: PersistentVolumeClaimCondition contails
+                                      details about state of pvc
+                                    properties:
+                                      lastProbeTime:
+                                        description: Last time we probed the condition.
+                                        format: date-time
+                                        type: string
+                                      lastTransitionTime:
+                                        description: Last time the condition transitioned
+                                          from one status to another.
+                                        format: date-time
+                                        type: string
+                                      message:
+                                        description: Human-readable message indicating
+                                          details about last transition.
+                                        type: string
+                                      reason:
+                                        description: Unique, this should be a short,
+                                          machine understandable string that gives the
+                                          reason for condition's last transition. If
+                                          it reports "ResizeStarted" that means the
+                                          underlying persistent volume is being resized.
+                                        type: string
+                                      status:
+                                        type: string
+                                      type:
+                                        description: PersistentVolumeClaimConditionType
+                                          is a valid value of PersistentVolumeClaimCondition.Type
+                                        type: string
+                                    required:
+                                      - status
+                                      - type
+                                    type: object
+                                  type: array
+                                phase:
+                                  description: Phase represents the current phase of
+                                    PersistentVolumeClaim.
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
+                      volumeMounts:
+                        description: VolumeMounts is a list of volumes to mount into
+                          the container's filesystem. If a non-empty list is specified,
+                          the original values of the main container in the desired STS
+                          will be replaced.
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the volume
+                                should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts are
+                                propagated from the host to container and the other
+                                way around. When not set, MountPropagationNone is used.
+                                This field is beta in 1.10.
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise
+                                (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's
+                                volume should be mounted. Defaults to "" (volume's root).
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which
+                                the container's volume should be mounted. Behaves similarly
+                                to SubPath but environment variable references $(VAR_NAME)
+                                are expanded using the container's environment. Defaults
+                                to "" (volume's root). SubPathExpr and SubPath are mutually
+                                exclusive.
+                              type: string
+                          required:
+                            - mountPath
+                            - name
+                          type: object
+                        type: array
+                    type: object
+                  websocketConfigMap:
+                    description: WebSocketConfigMap defines the Pulsar WebSocket ConfigMap
+                      resource template.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                    type: object
+                type: object
+              brokerAddress:
+                description: The address of the broker
+                type: string
+              certSecretName:
+                description: CertSecretName defines the name of the secret that contains
+                  the certificate to use in the proxy if the value is not set, then
+                  the operator create an certificate automatically if the value is set
+                  to be an empty string, then the proxy will not use a certificate otherwise
+                  the value should be name of the secret that contains a valid certificate
+                  to use in the proxy
+                type: string
+              config:
+                description: Config defines configurations for proxies
+                properties:
+                  custom:
+                    additionalProperties:
+                      type: string
+                    description: Custom allows to customize broker configurations directly.
+                    type: object
+                  prometheusPlugin:
+                    description: PrometheusPlugin defines the configuration of the Prometheus
+                      servlet plugin which could be used to query the Prometheus cluster
+                      deployed alongside the proxy cluster.
+                    properties:
+                      host:
+                        description: Host defines the host of the Prometheus service
+                        type: string
+                    type: object
+                  tls:
+                    description: TLS defines the configuration of TLS in proxies
+                    properties:
+                      certSecretName:
+                        description: CertSecretName defines the name of the secret that
+                          contains the certificate to use the value should be name of
+                          the secret that contains a valid certificate to use in the
+                          proxy
+                        type: string
+                      enabled:
+                        description: Enabled determines whether to enable TLS in proxies
+                          TODO move other TLS related fields here
+                        type: boolean
+                      trustCertsEnabled:
+                        description: TrustCertsEnabled defines whether to enable trust
+                          store
+                        type: boolean
+                    type: object
+                type: object
+              configs:
+                additionalProperties:
+                  type: string
+                description: Configs defines custom configurations for proxies
+                type: object
+              configurationStoreServers:
+                description: ConfigurationStoreServers defines the configuration store
+                  servers address
+                type: string
+              dnsNames:
+                description: A list of service urls this pulsar proxy advertise
+                items:
+                  type: string
+                type: array
+              image:
+                description: Image is the container image used to run pulsar proxy pods.
+                  default is apachepulsar/pulsar:latest
+                type: string
+              imagePullPolicy:
+                description: Image pull policy, one of Always, Never, IfNotPresent,
+                  default to Always.
+                type: string
+              issuerRef:
+                description: IssuerRef is a reference to the issuer for the TLS endpoint.  If
+                  the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                  with the given name in the same namespace as the PulsarProxy will
+                  be used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                  with the provided name will be used. The 'name' field in this stanza
+                  is required at all times. The group field refers to the API group
+                  of the issuer which defaults to 'cert-manager.io' if empty.
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                required:
+                  - name
+                type: object
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels specifies the labels to attach to the stateful set
+                  created by operator for pulsar proxy
+                type: object
+              pod:
+                description: Pod defines the policy for creating a proxy pod
+                properties:
+                  affinity:
+                    description: Affinity specifies the scheduling constraints of a
+                      pod
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the
+                          pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling requirements
+                              (resource request, requiredDuringScheduling affinity expressions,
+                              etc.), compute a sum by iterating through the elements
+                              of this field and adding "weight" to the sum if the node
+                              matches the corresponding matchExpressions; the node(s)
+                              with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches
+                                all objects with implicit weight 0 (i.e. it's a no-op).
+                                A null preferred scheduling term matches no objects
+                                (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values
+                                              array must be empty. If the operator is
+                                              Gt or Lt, the values array must have a
+                                              single element, which will be interpreted
+                                              as an integer. This array is replaced
+                                              during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values
+                                              array must be empty. If the operator is
+                                              Gt or Lt, the values array must have a
+                                              single element, which will be interpreted
+                                              as an integer. This array is replaced
+                                              during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding
+                                    nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                                - preference
+                                - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this
+                              field are not met at scheduling time, the pod will not
+                              be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from its
+                              node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches
+                                    no objects. The requirements of them are ANDed.
+                                    The TopologySelectorTerm type implements a subset
+                                    of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values
+                                              array must be empty. If the operator is
+                                              Gt or Lt, the values array must have a
+                                              single element, which will be interpreted
+                                              as an integer. This array is replaced
+                                              during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values
+                                              array must be empty. If the operator is
+                                              Gt or Lt, the values array must have a
+                                              single element, which will be interpreted
+                                              as an integer. This array is replaced
+                                              during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                              - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate
+                          this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling requirements
+                              (resource request, requiredDuringScheduling affinity expressions,
+                              etc.), compute a sum by iterating through the elements
+                              of this field and adding "weight" to the sum if the node
+                              has pods which matches the corresponding podAffinityTerm;
+                              the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of
+                                            label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values, a
+                                              key, and an operator that relates the
+                                              key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that
+                                                  the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and
+                                                  DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This
+                                                  array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is
+                                            "In", and the values array contains only
+                                            "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the pods
+                                        matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as running
+                                        on a node whose value of the label with key
+                                        topologyKey matches that of any node on which
+                                        any of the selected pods is running. Empty topologyKey
+                                        is not allowed.
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding
+                                    podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                                - podAffinityTerm
+                                - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this
+                              field are not met at scheduling time, the pod will not
+                              be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to a pod label update),
+                              the system may or may not try to eventually evict the
+                              pod from its node. When there are multiple elements, the
+                              lists of nodes corresponding to each podAffinityTerm are
+                              intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located is
+                                defined as running on a node whose value of the label
+                                with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If
+                                              the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array
+                                              is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is "In",
+                                        and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches
+                                    that of any node on which any of the selected pods
+                                    is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                                - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g.
+                          avoid putting this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the anti-affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling requirements
+                              (resource request, requiredDuringScheduling anti-affinity
+                              expressions, etc.), compute a sum by iterating through
+                              the elements of this field and adding "weight" to the
+                              sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of
+                                            label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values, a
+                                              key, and an operator that relates the
+                                              key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that
+                                                  the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and
+                                                  DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This
+                                                  array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is
+                                            "In", and the values array contains only
+                                            "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the pods
+                                        matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as running
+                                        on a node whose value of the label with key
+                                        topologyKey matches that of any node on which
+                                        any of the selected pods is running. Empty topologyKey
+                                        is not allowed.
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding
+                                    podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                                - podAffinityTerm
+                                - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified
+                              by this field are not met at scheduling time, the pod
+                              will not be scheduled onto the node. If the anti-affinity
+                              requirements specified by this field cease to be met at
+                              some point during pod execution (e.g. due to a pod label
+                              update), the system may or may not try to eventually evict
+                              the pod from its node. When there are multiple elements,
+                              the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located is
+                                defined as running on a node whose value of the label
+                                with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If
+                                              the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array
+                                              is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is "In",
+                                        and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches
+                                    that of any node on which any of the selected pods
+                                    is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                                - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations specifies the annotations to attach to
+                      pods the operator creates
+                    type: object
+                  debug:
+                    description: Debug defines a switch enable debug
+                    type: boolean
+                  initContainers:
+                    description: InitContainers defines init containers of the pod.
+                      A typical use case could be using an init container to download
+                      a remote jar to a local path.
+                    items:
+                      description: A single application container that you want to run
+                        within a pod. The Container API from the core group is not used
+                        directly to avoid unneeded fields and reduce the size of the
+                        CRD. New fields could be added as needed.
+                      properties:
+                        args:
+                          description: Arguments to the entrypoint.
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: Entrypoint array. Not executed within a shell.
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the container.
+                          items:
+                            description: EnvVar represents an environment variable present
+                              in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are expanded
+                                  using the previous defined environment variables in
+                                  the container and any service environment variables.
+                                  If a variable cannot be resolved, the reference in
+                                  the input string will be unchanged. The $(VAR_NAME)
+                                  syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                  Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's value.
+                                  Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                      - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for volumes,
+                                          optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                      - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the pod's
+                                      namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its
+                                          key must be defined
+                                        type: boolean
+                                    required:
+                                      - key
                                     type: object
                                 type: object
-                              storageClassName:
-                                description: 'Name of the StorageClass required by
-                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                                type: string
-                              volumeMode:
-                                description: volumeMode defines what type of volume
-                                  is required by the claim. Value of Filesystem is
-                                  implied when not included in claim spec.
-                                type: string
-                              volumeName:
-                                description: VolumeName is the binding reference to
-                                  the PersistentVolume backing this claim.
-                                type: string
+                            required:
+                              - name
                             type: object
-                          status:
-                            description: 'Status represents the current information/status
-                              of a persistent volume claim. Read-only. More info:
-                              https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          type: array
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container.
+                          items:
+                            description: EnvFromSource represents the source of a set
+                              of ConfigMaps
                             properties:
-                              accessModes:
-                                description: 'AccessModes contains the actual access
-                                  modes the volume backing the PVC has. More info:
-                                  https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                items:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to each
+                                  key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: Docker image name.
+                          type: string
+                        imagePullPolicy:
+                          description: Image pull policy.
+                          type: string
+                        livenessProbe:
+                          description: Periodic probe of container liveness.
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
                                   type: string
-                                type: array
-                              capacity:
-                                additionalProperties:
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
-                                description: Represents the actual resources of the
-                                  underlying volume.
-                                type: object
-                              conditions:
-                                description: Current Condition of persistent volume
-                                  claim. If underlying persistent volume is being
-                                  resized then the Condition will be set to 'ResizeStarted'.
-                                items:
-                                  description: PersistentVolumeClaimCondition contails
-                                    details about state of pvc
-                                  properties:
-                                    lastProbeTime:
-                                      description: Last time we probed the condition.
-                                      format: date-time
-                                      type: string
-                                    lastTransitionTime:
-                                      description: Last time the condition transitioned
-                                        from one status to another.
-                                      format: date-time
-                                      type: string
-                                    message:
-                                      description: Human-readable message indicating
-                                        details about last transition.
-                                      type: string
-                                    reason:
-                                      description: Unique, this should be a short,
-                                        machine understandable string that gives the
-                                        reason for condition's last transition. If
-                                        it reports "ResizeStarted" that means the
-                                        underlying persistent volume is being resized.
-                                      type: string
-                                    status:
-                                      type: string
-                                    type:
-                                      description: PersistentVolumeClaimConditionType
-                                        is a valid value of PersistentVolumeClaimCondition.Type
-                                      type: string
-                                  required:
-                                    - status
-                                    - type
-                                  type: object
-                                type: array
-                              phase:
-                                description: Phase represents the current phase of
-                                  PersistentVolumeClaim.
-                                type: string
-                            type: object
-                        type: object
-                      type: array
-                    volumeMounts:
-                      description: VolumeMounts is a list of volumes to mount into
-                        the container's filesystem. If a non-empty list is specified,
-                        the original values of the main container in the desired STS
-                        will be replaced.
-                      items:
-                        description: VolumeMount describes a mounting of a Volume
-                          within a container.
-                        properties:
-                          mountPath:
-                            description: Path within the container at which the volume
-                              should be mounted.  Must not contain ':'.
-                            type: string
-                          mountPropagation:
-                            description: mountPropagation determines how mounts are
-                              propagated from the host to container and the other
-                              way around. When not set, MountPropagationNone is used.
-                              This field is beta in 1.10.
-                            type: string
-                          name:
-                            description: This must match the Name of a Volume.
-                            type: string
-                          readOnly:
-                            description: Mounted read-only if true, read-write otherwise
-                              (false or unspecified). Defaults to false.
-                            type: boolean
-                          subPath:
-                            description: Path within the volume from which the container's
-                              volume should be mounted. Defaults to "" (volume's root).
-                            type: string
-                          subPathExpr:
-                            description: Expanded path within the volume from which
-                              the container's volume should be mounted. Behaves similarly
-                              to SubPath but environment variable references $(VAR_NAME)
-                              are expanded using the container's environment. Defaults
-                              to "" (volume's root). SubPathExpr and SubPath are mutually
-                              exclusive.
-                            type: string
-                        required:
-                          - mountPath
-                          - name
-                        type: object
-                      type: array
-                  type: object
-                websocketConfigMap:
-                  description: WebSocketConfigMap defines the Pulsar WebSocket ConfigMap
-                    resource template.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                  type: object
-              type: object
-            brokerAddress:
-              description: The address of the broker
-              type: string
-            certSecretName:
-              description: CertSecretName defines the name of the secret that contains
-                the certificate to use in the proxy if the value is not set, then
-                the operator create an certificate automatically if the value is set
-                to be an empty string, then the proxy will not use a certificate otherwise
-                the value should be name of the secret that contains a valid certificate
-                to use in the proxy
-              type: string
-            config:
-              description: Config defines configurations for proxies
-              properties:
-                custom:
-                  additionalProperties:
-                    type: string
-                  description: Custom allows to customize broker configurations directly.
-                  type: object
-                prometheusPlugin:
-                  description: PrometheusPlugin defines the configuration of the Prometheus
-                    servlet plugin which could be used to query the Prometheus cluster
-                    deployed alongside the proxy cluster.
-                  properties:
-                    host:
-                      description: Host defines the host of the Prometheus service
-                      type: string
-                  type: object
-                tls:
-                  description: TLS defines the configuration of TLS in proxies
-                  properties:
-                    certSecretName:
-                      description: CertSecretName defines the name of the secret that
-                        contains the certificate to use the value should be name of
-                        the secret that contains a valid certificate to use in the
-                        proxy
-                      type: string
-                    enabled:
-                      description: Enabled determines whether to enable TLS in proxies
-                        TODO move other TLS related fields here
-                      type: boolean
-                    trustCertsEnabled:
-                      description: TrustCertsEnabled defines whether to enable trust
-                        store
-                      type: boolean
-                  type: object
-              type: object
-            configs:
-              additionalProperties:
-                type: string
-              description: Configs defines custom configurations for proxies
-              type: object
-            configurationStoreServers:
-              description: ConfigurationStoreServers defines the configuration store
-                servers address
-              type: string
-            dnsNames:
-              description: A list of service urls this pulsar proxy advertise
-              items:
-                type: string
-              type: array
-            image:
-              description: Image is the container image used to run pulsar proxy pods.
-                default is apachepulsar/pulsar:latest
-              type: string
-            imagePullPolicy:
-              description: Image pull policy, one of Always, Never, IfNotPresent,
-                default to Always.
-              type: string
-            issuerRef:
-              description: IssuerRef is a reference to the issuer for the TLS endpoint.  If
-                the 'kind' field is not set, or set to 'Issuer', an Issuer resource
-                with the given name in the same namespace as the PulsarProxy will
-                be used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
-                with the provided name will be used. The 'name' field in this stanza
-                is required at all times. The group field refers to the API group
-                of the issuer which defaults to 'cert-manager.io' if empty.
-              properties:
-                group:
-                  type: string
-                kind:
-                  type: string
-                name:
-                  type: string
-              required:
-                - name
-              type: object
-            labels:
-              additionalProperties:
-                type: string
-              description: Labels specifies the labels to attach to the stateful set
-                created by operator for pulsar proxy
-              type: object
-            pod:
-              description: Pod defines the policy for creating a proxy pod
-              properties:
-                affinity:
-                  description: Affinity specifies the scheduling constraints of a
-                    pod
-                  properties:
-                    nodeAffinity:
-                      description: Describes node affinity scheduling rules for the
-                        pod.
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods
-                            to nodes that satisfy the affinity expressions specified
-                            by this field, but it may choose a node that violates
-                            one or more of the expressions. The node that is most
-                            preferred is the one with the greatest sum of weights,
-                            i.e. for each node that meets all of the scheduling requirements
-                            (resource request, requiredDuringScheduling affinity expressions,
-                            etc.), compute a sum by iterating through the elements
-                            of this field and adding "weight" to the sum if the node
-                            matches the corresponding matchExpressions; the node(s)
-                            with the highest sum are the most preferred.
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container.
                           items:
-                            description: An empty preferred scheduling term matches
-                              all objects with implicit weight 0 (i.e. it's a no-op).
-                              A null preferred scheduling term matches no objects
-                              (i.e. is also a no-op).
+                            description: ContainerPort represents a network port in
+                              a single container.
                             properties:
-                              preference:
-                                description: A node selector term, associated with
-                                  the corresponding weight.
-                                properties:
-                                  matchExpressions:
-                                    description: A list of node selector requirements
-                                      by node's labels.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    description: A list of node selector requirements
-                                      by node's fields.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              weight:
-                                description: Weight associated with matching the corresponding
-                                  nodeSelectorTerm, in the range 1-100.
+                              containerPort:
+                                description: Number of port to expose on the pod's IP
+                                  address. This must be a valid port number, 0 < x <
+                                  65536.
                                 format: int32
                                 type: integer
-                            required:
-                              - preference
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this
-                            field are not met at scheduling time, the pod will not
-                            be scheduled onto the node. If the affinity requirements
-                            specified by this field cease to be met at some point
-                            during pod execution (e.g. due to an update), the system
-                            may or may not try to eventually evict the pod from its
-                            node.
-                          properties:
-                            nodeSelectorTerms:
-                              description: Required. A list of node selector terms.
-                                The terms are ORed.
-                              items:
-                                description: A null or empty node selector term matches
-                                  no objects. The requirements of them are ANDed.
-                                  The TopologySelectorTerm type implements a subset
-                                  of the NodeSelectorTerm.
-                                properties:
-                                  matchExpressions:
-                                    description: A list of node selector requirements
-                                      by node's labels.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    description: A list of node selector requirements
-                                      by node's fields.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              type: array
-                          required:
-                            - nodeSelectorTerms
-                          type: object
-                      type: object
-                    podAffinity:
-                      description: Describes pod affinity scheduling rules (e.g. co-locate
-                        this pod in the same node, zone, etc. as some other pod(s)).
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods
-                            to nodes that satisfy the affinity expressions specified
-                            by this field, but it may choose a node that violates
-                            one or more of the expressions. The node that is most
-                            preferred is the one with the greatest sum of weights,
-                            i.e. for each node that meets all of the scheduling requirements
-                            (resource request, requiredDuringScheduling affinity expressions,
-                            etc.), compute a sum by iterating through the elements
-                            of this field and adding "weight" to the sum if the node
-                            has pods which matches the corresponding podAffinityTerm;
-                            the node(s) with the highest sum are the most preferred.
-                          items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm
-                              fields are added per-node to find the most preferred
-                              node(s)
-                            properties:
-                              podAffinityTerm:
-                                description: Required. A pod affinity term, associated
-                                  with the corresponding weight.
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified
-                                      namespaces, where co-located is defined as running
-                                      on a node whose value of the label with key
-                                      topologyKey matches that of any node on which
-                                      any of the selected pods is running. Empty topologyKey
-                                      is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              weight:
-                                description: weight associated with matching the corresponding
-                                  podAffinityTerm, in the range 1-100.
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host. If
+                                  specified, this must be a valid port number, 0 < x
+                                  < 65536. If HostNetwork is specified, this must match
+                                  ContainerPort. Most containers do not need this.
                                 format: int32
                                 type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this
-                            field are not met at scheduling time, the pod will not
-                            be scheduled onto the node. If the affinity requirements
-                            specified by this field cease to be met at some point
-                            during pod execution (e.g. due to a pod label update),
-                            the system may or may not try to eventually evict the
-                            pod from its node. When there are multiple elements, the
-                            lists of nodes corresponding to each podAffinityTerm are
-                            intersected, i.e. all terms must be satisfied.
-                          items:
-                            description: Defines a set of pods (namely those matching
-                              the labelSelector relative to the given namespace(s))
-                              that this pod should be co-located (affinity) or not
-                              co-located (anti-affinity) with, where co-located is
-                              defined as running on a node whose value of the label
-                              with key <topologyKey> matches that of any node on which
-                              a pod of the set of pods is running
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                              - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                    podAntiAffinity:
-                      description: Describes pod anti-affinity scheduling rules (e.g.
-                        avoid putting this pod in the same node, zone, etc. as some
-                        other pod(s)).
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods
-                            to nodes that satisfy the anti-affinity expressions specified
-                            by this field, but it may choose a node that violates
-                            one or more of the expressions. The node that is most
-                            preferred is the one with the greatest sum of weights,
-                            i.e. for each node that meets all of the scheduling requirements
-                            (resource request, requiredDuringScheduling anti-affinity
-                            expressions, etc.), compute a sum by iterating through
-                            the elements of this field and adding "weight" to the
-                            sum if the node has pods which matches the corresponding
-                            podAffinityTerm; the node(s) with the highest sum are
-                            the most preferred.
-                          items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm
-                              fields are added per-node to find the most preferred
-                              node(s)
-                            properties:
-                              podAffinityTerm:
-                                description: Required. A pod affinity term, associated
-                                  with the corresponding weight.
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified
-                                      namespaces, where co-located is defined as running
-                                      on a node whose value of the label with key
-                                      topologyKey matches that of any node on which
-                                      any of the selected pods is running. Empty topologyKey
-                                      is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              weight:
-                                description: weight associated with matching the corresponding
-                                  podAffinityTerm, in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the anti-affinity requirements specified
-                            by this field are not met at scheduling time, the pod
-                            will not be scheduled onto the node. If the anti-affinity
-                            requirements specified by this field cease to be met at
-                            some point during pod execution (e.g. due to a pod label
-                            update), the system may or may not try to eventually evict
-                            the pod from its node. When there are multiple elements,
-                            the lists of nodes corresponding to each podAffinityTerm
-                            are intersected, i.e. all terms must be satisfied.
-                          items:
-                            description: Defines a set of pods (namely those matching
-                              the labelSelector relative to the given namespace(s))
-                              that this pod should be co-located (affinity) or not
-                              co-located (anti-affinity) with, where co-located is
-                              defined as running on a node whose value of the label
-                              with key <topologyKey> matches that of any node on which
-                              a pod of the set of pods is running
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                              - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                  type: object
-                annotations:
-                  additionalProperties:
-                    type: string
-                  description: Annotations specifies the annotations to attach to
-                    pods the operator creates
-                  type: object
-                debug:
-                  description: Debug defines a switch enable debug
-                  type: boolean
-                initContainers:
-                  description: InitContainers defines init containers of the pod.
-                    A typical use case could be using an init container to download
-                    a remote jar to a local path.
-                  items:
-                    description: A single application container that you want to run
-                      within a pod. The Container API from the core group is not used
-                      directly to avoid unneeded fields and reduce the size of the
-                      CRD. New fields could be added as needed.
-                    properties:
-                      args:
-                        description: Arguments to the entrypoint.
-                        items:
-                          type: string
-                        type: array
-                      command:
-                        description: Entrypoint array. Not executed within a shell.
-                        items:
-                          type: string
-                        type: array
-                      env:
-                        description: List of environment variables to set in the container.
-                        items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
-                          properties:
-                            name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
-                              type: string
-                            value:
-                              description: 'Variable references $(VAR_NAME) are expanded
-                                using the previous defined environment variables in
-                                the container and any service environment variables.
-                                If a variable cannot be resolved, the reference in
-                                the input string will be unchanged. The $(VAR_NAME)
-                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
-                                Escaped references will never be expanded, regardless
-                                of whether the variable exists or not. Defaults to
-                                "".'
-                              type: string
-                            valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
-                              properties:
-                                configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
-                                  properties:
-                                    key:
-                                      description: The key to select.
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
-                                fieldRef:
-                                  description: 'Selects a field of the pod: supports
-                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                    spec.serviceAccountName, status.hostIP, status.podIP,
-                                    status.podIPs.'
-                                  properties:
-                                    apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
-                                      type: string
-                                    fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
-                                      type: string
-                                  required:
-                                    - fieldPath
-                                  type: object
-                                resourceFieldRef:
-                                  description: 'Selects a resource of the container:
-                                    only resources limits and requests (limits.cpu,
-                                    limits.memory, limits.ephemeral-storage, requests.cpu,
-                                    requests.memory and requests.ephemeral-storage)
-                                    are currently supported.'
-                                  properties:
-                                    containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
-                                      type: string
-                                    divisor:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    resource:
-                                      description: 'Required: resource to select'
-                                      type: string
-                                  required:
-                                    - resource
-                                  type: object
-                                secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
-                                  properties:
-                                    key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
-                              type: object
-                          required:
-                            - name
-                          type: object
-                        type: array
-                      envFrom:
-                        description: List of sources to populate environment variables
-                          in the container.
-                        items:
-                          description: EnvFromSource represents the source of a set
-                            of ConfigMaps
-                          properties:
-                            configMapRef:
-                              description: The ConfigMap to select from
-                              properties:
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap must
-                                    be defined
-                                  type: boolean
-                              type: object
-                            prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
-                              type: string
-                            secretRef:
-                              description: The Secret to select from
-                              properties:
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret must be
-                                    defined
-                                  type: boolean
-                              type: object
-                          type: object
-                        type: array
-                      image:
-                        description: Docker image name.
-                        type: string
-                      imagePullPolicy:
-                        description: Image pull policy.
-                        type: string
-                      livenessProbe:
-                        description: Periodic probe of container liveness.
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      name:
-                        description: Name of the container specified as a DNS_LABEL.
-                          Each container in a pod must have a unique name (DNS_LABEL).
-                        type: string
-                      ports:
-                        description: List of ports to expose from the container.
-                        items:
-                          description: ContainerPort represents a network port in
-                            a single container.
-                          properties:
-                            containerPort:
-                              description: Number of port to expose on the pod's IP
-                                address. This must be a valid port number, 0 < x <
-                                65536.
-                              format: int32
-                              type: integer
-                            hostIP:
-                              description: What host IP to bind the external port
-                                to.
-                              type: string
-                            hostPort:
-                              description: Number of port to expose on the host. If
-                                specified, this must be a valid port number, 0 < x
-                                < 65536. If HostNetwork is specified, this must match
-                                ContainerPort. Most containers do not need this.
-                              format: int32
-                              type: integer
-                            name:
-                              description: If specified, this must be an IANA_SVC_NAME
-                                and unique within the pod. Each named port in a pod
-                                must have a unique name. Name for the port that can
-                                be referred to by services.
-                              type: string
-                            protocol:
-                              description: Protocol for port. Must be UDP, TCP, or
-                                SCTP. Defaults to "TCP".
-                              type: string
-                          required:
-                            - containerPort
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                          - containerPort
-                        x-kubernetes-list-type: map
-                      readinessProbe:
-                        description: 'Periodic probe of container service readiness.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      resources:
-                        description: Compute Resources required by this container.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                        type: object
-                      startupProbe:
-                        description: StartupProbe indicates that the Pod has successfully
-                          initialized.
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      volumeMounts:
-                        description: Pod volumes to mount into the container's filesystem.
-                        items:
-                          description: VolumeMount describes a mounting of a Volume
-                            within a container.
-                          properties:
-                            mountPath:
-                              description: Path within the container at which the
-                                volume should be mounted.  Must not contain ':'.
-                              type: string
-                            mountPropagation:
-                              description: mountPropagation determines how mounts
-                                are propagated from the host to container and the
-                                other way around. When not set, MountPropagationNone
-                                is used. This field is beta in 1.10.
-                              type: string
-                            name:
-                              description: This must match the Name of a Volume.
-                              type: string
-                            readOnly:
-                              description: Mounted read-only if true, read-write otherwise
-                                (false or unspecified). Defaults to false.
-                              type: boolean
-                            subPath:
-                              description: Path within the volume from which the container's
-                                volume should be mounted. Defaults to "" (volume's
-                                root).
-                              type: string
-                            subPathExpr:
-                              description: Expanded path within the volume from which
-                                the container's volume should be mounted. Behaves
-                                similarly to SubPath but environment variable references
-                                $(VAR_NAME) are expanded using the container's environment.
-                                Defaults to "" (volume's root). SubPathExpr and SubPath
-                                are mutually exclusive.
-                              type: string
-                          required:
-                            - mountPath
-                            - name
-                          type: object
-                        type: array
-                      workingDir:
-                        description: Container's working directory.
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-                jvmOptions:
-                  description: JvmOptions defines the Jvm options passed to the proxy
-                  properties:
-                    extraOptions:
-                      items:
-                        type: string
-                      type: array
-                    gcLoggingOptions:
-                      items:
-                        type: string
-                      type: array
-                    gcOptions:
-                      items:
-                        type: string
-                      type: array
-                    memoryOptions:
-                      items:
-                        type: string
-                      type: array
-                  required:
-                    - extraOptions
-                    - gcLoggingOptions
-                    - gcOptions
-                    - memoryOptions
-                  type: object
-                labels:
-                  additionalProperties:
-                    type: string
-                  description: Labels specifies the labels to attach to pod the operator
-                    creates for the cluster.
-                  type: object
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  description: NodeSelector specifies a map of key-value pairs. For
-                    a pod to be eligible to run on a node, the node must have each
-                    of the indicated key-value pairs as labels.
-                  type: object
-                resources:
-                  description: Resources specifies the resource requirements of a
-                    pod to run in the cluster
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                secretRefs:
-                  description: SecretRefs defines how to mount required secrets into
-                    containers
-                  items:
-                    properties:
-                      mountPath:
-                        type: string
-                      secretName:
-                        type: string
-                    required:
-                      - mountPath
-                      - secretName
-                    type: object
-                  type: array
-                securityContext:
-                  description: 'SecurityContext specifies the security context for
-                    the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
-                  properties:
-                    fsGroup:
-                      description: "A special supplemental group that applies to all
-                        containers in a pod. Some volume types allow the Kubelet to
-                        change the ownership of that volume to be owned by the pod:
-                        \n 1. The owning GID will be the FSGroup 2. The setgid bit
-                        is set (new files created in the volume will be owned by FSGroup)
-                        3. The permission bits are OR'd with rw-rw---- \n If unset,
-                        the Kubelet will not modify the ownership and permissions
-                        of any volume."
-                      format: int64
-                      type: integer
-                    fsGroupChangePolicy:
-                      description: 'fsGroupChangePolicy defines behavior of changing
-                        ownership and permission of the volume before being exposed
-                        inside Pod. This field will only apply to volume types which
-                        support fsGroup based ownership(and permissions). It will
-                        have no effect on ephemeral volume types such as: secret,
-                        configmaps and emptydir. Valid values are "OnRootMismatch"
-                        and "Always". If not specified defaults to "Always".'
-                      type: string
-                    runAsGroup:
-                      description: The GID to run the entrypoint of the container
-                        process. Uses runtime default if unset. May also be set in
-                        SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence for
-                        that container.
-                      format: int64
-                      type: integer
-                    runAsNonRoot:
-                      description: Indicates that the container must run as a non-root
-                        user. If true, the Kubelet will validate the image at runtime
-                        to ensure that it does not run as UID 0 (root) and fail to
-                        start the container if it does. If unset or false, no such
-                        validation will be performed. May also be set in SecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence.
-                      type: boolean
-                    runAsUser:
-                      description: The UID to run the entrypoint of the container
-                        process. Defaults to user specified in image metadata if unspecified.
-                        May also be set in SecurityContext.  If set in both SecurityContext
-                        and PodSecurityContext, the value specified in SecurityContext
-                        takes precedence for that container.
-                      format: int64
-                      type: integer
-                    seLinuxOptions:
-                      description: The SELinux context to be applied to all containers.
-                        If unspecified, the container runtime will allocate a random
-                        SELinux context for each container.  May also be set in SecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence for that container.
-                      properties:
-                        level:
-                          description: Level is SELinux level label that applies to
-                            the container.
-                          type: string
-                        role:
-                          description: Role is a SELinux role label that applies to
-                            the container.
-                          type: string
-                        type:
-                          description: Type is a SELinux type label that applies to
-                            the container.
-                          type: string
-                        user:
-                          description: User is a SELinux user label that applies to
-                            the container.
-                          type: string
-                      type: object
-                    seccompProfile:
-                      description: The seccomp options to use by the containers in
-                        this pod.
-                      properties:
-                        localhostProfile:
-                          description: localhostProfile indicates a profile defined
-                            in a file on the node should be used. The profile must
-                            be preconfigured on the node to work. Must be a descending
-                            path, relative to the kubelet's configured seccomp profile
-                            location. Must only be set if type is "Localhost".
-                          type: string
-                        type:
-                          description: "type indicates which kind of seccomp profile
-                            will be applied. Valid options are: \n Localhost - a profile
-                            defined in a file on the node should be used. RuntimeDefault
-                            - the container runtime default profile should be used.
-                            Unconfined - no profile should be applied."
-                          type: string
-                      required:
-                        - type
-                      type: object
-                    supplementalGroups:
-                      description: A list of groups applied to the first process run
-                        in each container, in addition to the container's primary
-                        GID.  If unspecified, no groups will be added to any container.
-                      items:
-                        format: int64
-                        type: integer
-                      type: array
-                    sysctls:
-                      description: Sysctls hold a list of namespaced sysctls used
-                        for the pod. Pods with unsupported sysctls (by the container
-                        runtime) might fail to launch.
-                      items:
-                        description: Sysctl defines a kernel parameter to be set
-                        properties:
-                          name:
-                            description: Name of a property to set
-                            type: string
-                          value:
-                            description: Value of a property to set
-                            type: string
-                        required:
-                          - name
-                          - value
-                        type: object
-                      type: array
-                    windowsOptions:
-                      description: The Windows specific settings applied to all containers.
-                        If unspecified, the options within a container's SecurityContext
-                        will be used. If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence.
-                      properties:
-                        gmsaCredentialSpec:
-                          description: GMSACredentialSpec is where the GMSA admission
-                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                            inlines the contents of the GMSA credential spec named
-                            by the GMSACredentialSpecName field.
-                          type: string
-                        gmsaCredentialSpecName:
-                          description: GMSACredentialSpecName is the name of the GMSA
-                            credential spec to use.
-                          type: string
-                        runAsUserName:
-                          description: The UserName in Windows to run the entrypoint
-                            of the container process. Defaults to the user specified
-                            in image metadata if unspecified. May also be set in PodSecurityContext.
-                            If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
-                          type: string
-                      type: object
-                  type: object
-                serviceAccountName:
-                  description: ServiceAccountName is the name of the ServiceAccount
-                    to use to run this pod.
-                  type: string
-                sidecars:
-                  description: Sidecars defines sidecar containers running alongside
-                    with the main function container in the pod.
-                  items:
-                    description: A single application container that you want to run
-                      within a pod. The Container API from the core group is not used
-                      directly to avoid unneeded fields and reduce the size of the
-                      CRD. New fields could be added as needed.
-                    properties:
-                      args:
-                        description: Arguments to the entrypoint.
-                        items:
-                          type: string
-                        type: array
-                      command:
-                        description: Entrypoint array. Not executed within a shell.
-                        items:
-                          type: string
-                        type: array
-                      env:
-                        description: List of environment variables to set in the container.
-                        items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
-                          properties:
-                            name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
-                              type: string
-                            value:
-                              description: 'Variable references $(VAR_NAME) are expanded
-                                using the previous defined environment variables in
-                                the container and any service environment variables.
-                                If a variable cannot be resolved, the reference in
-                                the input string will be unchanged. The $(VAR_NAME)
-                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
-                                Escaped references will never be expanded, regardless
-                                of whether the variable exists or not. Defaults to
-                                "".'
-                              type: string
-                            valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
-                              properties:
-                                configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
-                                  properties:
-                                    key:
-                                      description: The key to select.
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
-                                fieldRef:
-                                  description: 'Selects a field of the pod: supports
-                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                    spec.serviceAccountName, status.hostIP, status.podIP,
-                                    status.podIPs.'
-                                  properties:
-                                    apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
-                                      type: string
-                                    fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
-                                      type: string
-                                  required:
-                                    - fieldPath
-                                  type: object
-                                resourceFieldRef:
-                                  description: 'Selects a resource of the container:
-                                    only resources limits and requests (limits.cpu,
-                                    limits.memory, limits.ephemeral-storage, requests.cpu,
-                                    requests.memory and requests.ephemeral-storage)
-                                    are currently supported.'
-                                  properties:
-                                    containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
-                                      type: string
-                                    divisor:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    resource:
-                                      description: 'Required: resource to select'
-                                      type: string
-                                  required:
-                                    - resource
-                                  type: object
-                                secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
-                                  properties:
-                                    key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
-                              type: object
-                          required:
-                            - name
-                          type: object
-                        type: array
-                      envFrom:
-                        description: List of sources to populate environment variables
-                          in the container.
-                        items:
-                          description: EnvFromSource represents the source of a set
-                            of ConfigMaps
-                          properties:
-                            configMapRef:
-                              description: The ConfigMap to select from
-                              properties:
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap must
-                                    be defined
-                                  type: boolean
-                              type: object
-                            prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
-                              type: string
-                            secretRef:
-                              description: The Secret to select from
-                              properties:
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret must be
-                                    defined
-                                  type: boolean
-                              type: object
-                          type: object
-                        type: array
-                      image:
-                        description: Docker image name.
-                        type: string
-                      imagePullPolicy:
-                        description: Image pull policy.
-                        type: string
-                      livenessProbe:
-                        description: Periodic probe of container liveness.
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      name:
-                        description: Name of the container specified as a DNS_LABEL.
-                          Each container in a pod must have a unique name (DNS_LABEL).
-                        type: string
-                      ports:
-                        description: List of ports to expose from the container.
-                        items:
-                          description: ContainerPort represents a network port in
-                            a single container.
-                          properties:
-                            containerPort:
-                              description: Number of port to expose on the pod's IP
-                                address. This must be a valid port number, 0 < x <
-                                65536.
-                              format: int32
-                              type: integer
-                            hostIP:
-                              description: What host IP to bind the external port
-                                to.
-                              type: string
-                            hostPort:
-                              description: Number of port to expose on the host. If
-                                specified, this must be a valid port number, 0 < x
-                                < 65536. If HostNetwork is specified, this must match
-                                ContainerPort. Most containers do not need this.
-                              format: int32
-                              type: integer
-                            name:
-                              description: If specified, this must be an IANA_SVC_NAME
-                                and unique within the pod. Each named port in a pod
-                                must have a unique name. Name for the port that can
-                                be referred to by services.
-                              type: string
-                            protocol:
-                              description: Protocol for port. Must be UDP, TCP, or
-                                SCTP. Defaults to "TCP".
-                              type: string
-                          required:
-                            - containerPort
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                          - containerPort
-                        x-kubernetes-list-type: map
-                      readinessProbe:
-                        description: 'Periodic probe of container service readiness.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      resources:
-                        description: Compute Resources required by this container.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                        type: object
-                      startupProbe:
-                        description: StartupProbe indicates that the Pod has successfully
-                          initialized.
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      volumeMounts:
-                        description: Pod volumes to mount into the container's filesystem.
-                        items:
-                          description: VolumeMount describes a mounting of a Volume
-                            within a container.
-                          properties:
-                            mountPath:
-                              description: Path within the container at which the
-                                volume should be mounted.  Must not contain ':'.
-                              type: string
-                            mountPropagation:
-                              description: mountPropagation determines how mounts
-                                are propagated from the host to container and the
-                                other way around. When not set, MountPropagationNone
-                                is used. This field is beta in 1.10.
-                              type: string
-                            name:
-                              description: This must match the Name of a Volume.
-                              type: string
-                            readOnly:
-                              description: Mounted read-only if true, read-write otherwise
-                                (false or unspecified). Defaults to false.
-                              type: boolean
-                            subPath:
-                              description: Path within the volume from which the container's
-                                volume should be mounted. Defaults to "" (volume's
-                                root).
-                              type: string
-                            subPathExpr:
-                              description: Expanded path within the volume from which
-                                the container's volume should be mounted. Behaves
-                                similarly to SubPath but environment variable references
-                                $(VAR_NAME) are expanded using the container's environment.
-                                Defaults to "" (volume's root). SubPathExpr and SubPath
-                                are mutually exclusive.
-                              type: string
-                          required:
-                            - mountPath
-                            - name
-                          type: object
-                        type: array
-                      workingDir:
-                        description: Container's working directory.
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-                terminationGracePeriodSeconds:
-                  description: TerminationGracePeriodSeconds is the amount of time
-                    that kubernetes will give for a pod before terminating it.
-                  format: int64
-                  type: integer
-                tolerations:
-                  description: Tolerations specifies the tolerations of a Pod
-                  items:
-                    description: The pod this Toleration is attached to tolerates
-                      any taint that matches the triple <key,value,effect> using the
-                      matching operator <operator>.
-                    properties:
-                      effect:
-                        description: Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match
-                          all values and all keys.
-                        type: string
-                      operator:
-                        description: Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to
-                          Equal. Exists is equivalent to wildcard for value, so that
-                          a pod can tolerate all taints of a particular category.
-                        type: string
-                      tolerationSeconds:
-                        description: TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default,
-                          it is not set, which means tolerate the taint forever (do
-                          not evict). Zero and negative values will be treated as
-                          0 (evict immediately) by the system.
-                        format: int64
-                        type: integer
-                      value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
-                        type: string
-                    type: object
-                  type: array
-                vars:
-                  description: Vars specifies the environment variables of a Pod
-                  items:
-                    description: EnvVar represents an environment variable present
-                      in a Container.
-                    properties:
-                      name:
-                        description: Name of the environment variable. Must be a C_IDENTIFIER.
-                        type: string
-                      value:
-                        description: 'Variable references $(VAR_NAME) are expanded
-                          using the previous defined environment variables in the
-                          container and any service environment variables. If a variable
-                          cannot be resolved, the reference in the input string will
-                          be unchanged. The $(VAR_NAME) syntax can be escaped with
-                          a double $$, ie: $$(VAR_NAME). Escaped references will never
-                          be expanded, regardless of whether the variable exists or
-                          not. Defaults to "".'
-                        type: string
-                      valueFrom:
-                        description: Source for the environment variable's value.
-                          Cannot be used if value is not empty.
-                        properties:
-                          configMapKeyRef:
-                            description: Selects a key of a ConfigMap.
-                            properties:
-                              key:
-                                description: The key to select.
-                                type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a pod
+                                  must have a unique name. Name for the port that can
+                                  be referred to by services.
                                 type: string
-                              optional:
-                                description: Specify whether the ConfigMap or its
-                                  key must be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                          fieldRef:
-                            description: 'Selects a field of the pod: supports metadata.name,
-                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                              spec.nodeName, spec.serviceAccountName, status.hostIP,
-                              status.podIP, status.podIPs.'
-                            properties:
-                              apiVersion:
-                                description: Version of the schema the FieldPath is
-                                  written in terms of, defaults to "v1".
-                                type: string
-                              fieldPath:
-                                description: Path of the field to select in the specified
-                                  API version.
+                              protocol:
+                                description: Protocol for port. Must be UDP, TCP, or
+                                  SCTP. Defaults to "TCP".
                                 type: string
                             required:
-                              - fieldPath
+                              - containerPort
                             type: object
-                          resourceFieldRef:
-                            description: 'Selects a resource of the container: only
-                              resources limits and requests (limits.cpu, limits.memory,
-                              limits.ephemeral-storage, requests.cpu, requests.memory
-                              and requests.ephemeral-storage) are currently supported.'
-                            properties:
-                              containerName:
-                                description: 'Container name: required for volumes,
-                                  optional for env vars'
-                                type: string
-                              divisor:
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - containerPort
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: Compute Resources required by this container.
+                          properties:
+                            limits:
+                              additionalProperties:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Specifies the output format of the exposed
-                                  resources, defaults to "1"
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              resource:
-                                description: 'Required: resource to select'
-                                type: string
-                            required:
-                              - resource
-                            type: object
-                          secretKeyRef:
-                            description: Selects a key of a secret in the pod's namespace
+                              description: 'Limits describes the maximum amount of compute
+                                resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of
+                                compute resources required. If Requests is omitted for
+                                a container, it defaults to Limits if that is explicitly
+                                specified, otherwise to an implementation-defined value.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: StartupProbe indicates that the Pod has successfully
+                            initialized.
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
                             properties:
-                              key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: This must match the Name of a Volume.
                                 type: string
-                              optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
+                              readOnly:
+                                description: Mounted read-only if true, read-write otherwise
+                                  (false or unspecified). Defaults to false.
                                 type: boolean
+                              subPath:
+                                description: Path within the volume from which the container's
+                                  volume should be mounted. Defaults to "" (volume's
+                                  root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from which
+                                  the container's volume should be mounted. Behaves
+                                  similarly to SubPath but environment variable references
+                                  $(VAR_NAME) are expanded using the container's environment.
+                                  Defaults to "" (volume's root). SubPathExpr and SubPath
+                                  are mutually exclusive.
+                                type: string
                             required:
-                              - key
+                              - mountPath
+                              - name
                             type: object
-                        type: object
-                    required:
-                      - name
-                    type: object
-                  type: array
-                volumes:
-                  description: Volumes defines extra volumes of the pod.
-                  items:
-                    description: Volume represents a named volume in a pod that may
-                      be accessed by any container in the pod. The Volume API from
-                      the core group is not used directly to avoid unneeded fields
-                      defined in `VolumeSource` and reduce the size of the CRD. New
-                      fields in VolumeSource could be added as needed.
+                          type: array
+                        workingDir:
+                          description: Container's working directory.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    type: array
+                  jvmOptions:
+                    description: JvmOptions defines the Jvm options passed to the proxy
                     properties:
-                      configMap:
-                        description: ConfigMap represents a configMap that should
-                          populate this volume
-                        properties:
-                          defaultMode:
-                            description: 'Optional: mode bits used to set permissions
-                              on created files by default. Must be an octal value
-                              between 0000 and 0777 or a decimal value between 0 and
-                              511. YAML accepts both octal and decimal values, JSON
-                              requires decimal values for mode bits. Defaults to 0644.
-                              Directories within the path are not affected by this
-                              setting. This might be in conflict with other options
-                              that affect the file mode, like fsGroup, and the result
-                              can be other mode bits set.'
-                            format: int32
-                            type: integer
-                          items:
-                            description: If unspecified, each key-value pair in the
-                              Data field of the referenced ConfigMap will be projected
-                              into the volume as a file whose name is the key and
-                              content is the value. If specified, the listed keys
-                              will be projected into the specified paths, and unlisted
-                              keys will not be present. If a key is specified which
-                              is not present in the ConfigMap, the volume setup will
-                              error unless it is marked optional. Paths must be relative
-                              and may not contain the '..' path or start with '..'.
-                            items:
-                              description: Maps a string key to a path within a volume.
-                              properties:
-                                key:
-                                  description: The key to project.
-                                  type: string
-                                mode:
-                                  description: 'Optional: mode bits used to set permissions
-                                    on this file. Must be an octal value between 0000
-                                    and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON
-                                    requires decimal values for mode bits. If not
-                                    specified, the volume defaultMode will be used.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
-                                  format: int32
-                                  type: integer
-                                path:
-                                  description: The relative path of the file to map
-                                    the key to. May not be an absolute path. May not
-                                    contain the path element '..'. May not start with
-                                    the string '..'.
-                                  type: string
-                              required:
-                                - key
-                                - path
-                              type: object
-                            type: array
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                          optional:
-                            description: Specify whether the ConfigMap or its keys
-                              must be defined
-                            type: boolean
-                        type: object
-                      name:
-                        description: 'Volume''s name. Must be a DNS_LABEL and unique
-                          within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      secret:
-                        description: Secret represents a secret that should populate
-                          this volume.
-                        properties:
-                          defaultMode:
-                            description: 'Optional: mode bits used to set permissions
-                              on created files by default. Must be an octal value
-                              between 0000 and 0777 or a decimal value between 0 and
-                              511. YAML accepts both octal and decimal values, JSON
-                              requires decimal values for mode bits. Defaults to 0644.
-                              Directories within the path are not affected by this
-                              setting. This might be in conflict with other options
-                              that affect the file mode, like fsGroup, and the result
-                              can be other mode bits set.'
-                            format: int32
-                            type: integer
-                          items:
-                            description: If unspecified, each key-value pair in the
-                              Data field of the referenced Secret will be projected
-                              into the volume as a file whose name is the key and
-                              content is the value. If specified, the listed keys
-                              will be projected into the specified paths, and unlisted
-                              keys will not be present. If a key is specified which
-                              is not present in the Secret, the volume setup will
-                              error unless it is marked optional. Paths must be relative
-                              and may not contain the '..' path or start with '..'.
-                            items:
-                              description: Maps a string key to a path within a volume.
-                              properties:
-                                key:
-                                  description: The key to project.
-                                  type: string
-                                mode:
-                                  description: 'Optional: mode bits used to set permissions
-                                    on this file. Must be an octal value between 0000
-                                    and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON
-                                    requires decimal values for mode bits. If not
-                                    specified, the volume defaultMode will be used.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
-                                  format: int32
-                                  type: integer
-                                path:
-                                  description: The relative path of the file to map
-                                    the key to. May not be an absolute path. May not
-                                    contain the path element '..'. May not start with
-                                    the string '..'.
-                                  type: string
-                              required:
-                                - key
-                                - path
-                              type: object
-                            type: array
-                          optional:
-                            description: Specify whether the Secret or its keys must
-                              be defined
-                            type: boolean
-                          secretName:
-                            description: 'Name of the secret in the pod''s namespace
-                              to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                            type: string
-                        type: object
+                      extraOptions:
+                        items:
+                          type: string
+                        type: array
+                      gcLoggingOptions:
+                        items:
+                          type: string
+                        type: array
+                      gcOptions:
+                        items:
+                          type: string
+                        type: array
+                      memoryOptions:
+                        items:
+                          type: string
+                        type: array
                     required:
-                      - name
+                      - extraOptions
+                      - gcLoggingOptions
+                      - gcOptions
+                      - memoryOptions
                     type: object
-                  type: array
-              type: object
-            replicas:
-              description: Replicas is the expected size of the pulsar proxy
-              format: int32
-              type: integer
-            webSocketServiceEnabled:
-              description: WebSocketServiceEnabled defines whether WebSocket will
-                be enabled
-              type: boolean
-          required:
-            - brokerAddress
-            - dnsNames
-            - issuerRef
-          type: object
-        status:
-          description: PulsarProxyStatus defines the observed state of PulsarProxy
-          properties:
-            conditions:
-              additionalProperties:
-                description: The `Status` of a given `Condition` and the `Action`
-                  needed to reach the `Status`
-                properties:
-                  action:
-                    description: The action needed to advance components to ready
-                      status
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels specifies the labels to attach to pod the operator
+                      creates for the cluster.
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector specifies a map of key-value pairs. For
+                      a pod to be eligible to run on a node, the node must have each
+                      of the indicated key-value pairs as labels.
+                    type: object
+                  resources:
+                    description: Resources specifies the resource requirements of a
+                      pod to run in the cluster
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  secretRefs:
+                    description: SecretRefs defines how to mount required secrets into
+                      containers
+                    items:
+                      properties:
+                        mountPath:
+                          type: string
+                        secretName:
+                          type: string
+                      required:
+                        - mountPath
+                        - secretName
+                      type: object
+                    type: array
+                  securityContext:
+                    description: 'SecurityContext specifies the security context for
+                      the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
+                    properties:
+                      fsGroup:
+                        description: "A special supplemental group that applies to all
+                          containers in a pod. Some volume types allow the Kubelet to
+                          change the ownership of that volume to be owned by the pod:
+                          \n 1. The owning GID will be the FSGroup 2. The setgid bit
+                          is set (new files created in the volume will be owned by FSGroup)
+                          3. The permission bits are OR'd with rw-rw---- \n If unset,
+                          the Kubelet will not modify the ownership and permissions
+                          of any volume."
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        description: 'fsGroupChangePolicy defines behavior of changing
+                          ownership and permission of the volume before being exposed
+                          inside Pod. This field will only apply to volume types which
+                          support fsGroup based ownership(and permissions). It will
+                          have no effect on ephemeral volume types such as: secret,
+                          configmaps and emptydir. Valid values are "OnRootMismatch"
+                          and "Always". If not specified defaults to "Always".'
+                        type: string
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set in
+                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence for
+                          that container.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail to
+                          start the container if it does. If unset or false, no such
+                          validation will be performed. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if unspecified.
+                          May also be set in SecurityContext.  If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies to
+                              the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies to
+                              the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies to
+                              the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies to
+                              the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by the containers in
+                          this pod.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a profile
+                              defined in a file on the node should be used. RuntimeDefault
+                              - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied."
+                            type: string
+                        required:
+                          - type
+                        type: object
+                      supplementalGroups:
+                        description: A list of groups applied to the first process run
+                          in each container, in addition to the container's primary
+                          GID.  If unspecified, no groups will be added to any container.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used
+                          for the pod. Pods with unsupported sysctls (by the container
+                          runtime) might fail to launch.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                            - name
+                            - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        description: The Windows specific settings applied to all containers.
+                          If unspecified, the options within a container's SecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the GMSA
+                              credential spec to use.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in PodSecurityContext.
+                              If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  serviceAccountName:
+                    description: ServiceAccountName is the name of the ServiceAccount
+                      to use to run this pod.
                     type: string
-                  condition:
-                    type: string
-                  status:
-                    type: string
-                required:
-                  - action
-                  - condition
-                  - status
+                  sidecars:
+                    description: Sidecars defines sidecar containers running alongside
+                      with the main function container in the pod.
+                    items:
+                      description: A single application container that you want to run
+                        within a pod. The Container API from the core group is not used
+                        directly to avoid unneeded fields and reduce the size of the
+                        CRD. New fields could be added as needed.
+                      properties:
+                        args:
+                          description: Arguments to the entrypoint.
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: Entrypoint array. Not executed within a shell.
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the container.
+                          items:
+                            description: EnvVar represents an environment variable present
+                              in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are expanded
+                                  using the previous defined environment variables in
+                                  the container and any service environment variables.
+                                  If a variable cannot be resolved, the reference in
+                                  the input string will be unchanged. The $(VAR_NAME)
+                                  syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                  Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's value.
+                                  Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                      - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for volumes,
+                                          optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                      - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the pod's
+                                      namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its
+                                          key must be defined
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                type: object
+                            required:
+                              - name
+                            type: object
+                          type: array
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container.
+                          items:
+                            description: EnvFromSource represents the source of a set
+                              of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to each
+                                  key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: Docker image name.
+                          type: string
+                        imagePullPolicy:
+                          description: Image pull policy.
+                          type: string
+                        livenessProbe:
+                          description: Periodic probe of container liveness.
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's IP
+                                  address. This must be a valid port number, 0 < x <
+                                  65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host. If
+                                  specified, this must be a valid port number, 0 < x
+                                  < 65536. If HostNetwork is specified, this must match
+                                  ContainerPort. Most containers do not need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a pod
+                                  must have a unique name. Name for the port that can
+                                  be referred to by services.
+                                type: string
+                              protocol:
+                                description: Protocol for port. Must be UDP, TCP, or
+                                  SCTP. Defaults to "TCP".
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - containerPort
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: Compute Resources required by this container.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute
+                                resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of
+                                compute resources required. If Requests is omitted for
+                                a container, it defaults to Limits if that is explicitly
+                                specified, otherwise to an implementation-defined value.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: StartupProbe indicates that the Pod has successfully
+                            initialized.
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write otherwise
+                                  (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the container's
+                                  volume should be mounted. Defaults to "" (volume's
+                                  root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from which
+                                  the container's volume should be mounted. Behaves
+                                  similarly to SubPath but environment variable references
+                                  $(VAR_NAME) are expanded using the container's environment.
+                                  Defaults to "" (volume's root). SubPathExpr and SubPath
+                                  are mutually exclusive.
+                                type: string
+                            required:
+                              - mountPath
+                              - name
+                            type: object
+                          type: array
+                        workingDir:
+                          description: Container's working directory.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    type: array
+                  terminationGracePeriodSeconds:
+                    description: TerminationGracePeriodSeconds is the amount of time
+                      that kubernetes will give for a pod before terminating it.
+                    format: int64
+                    type: integer
+                  tolerations:
+                    description: Tolerations specifies the tolerations of a Pod
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using the
+                        matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty
+                            means match all taint effects. When specified, allowed values
+                            are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the
+                            value. Valid operators are Exists and Equal. Defaults to
+                            Equal. Exists is equivalent to wildcard for value, so that
+                            a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time
+                            the toleration (which must be of effect NoExecute, otherwise
+                            this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do
+                            not evict). Zero and negative values will be treated as
+                            0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  vars:
+                    description: Vars specifies the environment variables of a Pod
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a variable
+                            cannot be resolved, the reference in the input string will
+                            be unchanged. The $(VAR_NAME) syntax can be escaped with
+                            a double $$, ie: $$(VAR_NAME). Escaped references will never
+                            be expanded, regardless of whether the variable exists or
+                            not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP,
+                                status.podIP, status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath is
+                                    written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the specified
+                                    API version.
+                                  type: string
+                              required:
+                                - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Specifies the output format of the exposed
+                                    resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                                - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                          type: object
+                      required:
+                        - name
+                      type: object
+                    type: array
+                  volumes:
+                    description: Volumes defines extra volumes of the pod.
+                    items:
+                      description: Volume represents a named volume in a pod that may
+                        be accessed by any container in the pod. The Volume API from
+                        the core group is not used directly to avoid unneeded fields
+                        defined in `VolumeSource` and reduce the size of the CRD. New
+                        fields in VolumeSource could be added as needed.
+                      properties:
+                        configMap:
+                          description: ConfigMap represents a configMap that should
+                            populate this volume
+                          properties:
+                            defaultMode:
+                              description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0 and
+                                511. YAML accepts both octal and decimal values, JSON
+                                requires decimal values for mode bits. Defaults to 0644.
+                                Directories within the path are not affected by this
+                                setting. This might be in conflict with other options
+                                that affect the file mode, like fsGroup, and the result
+                                can be other mode bits set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: If unspecified, each key-value pair in the
+                                Data field of the referenced ConfigMap will be projected
+                                into the volume as a file whose name is the key and
+                                content is the value. If specified, the listed keys
+                                will be projected into the specified paths, and unlisted
+                                keys will not be present. If a key is specified which
+                                is not present in the ConfigMap, the volume setup will
+                                error unless it is marked optional. Paths must be relative
+                                and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a volume.
+                                properties:
+                                  key:
+                                    description: The key to project.
+                                    type: string
+                                  mode:
+                                    description: 'Optional: mode bits used to set permissions
+                                      on this file. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON
+                                      requires decimal values for mode bits. If not
+                                      specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that
+                                      affect the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: The relative path of the file to map
+                                      the key to. May not be an absolute path. May not
+                                      contain the path element '..'. May not start with
+                                      the string '..'.
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                type: object
+                              type: array
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its keys
+                                must be defined
+                              type: boolean
+                          type: object
+                        name:
+                          description: 'Volume''s name. Must be a DNS_LABEL and unique
+                            within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        secret:
+                          description: Secret represents a secret that should populate
+                            this volume.
+                          properties:
+                            defaultMode:
+                              description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0 and
+                                511. YAML accepts both octal and decimal values, JSON
+                                requires decimal values for mode bits. Defaults to 0644.
+                                Directories within the path are not affected by this
+                                setting. This might be in conflict with other options
+                                that affect the file mode, like fsGroup, and the result
+                                can be other mode bits set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: If unspecified, each key-value pair in the
+                                Data field of the referenced Secret will be projected
+                                into the volume as a file whose name is the key and
+                                content is the value. If specified, the listed keys
+                                will be projected into the specified paths, and unlisted
+                                keys will not be present. If a key is specified which
+                                is not present in the Secret, the volume setup will
+                                error unless it is marked optional. Paths must be relative
+                                and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a volume.
+                                properties:
+                                  key:
+                                    description: The key to project.
+                                    type: string
+                                  mode:
+                                    description: 'Optional: mode bits used to set permissions
+                                      on this file. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON
+                                      requires decimal values for mode bits. If not
+                                      specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that
+                                      affect the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: The relative path of the file to map
+                                      the key to. May not be an absolute path. May not
+                                      contain the path element '..'. May not start with
+                                      the string '..'.
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                type: object
+                              type: array
+                            optional:
+                              description: Specify whether the Secret or its keys must
+                                be defined
+                              type: boolean
+                            secretName:
+                              description: 'Name of the secret in the pod''s namespace
+                                to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              type: string
+                          type: object
+                      required:
+                        - name
+                      type: object
+                    type: array
                 type: object
-              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                of cluster Important: Run "make" to regenerate code after modifying
-                this file'
-              type: object
-            observedGeneration:
-              description: ObservedGeneration is the most recent generation observed
-                for this cluster. It corresponds to the metadata generation, which
-                is updated on mutation by the API Server.
-              format: int64
-              type: integer
-            readyReplicas:
-              description: ReadyReplicas is the number of ready servers in the cluster
-              format: int32
-              type: integer
-            replicas:
-              description: Replicas is the number of servers in the cluster
-              format: int32
-              type: integer
-            updatedReplicas:
-              description: UpdatedReplicas is the number of servers that has been
-                updated to the latest configuration
-              format: int32
-              type: integer
-          required:
-            - conditions
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+              replicas:
+                description: Replicas is the expected size of the pulsar proxy
+                format: int32
+                type: integer
+              webSocketServiceEnabled:
+                description: WebSocketServiceEnabled defines whether WebSocket will
+                  be enabled
+                type: boolean
+            required:
+              - brokerAddress
+              - dnsNames
+              - issuerRef
+            type: object
+          status:
+            description: PulsarProxyStatus defines the observed state of PulsarProxy
+            properties:
+              conditions:
+                additionalProperties:
+                  description: The `Status` of a given `Condition` and the `Action`
+                    needed to reach the `Status`
+                  properties:
+                    action:
+                      description: The action needed to advance components to ready
+                        status
+                      type: string
+                    condition:
+                      type: string
+                    status:
+                      type: string
+                  required:
+                    - action
+                    - condition
+                    - status
+                  type: object
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file'
+                type: object
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  for this cluster. It corresponds to the metadata generation, which
+                  is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: ReadyReplicas is the number of ready servers in the cluster
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the number of servers in the cluster
+                format: int32
+                type: integer
+              updatedReplicas:
+                description: UpdatedReplicas is the number of servers that has been
+                  updated to the latest configuration
+                format: int32
+                type: integer
+            required:
+              - conditions
+            type: object
+        type: object
 status:
   acceptedNames:
     kind: ""

--- a/charts/pulsar-operator/crds/zookeeper.streamnative.io_zookeeperclusters.yaml
+++ b/charts/pulsar-operator/crds/zookeeper.streamnative.io_zookeeperclusters.yaml
@@ -1,6 +1,5 @@
-
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -19,3308 +18,3307 @@ spec:
       - zk
     singular: zookeepercluster
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: ZooKeeperCluster is the Schema for the zookeeperclusters API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: ZooKeeperClusterSpec defines the desired state of ZooKeeperCluster
-          properties:
-            advancedOptions:
-              description: AdvancedOptions contains advancedOptions for additional
-                customization the pod
-              properties:
-                customStartupCommand:
-                  description: CustomStartupCommand defines a custom command to use
-                    for starting up
-                  type: string
-                staticServerList:
-                  description: StaticServerList defines a list of static servers to
-                    be used in the zookeeper config. this overrides the default generated
-                    list of servers
-                  properties:
-                    servers:
-                      description: Servers is the list of zookeeper servers used
-                      items:
-                        properties:
-                          clientAddress:
-                            description: ClientAddress is the address to bind for
-                              client connections, defaults to `0.0.0.0`
-                            type: string
-                          id:
-                            description: ID is the id of this server
-                            type: integer
-                          listeners:
-                            description: Listeners is an array of listeners, must
-                              have at least one listener
-                            items:
-                              properties:
-                                electionPort:
-                                  description: ElectionPort is the port for connecting
-                                    to leader, defaults to 3888
-                                  type: integer
-                                followerPort:
-                                  description: FollowerPort is the port for connecting
-                                    to leader, defaults to 2888
-                                  type: integer
-                                hostname:
-                                  description: Hostname is the name of the listener
-                                  type: string
-                                role:
-                                  description: Role is the type of node this is, options
-                                    are participant or observer, defaults to participant
-                                  type: string
-                              required:
-                                - hostname
-                              type: object
-                            type: array
-                          port:
-                            description: ClientPort is the port to bind for client
-                              connections, defaults to `2181`
-                            type: integer
-                        required:
-                          - id
-                          - listeners
-                        type: object
-                      type: array
-                  required:
-                    - servers
-                  type: object
-              type: object
-            apiObjects:
-              description: APIObjects allows precise control over how components (services,
-                statefulset and so on) should be managed
-              properties:
-                clientService:
-                  description: ClientService defines the Zookeeper Client Service
-                    resource template.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                  type: object
-                configMap:
-                  description: ConfigMap defines the configmap resource template.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                  type: object
-                headlessService:
-                  description: HeadlessService defines the Zookeeper Headless Service
-                    resource template.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                  type: object
-                pdb:
-                  description: PDB defines the podDisruptionBudget resource template.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                  type: object
-                statefulSet:
-                  description: StatefulSet defines the Zookeeper Cluster Statefulset
-                    resource template.
-                  properties:
-                    metadata:
-                      description: 'Standard object''s metadata used to customize
-                        the name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                      type: object
-                    updatePolicy:
-                      description: UpdatePolicy defines which field to update.
-                      items:
-                        description: UpdateMode defines how to update resource.
-                        type: string
-                      type: array
-                    volumeClaimTemplates:
-                      description: VolumeClaimTemplates is a list of claims that pods
-                        are allowed to reference. If a non-empty list is specified,
-                        the original values in the desired STS will be replaced.
-                      items:
-                        description: PersistentVolumeClaim is a user's request for
-                          and claim to a persistent volume
-                        properties:
-                          apiVersion:
-                            description: 'APIVersion defines the versioned schema
-                              of this representation of an object. Servers should
-                              convert recognized schemas to the latest internal value,
-                              and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-                            type: string
-                          kind:
-                            description: 'Kind is a string value representing the
-                              REST resource this object represents. Servers may infer
-                              this from the endpoint the client submits requests to.
-                              Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          metadata:
-                            description: 'Standard object''s metadata. More info:
-                              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                            type: object
-                          spec:
-                            description: 'Spec defines the desired characteristics
-                              of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                            properties:
-                              accessModes:
-                                description: 'AccessModes contains the desired access
-                                  modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                items:
-                                  type: string
-                                type: array
-                              dataSource:
-                                description: 'This field can be used to specify either:
-                                  * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                                  - Beta) * An existing PVC (PersistentVolumeClaim)
-                                  * An existing custom resource/object that implements
-                                  data population (Alpha) In order to use VolumeSnapshot
-                                  object types, the appropriate feature gate must
-                                  be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
-                                  If the provisioner or an external controller can
-                                  support the specified data source, it will create
-                                  a new volume based on the contents of the specified
-                                  data source. If the specified data source is not
-                                  supported, the volume will not be created and the
-                                  failure will be reported as an event. In the future,
-                                  we plan to support more data source types and the
-                                  behavior of the provisioner may change.'
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: ZooKeeperCluster is the Schema for the zookeeperclusters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ZooKeeperClusterSpec defines the desired state of ZooKeeperCluster
+            properties:
+              advancedOptions:
+                description: AdvancedOptions contains advancedOptions for additional
+                  customization the pod
+                properties:
+                  customStartupCommand:
+                    description: CustomStartupCommand defines a custom command to use
+                      for starting up
+                    type: string
+                  staticServerList:
+                    description: StaticServerList defines a list of static servers to
+                      be used in the zookeeper config. this overrides the default generated
+                      list of servers
+                    properties:
+                      servers:
+                        description: Servers is the list of zookeeper servers used
+                        items:
+                          properties:
+                            clientAddress:
+                              description: ClientAddress is the address to bind for
+                                client connections, defaults to `0.0.0.0`
+                              type: string
+                            id:
+                              description: ID is the id of this server
+                              type: integer
+                            listeners:
+                              description: Listeners is an array of listeners, must
+                                have at least one listener
+                              items:
                                 properties:
-                                  apiGroup:
-                                    description: APIGroup is the group for the resource
-                                      being referenced. If APIGroup is not specified,
-                                      the specified Kind must be in the core API group.
-                                      For any other third-party types, APIGroup is
-                                      required.
+                                  electionPort:
+                                    description: ElectionPort is the port for connecting
+                                      to leader, defaults to 3888
+                                    type: integer
+                                  followerPort:
+                                    description: FollowerPort is the port for connecting
+                                      to leader, defaults to 2888
+                                    type: integer
+                                  hostname:
+                                    description: Hostname is the name of the listener
                                     type: string
-                                  kind:
-                                    description: Kind is the type of resource being
-                                      referenced
-                                    type: string
-                                  name:
-                                    description: Name is the name of resource being
-                                      referenced
+                                  role:
+                                    description: Role is the type of node this is, options
+                                      are participant or observer, defaults to participant
                                     type: string
                                 required:
-                                  - kind
-                                  - name
+                                  - hostname
                                 type: object
-                              resources:
-                                description: 'Resources represents the minimum resources
-                                  the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                                properties:
-                                  limits:
-                                    additionalProperties:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    description: 'Limits describes the maximum amount
-                                      of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                    type: object
-                                  requests:
-                                    additionalProperties:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    description: 'Requests describes the minimum amount
-                                      of compute resources required. If Requests is
-                                      omitted for a container, it defaults to Limits
-                                      if that is explicitly specified, otherwise to
-                                      an implementation-defined value. More info:
-                                      https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                    type: object
-                                type: object
-                              selector:
-                                description: A label query over volumes to consider
-                                  for binding.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
+                              type: array
+                            port:
+                              description: ClientPort is the port to bind for client
+                                connections, defaults to `2181`
+                              type: integer
+                          required:
+                            - id
+                            - listeners
+                          type: object
+                        type: array
+                    required:
+                      - servers
+                    type: object
+                type: object
+              apiObjects:
+                description: APIObjects allows precise control over how components (services,
+                  statefulset and so on) should be managed
+                properties:
+                  clientService:
+                    description: ClientService defines the Zookeeper Client Service
+                      resource template.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                    type: object
+                  configMap:
+                    description: ConfigMap defines the configmap resource template.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                    type: object
+                  headlessService:
+                    description: HeadlessService defines the Zookeeper Headless Service
+                      resource template.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                    type: object
+                  pdb:
+                    description: PDB defines the podDisruptionBudget resource template.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                    type: object
+                  statefulSet:
+                    description: StatefulSet defines the Zookeeper Cluster Statefulset
+                      resource template.
+                    properties:
+                      metadata:
+                        description: 'Standard object''s metadata used to customize
+                          the name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        type: object
+                      updatePolicy:
+                        description: UpdatePolicy defines which field to update.
+                        items:
+                          description: UpdateMode defines how to update resource.
+                          type: string
+                        type: array
+                      volumeClaimTemplates:
+                        description: VolumeClaimTemplates is a list of claims that pods
+                          are allowed to reference. If a non-empty list is specified,
+                          the original values in the desired STS will be replaced.
+                        items:
+                          description: PersistentVolumeClaim is a user's request for
+                            and claim to a persistent volume
+                          properties:
+                            apiVersion:
+                              description: 'APIVersion defines the versioned schema
+                                of this representation of an object. Servers should
+                                convert recognized schemas to the latest internal value,
+                                and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                              type: string
+                            kind:
+                              description: 'Kind is a string value representing the
+                                REST resource this object represents. Servers may infer
+                                this from the endpoint the client submits requests to.
+                                Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            metadata:
+                              description: 'Standard object''s metadata. More info:
+                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                              type: object
+                            spec:
+                              description: 'Spec defines the desired characteristics
+                                of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              properties:
+                                accessModes:
+                                  description: 'AccessModes contains the desired access
+                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                  items:
+                                    type: string
+                                  type: array
+                                dataSource:
+                                  description: 'This field can be used to specify either:
+                                    * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                                    - Beta) * An existing PVC (PersistentVolumeClaim)
+                                    * An existing custom resource/object that implements
+                                    data population (Alpha) In order to use VolumeSnapshot
+                                    object types, the appropriate feature gate must
+                                    be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
+                                    If the provisioner or an external controller can
+                                    support the specified data source, it will create
+                                    a new volume based on the contents of the specified
+                                    data source. If the specified data source is not
+                                    supported, the volume will not be created and the
+                                    failure will be reported as an event. In the future,
+                                    we plan to support more data source types and the
+                                    behavior of the provisioner may change.'
+                                  properties:
+                                    apiGroup:
+                                      description: APIGroup is the group for the resource
+                                        being referenced. If APIGroup is not specified,
+                                        the specified Kind must be in the core API group.
+                                        For any other third-party types, APIGroup is
+                                        required.
                                       type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
+                                    kind:
+                                      description: Kind is the type of resource being
+                                        referenced
+                                      type: string
+                                    name:
+                                      description: Name is the name of resource being
+                                        referenced
+                                      type: string
+                                  required:
+                                    - kind
+                                    - name
+                                  type: object
+                                resources:
+                                  description: 'Resources represents the minimum resources
+                                    the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                  properties:
+                                    limits:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: 'Limits describes the maximum amount
+                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      type: object
+                                    requests:
+                                      additionalProperties:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      description: 'Requests describes the minimum amount
+                                        of compute resources required. If Requests is
+                                        omitted for a container, it defaults to Limits
+                                        if that is explicitly specified, otherwise to
+                                        an implementation-defined value. More info:
+                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                      type: object
+                                  type: object
+                                selector:
+                                  description: A label query over volumes to consider
+                                    for binding.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If
+                                              the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array
+                                              is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is "In",
+                                        and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                storageClassName:
+                                  description: 'Name of the StorageClass required by
+                                    the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                  type: string
+                                volumeMode:
+                                  description: volumeMode defines what type of volume
+                                    is required by the claim. Value of Filesystem is
+                                    implied when not included in claim spec.
+                                  type: string
+                                volumeName:
+                                  description: VolumeName is the binding reference to
+                                    the PersistentVolume backing this claim.
+                                  type: string
+                              type: object
+                            status:
+                              description: 'Status represents the current information/status
+                                of a persistent volume claim. Read-only. More info:
+                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              properties:
+                                accessModes:
+                                  description: 'AccessModes contains the actual access
+                                    modes the volume backing the PVC has. More info:
+                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                  items:
+                                    type: string
+                                  type: array
+                                capacity:
+                                  additionalProperties:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: Represents the actual resources of the
+                                    underlying volume.
+                                  type: object
+                                conditions:
+                                  description: Current Condition of persistent volume
+                                    claim. If underlying persistent volume is being
+                                    resized then the Condition will be set to 'ResizeStarted'.
+                                  items:
+                                    description: PersistentVolumeClaimCondition contails
+                                      details about state of pvc
+                                    properties:
+                                      lastProbeTime:
+                                        description: Last time we probed the condition.
+                                        format: date-time
+                                        type: string
+                                      lastTransitionTime:
+                                        description: Last time the condition transitioned
+                                          from one status to another.
+                                        format: date-time
+                                        type: string
+                                      message:
+                                        description: Human-readable message indicating
+                                          details about last transition.
+                                        type: string
+                                      reason:
+                                        description: Unique, this should be a short,
+                                          machine understandable string that gives the
+                                          reason for condition's last transition. If
+                                          it reports "ResizeStarted" that means the
+                                          underlying persistent volume is being resized.
+                                        type: string
+                                      status:
+                                        type: string
+                                      type:
+                                        description: PersistentVolumeClaimConditionType
+                                          is a valid value of PersistentVolumeClaimCondition.Type
+                                        type: string
+                                    required:
+                                      - status
+                                      - type
+                                    type: object
+                                  type: array
+                                phase:
+                                  description: Phase represents the current phase of
+                                    PersistentVolumeClaim.
+                                  type: string
+                              type: object
+                          type: object
+                        type: array
+                      volumeMounts:
+                        description: VolumeMounts is a list of volumes to mount into
+                          the container's filesystem. If a non-empty list is specified,
+                          the original values of the main container in the desired STS
+                          will be replaced.
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
+                          properties:
+                            mountPath:
+                              description: Path within the container at which the volume
+                                should be mounted.  Must not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: mountPropagation determines how mounts are
+                                propagated from the host to container and the other
+                                way around. When not set, MountPropagationNone is used.
+                                This field is beta in 1.10.
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: Mounted read-only if true, read-write otherwise
+                                (false or unspecified). Defaults to false.
+                              type: boolean
+                            subPath:
+                              description: Path within the volume from which the container's
+                                volume should be mounted. Defaults to "" (volume's root).
+                              type: string
+                            subPathExpr:
+                              description: Expanded path within the volume from which
+                                the container's volume should be mounted. Behaves similarly
+                                to SubPath but environment variable references $(VAR_NAME)
+                                are expanded using the container's environment. Defaults
+                                to "" (volume's root). SubPathExpr and SubPath are mutually
+                                exclusive.
+                              type: string
+                          required:
+                            - mountPath
+                            - name
+                          type: object
+                        type: array
+                    type: object
+                type: object
+              conf:
+                description: 'Conf defines the zookeeper configuration. It will be used
+                  for generating the configuration file used by zookeeper process. Deprecated:
+                  use `config`'
+                properties:
+                  custom:
+                    additionalProperties:
+                      type: string
+                    description: Custom accepts other configurations
+                    type: object
+                  globalOutstandingLimit:
+                    description: "GlobalOutstandingLimit limits the number of queued
+                      outstanding requests \n The default value is 100000"
+                    type: integer
+                  initLimit:
+                    description: "InitLimit is the number of ticks that the initial
+                      synchronization phase can take. \n The default value is 10."
+                    type: integer
+                  maxClientCnxns:
+                    description: "MaxClientCnxns limits the maximum number of client
+                      connections. \n The default value is 1000"
+                    type: integer
+                  serverCnxnFactory:
+                    description: "ServerCnxnFactory is the ServerCnxnFactory implementation.
+                      \n The default value is org.apache.zookeeper.server.NettyServerCnxnFactory"
+                    type: string
+                  snapCount:
+                    description: "SnapCount is the number of transactions recorded in
+                      the transaction log before a snapshot can be taken. \n The default
+                      value is 1000000"
+                    type: integer
+                  syncLimit:
+                    description: "SyncLimit is the number of ticks that can pass between
+                      sending a request and getting an acknowledgement \n The default
+                      value is 5."
+                    type: integer
+                  tickTime:
+                    description: "TickTime is the number of milliseconds of each tick.
+                      A tick is the basic time unit used by ZooKeeper, as measured in
+                      milliseconds \n The default value is 2000."
+                    type: integer
+                type: object
+              config:
+                description: Config defines the zookeeper configuration
+                properties:
+                  custom:
+                    additionalProperties:
+                      type: string
+                    description: Custom accepts other configurations
+                    type: object
+                  globalOutstandingLimit:
+                    description: "GlobalOutstandingLimit limits the number of queued
+                      outstanding requests \n The default value is 100000"
+                    type: integer
+                  initLimit:
+                    description: "InitLimit is the number of ticks that the initial
+                      synchronization phase can take. \n The default value is 10."
+                    type: integer
+                  maxClientCnxns:
+                    description: "MaxClientCnxns limits the maximum number of client
+                      connections. \n The default value is 1000"
+                    type: integer
+                  serverCnxnFactory:
+                    description: "ServerCnxnFactory is the ServerCnxnFactory implementation.
+                      \n The default value is org.apache.zookeeper.server.NettyServerCnxnFactory"
+                    type: string
+                  snapCount:
+                    description: "SnapCount is the number of transactions recorded in
+                      the transaction log before a snapshot can be taken. \n The default
+                      value is 1000000"
+                    type: integer
+                  syncLimit:
+                    description: "SyncLimit is the number of ticks that can pass between
+                      sending a request and getting an acknowledgement \n The default
+                      value is 5."
+                    type: integer
+                  tickTime:
+                    description: "TickTime is the number of milliseconds of each tick.
+                      A tick is the basic time unit used by ZooKeeper, as measured in
+                      milliseconds \n The default value is 2000."
+                    type: integer
+                type: object
+              image:
+                description: Image is the container image used to run zookeeper pods.
+                  default is apachepulsar/pulsar:latest
+                type: string
+              imagePullPolicy:
+                description: Image pull policy, one of Always, Never, IfNotPresent,
+                  default to Always.
+                type: string
+              labels:
+                additionalProperties:
+                  type: string
+                description: Labels specifies the labels to attach to the stateful set
+                  the operator creates for the zookeeper cluster.
+                type: object
+              persistence:
+                description: Persistence defines the persistent volume used for the
+                  zookeeper pod
+                properties:
+                  data:
+                    description: Data is the spec to define the data PVC for the container
+                    properties:
+                      accessModes:
+                        description: 'AccessModes contains the desired access modes
+                          the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                        items:
+                          type: string
+                        type: array
+                      dataSource:
+                        description: 'This field can be used to specify either: * An
+                          existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                          - Beta) * An existing PVC (PersistentVolumeClaim) * An existing
+                          custom resource/object that implements data population (Alpha)
+                          In order to use VolumeSnapshot object types, the appropriate
+                          feature gate must be enabled (VolumeSnapshotDataSource or
+                          AnyVolumeDataSource) If the provisioner or an external controller
+                          can support the specified data source, it will create a new
+                          volume based on the contents of the specified data source.
+                          If the specified data source is not supported, the volume
+                          will not be created and the failure will be reported as an
+                          event. In the future, we plan to support more data source
+                          types and the behavior of the provisioner may change.'
+                        properties:
+                          apiGroup:
+                            description: APIGroup is the group for the resource being
+                              referenced. If APIGroup is not specified, the specified
+                              Kind must be in the core API group. For any other third-party
+                              types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                          - kind
+                          - name
+                        type: object
+                      resources:
+                        description: 'Resources represents the minimum resources the
+                          volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute
+                              resources required. If Requests is omitted for a container,
+                              it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. More info:
+                              https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      selector:
+                        description: A label query over volumes to consider for binding.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that relates
+                                the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty. This
+                                    array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      storageClassName:
+                        description: 'Name of the StorageClass required by the claim.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                        type: string
+                      volumeMode:
+                        description: volumeMode defines what type of volume is required
+                          by the claim. Value of Filesystem is implied when not included
+                          in claim spec.
+                        type: string
+                      volumeName:
+                        description: VolumeName is the binding reference to the PersistentVolume
+                          backing this claim.
+                        type: string
+                    type: object
+                  dataLog:
+                    description: DataLog is the spec to define the data-log PVC for
+                      the container
+                    properties:
+                      accessModes:
+                        description: 'AccessModes contains the desired access modes
+                          the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                        items:
+                          type: string
+                        type: array
+                      dataSource:
+                        description: 'This field can be used to specify either: * An
+                          existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                          - Beta) * An existing PVC (PersistentVolumeClaim) * An existing
+                          custom resource/object that implements data population (Alpha)
+                          In order to use VolumeSnapshot object types, the appropriate
+                          feature gate must be enabled (VolumeSnapshotDataSource or
+                          AnyVolumeDataSource) If the provisioner or an external controller
+                          can support the specified data source, it will create a new
+                          volume based on the contents of the specified data source.
+                          If the specified data source is not supported, the volume
+                          will not be created and the failure will be reported as an
+                          event. In the future, we plan to support more data source
+                          types and the behavior of the provisioner may change.'
+                        properties:
+                          apiGroup:
+                            description: APIGroup is the group for the resource being
+                              referenced. If APIGroup is not specified, the specified
+                              Kind must be in the core API group. For any other third-party
+                              types, APIGroup is required.
+                            type: string
+                          kind:
+                            description: Kind is the type of resource being referenced
+                            type: string
+                          name:
+                            description: Name is the name of resource being referenced
+                            type: string
+                        required:
+                          - kind
+                          - name
+                        type: object
+                      resources:
+                        description: 'Resources represents the minimum resources the
+                          volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                        properties:
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                                - type: integer
+                                - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: 'Requests describes the minimum amount of compute
+                              resources required. If Requests is omitted for a container,
+                              it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. More info:
+                              https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                            type: object
+                        type: object
+                      selector:
+                        description: A label query over volumes to consider for binding.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector
+                              requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector
+                                that contains values, a key, and an operator that relates
+                                the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector
+                                    applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship
+                                    to a set of values. Valid operators are In, NotIn,
+                                    Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values.
+                                    If the operator is In or NotIn, the values array
+                                    must be non-empty. If the operator is Exists or
+                                    DoesNotExist, the values array must be empty. This
+                                    array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs.
+                              A single {key,value} in the matchLabels map is equivalent
+                              to an element of matchExpressions, whose key field is
+                              "key", the operator is "In", and the values array contains
+                              only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                      storageClassName:
+                        description: 'Name of the StorageClass required by the claim.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                        type: string
+                      volumeMode:
+                        description: volumeMode defines what type of volume is required
+                          by the claim. Value of Filesystem is implied when not included
+                          in claim spec.
+                        type: string
+                      volumeName:
+                        description: VolumeName is the binding reference to the PersistentVolume
+                          backing this claim.
+                        type: string
+                    type: object
+                  reclaimPolicy:
+                    description: VolumeReclaimPolicy defines how to reclaim PV.
+                    type: string
+                type: object
+              pod:
+                description: Pod defines the policy for creating a zookeeper pod for
+                  the cluster
+                properties:
+                  affinity:
+                    description: Affinity specifies the scheduling constraints of a
+                      pod
+                    properties:
+                      nodeAffinity:
+                        description: Describes node affinity scheduling rules for the
+                          pod.
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling requirements
+                              (resource request, requiredDuringScheduling affinity expressions,
+                              etc.), compute a sum by iterating through the elements
+                              of this field and adding "weight" to the sum if the node
+                              matches the corresponding matchExpressions; the node(s)
+                              with the highest sum are the most preferred.
+                            items:
+                              description: An empty preferred scheduling term matches
+                                all objects with implicit weight 0 (i.e. it's a no-op).
+                                A null preferred scheduling term matches no objects
+                                (i.e. is also a no-op).
+                              properties:
+                                preference:
+                                  description: A node selector term, associated with
+                                    the corresponding weight.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values
+                                              array must be empty. If the operator is
+                                              Gt or Lt, the values array must have a
+                                              single element, which will be interpreted
+                                              as an integer. This array is replaced
+                                              during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values
+                                              array must be empty. If the operator is
+                                              Gt or Lt, the values array must have a
+                                              single element, which will be interpreted
+                                              as an integer. This array is replaced
+                                              during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                weight:
+                                  description: Weight associated with matching the corresponding
+                                    nodeSelectorTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                                - preference
+                                - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this
+                              field are not met at scheduling time, the pod will not
+                              be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to an update), the system
+                              may or may not try to eventually evict the pod from its
+                              node.
+                            properties:
+                              nodeSelectorTerms:
+                                description: Required. A list of node selector terms.
+                                  The terms are ORed.
+                                items:
+                                  description: A null or empty node selector term matches
+                                    no objects. The requirements of them are ANDed.
+                                    The TopologySelectorTerm type implements a subset
+                                    of the NodeSelectorTerm.
+                                  properties:
+                                    matchExpressions:
+                                      description: A list of node selector requirements
+                                        by node's labels.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values
+                                              array must be empty. If the operator is
+                                              Gt or Lt, the values array must have a
+                                              single element, which will be interpreted
+                                              as an integer. This array is replaced
+                                              during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchFields:
+                                      description: A list of node selector requirements
+                                        by node's fields.
+                                      items:
+                                        description: A node selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: The label key that the selector
+                                              applies to.
+                                            type: string
+                                          operator:
+                                            description: Represents a key's relationship
+                                              to a set of values. Valid operators are
+                                              In, NotIn, Exists, DoesNotExist. Gt, and
+                                              Lt.
+                                            type: string
+                                          values:
+                                            description: An array of string values.
+                                              If the operator is In or NotIn, the values
+                                              array must be non-empty. If the operator
+                                              is Exists or DoesNotExist, the values
+                                              array must be empty. If the operator is
+                                              Gt or Lt, the values array must have a
+                                              single element, which will be interpreted
+                                              as an integer. This array is replaced
+                                              during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                  type: object
+                                type: array
+                            required:
+                              - nodeSelectorTerms
+                            type: object
+                        type: object
+                      podAffinity:
+                        description: Describes pod affinity scheduling rules (e.g. co-locate
+                          this pod in the same node, zone, etc. as some other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling requirements
+                              (resource request, requiredDuringScheduling affinity expressions,
+                              etc.), compute a sum by iterating through the elements
+                              of this field and adding "weight" to the sum if the node
+                              has pods which matches the corresponding podAffinityTerm;
+                              the node(s) with the highest sum are the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of
+                                            label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values, a
+                                              key, and an operator that relates the
+                                              key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that
+                                                  the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and
+                                                  DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This
+                                                  array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is
+                                            "In", and the values array contains only
+                                            "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the pods
+                                        matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as running
+                                        on a node whose value of the label with key
+                                        topologyKey matches that of any node on which
+                                        any of the selected pods is running. Empty topologyKey
+                                        is not allowed.
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding
+                                    podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                                - podAffinityTerm
+                                - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the affinity requirements specified by this
+                              field are not met at scheduling time, the pod will not
+                              be scheduled onto the node. If the affinity requirements
+                              specified by this field cease to be met at some point
+                              during pod execution (e.g. due to a pod label update),
+                              the system may or may not try to eventually evict the
+                              pod from its node. When there are multiple elements, the
+                              lists of nodes corresponding to each podAffinityTerm are
+                              intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located is
+                                defined as running on a node whose value of the label
+                                with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If
+                                              the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array
+                                              is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is "In",
+                                        and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches
+                                    that of any node on which any of the selected pods
+                                    is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                                - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                      podAntiAffinity:
+                        description: Describes pod anti-affinity scheduling rules (e.g.
+                          avoid putting this pod in the same node, zone, etc. as some
+                          other pod(s)).
+                        properties:
+                          preferredDuringSchedulingIgnoredDuringExecution:
+                            description: The scheduler will prefer to schedule pods
+                              to nodes that satisfy the anti-affinity expressions specified
+                              by this field, but it may choose a node that violates
+                              one or more of the expressions. The node that is most
+                              preferred is the one with the greatest sum of weights,
+                              i.e. for each node that meets all of the scheduling requirements
+                              (resource request, requiredDuringScheduling anti-affinity
+                              expressions, etc.), compute a sum by iterating through
+                              the elements of this field and adding "weight" to the
+                              sum if the node has pods which matches the corresponding
+                              podAffinityTerm; the node(s) with the highest sum are
+                              the most preferred.
+                            items:
+                              description: The weights of all of the matched WeightedPodAffinityTerm
+                                fields are added per-node to find the most preferred
+                                node(s)
+                              properties:
+                                podAffinityTerm:
+                                  description: Required. A pod affinity term, associated
+                                    with the corresponding weight.
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources,
+                                        in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of
+                                            label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: A label selector requirement
+                                              is a selector that contains values, a
+                                              key, and an operator that relates the
+                                              key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that
+                                                  the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's
+                                                  relationship to a set of values. Valid
+                                                  operators are In, NotIn, Exists and
+                                                  DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string
+                                                  values. If the operator is In or NotIn,
+                                                  the values array must be non-empty.
+                                                  If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This
+                                                  array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                              - key
+                                              - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value}
+                                            pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions,
+                                            whose key field is "key", the operator is
+                                            "In", and the values array contains only
+                                            "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces
+                                        the labelSelector applies to (matches against);
+                                        null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity)
+                                        or not co-located (anti-affinity) with the pods
+                                        matching the labelSelector in the specified
+                                        namespaces, where co-located is defined as running
+                                        on a node whose value of the label with key
+                                        topologyKey matches that of any node on which
+                                        any of the selected pods is running. Empty topologyKey
+                                        is not allowed.
+                                      type: string
+                                  required:
+                                    - topologyKey
+                                  type: object
+                                weight:
+                                  description: weight associated with matching the corresponding
+                                    podAffinityTerm, in the range 1-100.
+                                  format: int32
+                                  type: integer
+                              required:
+                                - podAffinityTerm
+                                - weight
+                              type: object
+                            type: array
+                          requiredDuringSchedulingIgnoredDuringExecution:
+                            description: If the anti-affinity requirements specified
+                              by this field are not met at scheduling time, the pod
+                              will not be scheduled onto the node. If the anti-affinity
+                              requirements specified by this field cease to be met at
+                              some point during pod execution (e.g. due to a pod label
+                              update), the system may or may not try to eventually evict
+                              the pod from its node. When there are multiple elements,
+                              the lists of nodes corresponding to each podAffinityTerm
+                              are intersected, i.e. all terms must be satisfied.
+                            items:
+                              description: Defines a set of pods (namely those matching
+                                the labelSelector relative to the given namespace(s))
+                                that this pod should be co-located (affinity) or not
+                                co-located (anti-affinity) with, where co-located is
+                                defined as running on a node whose value of the label
+                                with key <topologyKey> matches that of any node on which
+                                a pod of the set of pods is running
+                              properties:
+                                labelSelector:
+                                  description: A label query over a set of resources,
+                                    in this case pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: A label selector requirement is
+                                          a selector that contains values, a key, and
+                                          an operator that relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that the
+                                              selector applies to.
+                                            type: string
+                                          operator:
+                                            description: operator represents a key's
+                                              relationship to a set of values. Valid
+                                              operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: values is an array of string
+                                              values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If
+                                              the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array
+                                              is replaced during a strategic merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                        required:
+                                          - key
+                                          - operator
+                                        type: object
+                                      type: array
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: matchLabels is a map of {key,value}
+                                        pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions,
+                                        whose key field is "key", the operator is "In",
+                                        and the values array contains only "value".
+                                        The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                namespaces:
+                                  description: namespaces specifies which namespaces
+                                    the labelSelector applies to (matches against);
+                                    null or empty list means "this pod's namespace"
+                                  items:
+                                    type: string
+                                  type: array
+                                topologyKey:
+                                  description: This pod should be co-located (affinity)
+                                    or not co-located (anti-affinity) with the pods
+                                    matching the labelSelector in the specified namespaces,
+                                    where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches
+                                    that of any node on which any of the selected pods
+                                    is running. Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                                - topologyKey
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: Annotations specifies the annotations to attach to
+                      pods the operator creates
+                    type: object
+                  initContainers:
+                    description: InitContainers defines init containers of the pod.
+                      A typical use case could be using an init container to download
+                      a remote jar to a local path.
+                    items:
+                      description: A single application container that you want to run
+                        within a pod. The Container API from the core group is not used
+                        directly to avoid unneeded fields and reduce the size of the
+                        CRD. New fields could be added as needed.
+                      properties:
+                        args:
+                          description: Arguments to the entrypoint.
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: Entrypoint array. Not executed within a shell.
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the container.
+                          items:
+                            description: EnvVar represents an environment variable present
+                              in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are expanded
+                                  using the previous defined environment variables in
+                                  the container and any service environment variables.
+                                  If a variable cannot be resolved, the reference in
+                                  the input string will be unchanged. The $(VAR_NAME)
+                                  syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                  Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's value.
+                                  Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                      - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for volumes,
+                                          optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                      - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the pod's
+                                      namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its
+                                          key must be defined
+                                        type: boolean
+                                    required:
+                                      - key
                                     type: object
                                 type: object
-                              storageClassName:
-                                description: 'Name of the StorageClass required by
-                                  the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                                type: string
-                              volumeMode:
-                                description: volumeMode defines what type of volume
-                                  is required by the claim. Value of Filesystem is
-                                  implied when not included in claim spec.
-                                type: string
-                              volumeName:
-                                description: VolumeName is the binding reference to
-                                  the PersistentVolume backing this claim.
-                                type: string
+                            required:
+                              - name
                             type: object
-                          status:
-                            description: 'Status represents the current information/status
-                              of a persistent volume claim. Read-only. More info:
-                              https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          type: array
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container.
+                          items:
+                            description: EnvFromSource represents the source of a set
+                              of ConfigMaps
                             properties:
-                              accessModes:
-                                description: 'AccessModes contains the actual access
-                                  modes the volume backing the PVC has. More info:
-                                  https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                items:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to each
+                                  key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: Docker image name.
+                          type: string
+                        imagePullPolicy:
+                          description: Image pull policy.
+                          type: string
+                        livenessProbe:
+                          description: Periodic probe of container liveness.
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
                                   type: string
-                                type: array
-                              capacity:
-                                additionalProperties:
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
                                   anyOf:
                                     - type: integer
                                     - type: string
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
                                   x-kubernetes-int-or-string: true
-                                description: Represents the actual resources of the
-                                  underlying volume.
-                                type: object
-                              conditions:
-                                description: Current Condition of persistent volume
-                                  claim. If underlying persistent volume is being
-                                  resized then the Condition will be set to 'ResizeStarted'.
-                                items:
-                                  description: PersistentVolumeClaimCondition contails
-                                    details about state of pvc
-                                  properties:
-                                    lastProbeTime:
-                                      description: Last time we probed the condition.
-                                      format: date-time
-                                      type: string
-                                    lastTransitionTime:
-                                      description: Last time the condition transitioned
-                                        from one status to another.
-                                      format: date-time
-                                      type: string
-                                    message:
-                                      description: Human-readable message indicating
-                                        details about last transition.
-                                      type: string
-                                    reason:
-                                      description: Unique, this should be a short,
-                                        machine understandable string that gives the
-                                        reason for condition's last transition. If
-                                        it reports "ResizeStarted" that means the
-                                        underlying persistent volume is being resized.
-                                      type: string
-                                    status:
-                                      type: string
-                                    type:
-                                      description: PersistentVolumeClaimConditionType
-                                        is a valid value of PersistentVolumeClaimCondition.Type
-                                      type: string
-                                  required:
-                                    - status
-                                    - type
-                                  type: object
-                                type: array
-                              phase:
-                                description: Phase represents the current phase of
-                                  PersistentVolumeClaim.
-                                type: string
-                            type: object
-                        type: object
-                      type: array
-                    volumeMounts:
-                      description: VolumeMounts is a list of volumes to mount into
-                        the container's filesystem. If a non-empty list is specified,
-                        the original values of the main container in the desired STS
-                        will be replaced.
-                      items:
-                        description: VolumeMount describes a mounting of a Volume
-                          within a container.
-                        properties:
-                          mountPath:
-                            description: Path within the container at which the volume
-                              should be mounted.  Must not contain ':'.
-                            type: string
-                          mountPropagation:
-                            description: mountPropagation determines how mounts are
-                              propagated from the host to container and the other
-                              way around. When not set, MountPropagationNone is used.
-                              This field is beta in 1.10.
-                            type: string
-                          name:
-                            description: This must match the Name of a Volume.
-                            type: string
-                          readOnly:
-                            description: Mounted read-only if true, read-write otherwise
-                              (false or unspecified). Defaults to false.
-                            type: boolean
-                          subPath:
-                            description: Path within the volume from which the container's
-                              volume should be mounted. Defaults to "" (volume's root).
-                            type: string
-                          subPathExpr:
-                            description: Expanded path within the volume from which
-                              the container's volume should be mounted. Behaves similarly
-                              to SubPath but environment variable references $(VAR_NAME)
-                              are expanded using the container's environment. Defaults
-                              to "" (volume's root). SubPathExpr and SubPath are mutually
-                              exclusive.
-                            type: string
-                        required:
-                          - mountPath
-                          - name
-                        type: object
-                      type: array
-                  type: object
-              type: object
-            conf:
-              description: 'Conf defines the zookeeper configuration. It will be used
-                for generating the configuration file used by zookeeper process. Deprecated:
-                use `config`'
-              properties:
-                custom:
-                  additionalProperties:
-                    type: string
-                  description: Custom accepts other configurations
-                  type: object
-                globalOutstandingLimit:
-                  description: "GlobalOutstandingLimit limits the number of queued
-                    outstanding requests \n The default value is 100000"
-                  type: integer
-                initLimit:
-                  description: "InitLimit is the number of ticks that the initial
-                    synchronization phase can take. \n The default value is 10."
-                  type: integer
-                maxClientCnxns:
-                  description: "MaxClientCnxns limits the maximum number of client
-                    connections. \n The default value is 1000"
-                  type: integer
-                serverCnxnFactory:
-                  description: "ServerCnxnFactory is the ServerCnxnFactory implementation.
-                    \n The default value is org.apache.zookeeper.server.NettyServerCnxnFactory"
-                  type: string
-                snapCount:
-                  description: "SnapCount is the number of transactions recorded in
-                    the transaction log before a snapshot can be taken. \n The default
-                    value is 1000000"
-                  type: integer
-                syncLimit:
-                  description: "SyncLimit is the number of ticks that can pass between
-                    sending a request and getting an acknowledgement \n The default
-                    value is 5."
-                  type: integer
-                tickTime:
-                  description: "TickTime is the number of milliseconds of each tick.
-                    A tick is the basic time unit used by ZooKeeper, as measured in
-                    milliseconds \n The default value is 2000."
-                  type: integer
-              type: object
-            config:
-              description: Config defines the zookeeper configuration
-              properties:
-                custom:
-                  additionalProperties:
-                    type: string
-                  description: Custom accepts other configurations
-                  type: object
-                globalOutstandingLimit:
-                  description: "GlobalOutstandingLimit limits the number of queued
-                    outstanding requests \n The default value is 100000"
-                  type: integer
-                initLimit:
-                  description: "InitLimit is the number of ticks that the initial
-                    synchronization phase can take. \n The default value is 10."
-                  type: integer
-                maxClientCnxns:
-                  description: "MaxClientCnxns limits the maximum number of client
-                    connections. \n The default value is 1000"
-                  type: integer
-                serverCnxnFactory:
-                  description: "ServerCnxnFactory is the ServerCnxnFactory implementation.
-                    \n The default value is org.apache.zookeeper.server.NettyServerCnxnFactory"
-                  type: string
-                snapCount:
-                  description: "SnapCount is the number of transactions recorded in
-                    the transaction log before a snapshot can be taken. \n The default
-                    value is 1000000"
-                  type: integer
-                syncLimit:
-                  description: "SyncLimit is the number of ticks that can pass between
-                    sending a request and getting an acknowledgement \n The default
-                    value is 5."
-                  type: integer
-                tickTime:
-                  description: "TickTime is the number of milliseconds of each tick.
-                    A tick is the basic time unit used by ZooKeeper, as measured in
-                    milliseconds \n The default value is 2000."
-                  type: integer
-              type: object
-            image:
-              description: Image is the container image used to run zookeeper pods.
-                default is apachepulsar/pulsar:latest
-              type: string
-            imagePullPolicy:
-              description: Image pull policy, one of Always, Never, IfNotPresent,
-                default to Always.
-              type: string
-            labels:
-              additionalProperties:
-                type: string
-              description: Labels specifies the labels to attach to the stateful set
-                the operator creates for the zookeeper cluster.
-              type: object
-            persistence:
-              description: Persistence defines the persistent volume used for the
-                zookeeper pod
-              properties:
-                data:
-                  description: Data is the spec to define the data PVC for the container
-                  properties:
-                    accessModes:
-                      description: 'AccessModes contains the desired access modes
-                        the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                      items:
-                        type: string
-                      type: array
-                    dataSource:
-                      description: 'This field can be used to specify either: * An
-                        existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                        - Beta) * An existing PVC (PersistentVolumeClaim) * An existing
-                        custom resource/object that implements data population (Alpha)
-                        In order to use VolumeSnapshot object types, the appropriate
-                        feature gate must be enabled (VolumeSnapshotDataSource or
-                        AnyVolumeDataSource) If the provisioner or an external controller
-                        can support the specified data source, it will create a new
-                        volume based on the contents of the specified data source.
-                        If the specified data source is not supported, the volume
-                        will not be created and the failure will be reported as an
-                        event. In the future, we plan to support more data source
-                        types and the behavior of the provisioner may change.'
-                      properties:
-                        apiGroup:
-                          description: APIGroup is the group for the resource being
-                            referenced. If APIGroup is not specified, the specified
-                            Kind must be in the core API group. For any other third-party
-                            types, APIGroup is required.
-                          type: string
-                        kind:
-                          description: Kind is the type of resource being referenced
-                          type: string
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
                         name:
-                          description: Name is the name of resource being referenced
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
                           type: string
-                      required:
-                        - kind
-                        - name
-                      type: object
-                    resources:
-                      description: 'Resources represents the minimum resources the
-                        volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. More info:
-                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                    selector:
-                      description: A label query over volumes to consider for binding.
-                      properties:
-                        matchExpressions:
-                          description: matchExpressions is a list of label selector
-                            requirements. The requirements are ANDed.
+                        ports:
+                          description: List of ports to expose from the container.
                           items:
-                            description: A label selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
+                            description: ContainerPort represents a network port in
+                              a single container.
                             properties:
-                              key:
-                                description: key is the label key that the selector
-                                  applies to.
-                                type: string
-                              operator:
-                                description: operator represents a key's relationship
-                                  to a set of values. Valid operators are In, NotIn,
-                                  Exists and DoesNotExist.
-                                type: string
-                              values:
-                                description: values is an array of string values.
-                                  If the operator is In or NotIn, the values array
-                                  must be non-empty. If the operator is Exists or
-                                  DoesNotExist, the values array must be empty. This
-                                  array is replaced during a strategic merge patch.
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                              - key
-                              - operator
-                            type: object
-                          type: array
-                        matchLabels:
-                          additionalProperties:
-                            type: string
-                          description: matchLabels is a map of {key,value} pairs.
-                            A single {key,value} in the matchLabels map is equivalent
-                            to an element of matchExpressions, whose key field is
-                            "key", the operator is "In", and the values array contains
-                            only "value". The requirements are ANDed.
-                          type: object
-                      type: object
-                    storageClassName:
-                      description: 'Name of the StorageClass required by the claim.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                      type: string
-                    volumeMode:
-                      description: volumeMode defines what type of volume is required
-                        by the claim. Value of Filesystem is implied when not included
-                        in claim spec.
-                      type: string
-                    volumeName:
-                      description: VolumeName is the binding reference to the PersistentVolume
-                        backing this claim.
-                      type: string
-                  type: object
-                dataLog:
-                  description: DataLog is the spec to define the data-log PVC for
-                    the container
-                  properties:
-                    accessModes:
-                      description: 'AccessModes contains the desired access modes
-                        the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                      items:
-                        type: string
-                      type: array
-                    dataSource:
-                      description: 'This field can be used to specify either: * An
-                        existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                        - Beta) * An existing PVC (PersistentVolumeClaim) * An existing
-                        custom resource/object that implements data population (Alpha)
-                        In order to use VolumeSnapshot object types, the appropriate
-                        feature gate must be enabled (VolumeSnapshotDataSource or
-                        AnyVolumeDataSource) If the provisioner or an external controller
-                        can support the specified data source, it will create a new
-                        volume based on the contents of the specified data source.
-                        If the specified data source is not supported, the volume
-                        will not be created and the failure will be reported as an
-                        event. In the future, we plan to support more data source
-                        types and the behavior of the provisioner may change.'
-                      properties:
-                        apiGroup:
-                          description: APIGroup is the group for the resource being
-                            referenced. If APIGroup is not specified, the specified
-                            Kind must be in the core API group. For any other third-party
-                            types, APIGroup is required.
-                          type: string
-                        kind:
-                          description: Kind is the type of resource being referenced
-                          type: string
-                        name:
-                          description: Name is the name of resource being referenced
-                          type: string
-                      required:
-                        - kind
-                        - name
-                      type: object
-                    resources:
-                      description: 'Resources represents the minimum resources the
-                        volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                      properties:
-                        limits:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                        requests:
-                          additionalProperties:
-                            anyOf:
-                              - type: integer
-                              - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. More info:
-                            https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                          type: object
-                      type: object
-                    selector:
-                      description: A label query over volumes to consider for binding.
-                      properties:
-                        matchExpressions:
-                          description: matchExpressions is a list of label selector
-                            requirements. The requirements are ANDed.
-                          items:
-                            description: A label selector requirement is a selector
-                              that contains values, a key, and an operator that relates
-                              the key and values.
-                            properties:
-                              key:
-                                description: key is the label key that the selector
-                                  applies to.
-                                type: string
-                              operator:
-                                description: operator represents a key's relationship
-                                  to a set of values. Valid operators are In, NotIn,
-                                  Exists and DoesNotExist.
-                                type: string
-                              values:
-                                description: values is an array of string values.
-                                  If the operator is In or NotIn, the values array
-                                  must be non-empty. If the operator is Exists or
-                                  DoesNotExist, the values array must be empty. This
-                                  array is replaced during a strategic merge patch.
-                                items:
-                                  type: string
-                                type: array
-                            required:
-                              - key
-                              - operator
-                            type: object
-                          type: array
-                        matchLabels:
-                          additionalProperties:
-                            type: string
-                          description: matchLabels is a map of {key,value} pairs.
-                            A single {key,value} in the matchLabels map is equivalent
-                            to an element of matchExpressions, whose key field is
-                            "key", the operator is "In", and the values array contains
-                            only "value". The requirements are ANDed.
-                          type: object
-                      type: object
-                    storageClassName:
-                      description: 'Name of the StorageClass required by the claim.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                      type: string
-                    volumeMode:
-                      description: volumeMode defines what type of volume is required
-                        by the claim. Value of Filesystem is implied when not included
-                        in claim spec.
-                      type: string
-                    volumeName:
-                      description: VolumeName is the binding reference to the PersistentVolume
-                        backing this claim.
-                      type: string
-                  type: object
-                reclaimPolicy:
-                  description: VolumeReclaimPolicy defines how to reclaim PV.
-                  type: string
-              type: object
-            pod:
-              description: Pod defines the policy for creating a zookeeper pod for
-                the cluster
-              properties:
-                affinity:
-                  description: Affinity specifies the scheduling constraints of a
-                    pod
-                  properties:
-                    nodeAffinity:
-                      description: Describes node affinity scheduling rules for the
-                        pod.
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods
-                            to nodes that satisfy the affinity expressions specified
-                            by this field, but it may choose a node that violates
-                            one or more of the expressions. The node that is most
-                            preferred is the one with the greatest sum of weights,
-                            i.e. for each node that meets all of the scheduling requirements
-                            (resource request, requiredDuringScheduling affinity expressions,
-                            etc.), compute a sum by iterating through the elements
-                            of this field and adding "weight" to the sum if the node
-                            matches the corresponding matchExpressions; the node(s)
-                            with the highest sum are the most preferred.
-                          items:
-                            description: An empty preferred scheduling term matches
-                              all objects with implicit weight 0 (i.e. it's a no-op).
-                              A null preferred scheduling term matches no objects
-                              (i.e. is also a no-op).
-                            properties:
-                              preference:
-                                description: A node selector term, associated with
-                                  the corresponding weight.
-                                properties:
-                                  matchExpressions:
-                                    description: A list of node selector requirements
-                                      by node's labels.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    description: A list of node selector requirements
-                                      by node's fields.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              weight:
-                                description: Weight associated with matching the corresponding
-                                  nodeSelectorTerm, in the range 1-100.
+                              containerPort:
+                                description: Number of port to expose on the pod's IP
+                                  address. This must be a valid port number, 0 < x <
+                                  65536.
                                 format: int32
                                 type: integer
-                            required:
-                              - preference
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this
-                            field are not met at scheduling time, the pod will not
-                            be scheduled onto the node. If the affinity requirements
-                            specified by this field cease to be met at some point
-                            during pod execution (e.g. due to an update), the system
-                            may or may not try to eventually evict the pod from its
-                            node.
-                          properties:
-                            nodeSelectorTerms:
-                              description: Required. A list of node selector terms.
-                                The terms are ORed.
-                              items:
-                                description: A null or empty node selector term matches
-                                  no objects. The requirements of them are ANDed.
-                                  The TopologySelectorTerm type implements a subset
-                                  of the NodeSelectorTerm.
-                                properties:
-                                  matchExpressions:
-                                    description: A list of node selector requirements
-                                      by node's labels.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchFields:
-                                    description: A list of node selector requirements
-                                      by node's fields.
-                                    items:
-                                      description: A node selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: The label key that the selector
-                                            applies to.
-                                          type: string
-                                        operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
-                                          type: string
-                                        values:
-                                          description: An array of string values.
-                                            If the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values
-                                            array must be empty. If the operator is
-                                            Gt or Lt, the values array must have a
-                                            single element, which will be interpreted
-                                            as an integer. This array is replaced
-                                            during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                type: object
-                              type: array
-                          required:
-                            - nodeSelectorTerms
-                          type: object
-                      type: object
-                    podAffinity:
-                      description: Describes pod affinity scheduling rules (e.g. co-locate
-                        this pod in the same node, zone, etc. as some other pod(s)).
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods
-                            to nodes that satisfy the affinity expressions specified
-                            by this field, but it may choose a node that violates
-                            one or more of the expressions. The node that is most
-                            preferred is the one with the greatest sum of weights,
-                            i.e. for each node that meets all of the scheduling requirements
-                            (resource request, requiredDuringScheduling affinity expressions,
-                            etc.), compute a sum by iterating through the elements
-                            of this field and adding "weight" to the sum if the node
-                            has pods which matches the corresponding podAffinityTerm;
-                            the node(s) with the highest sum are the most preferred.
-                          items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm
-                              fields are added per-node to find the most preferred
-                              node(s)
-                            properties:
-                              podAffinityTerm:
-                                description: Required. A pod affinity term, associated
-                                  with the corresponding weight.
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified
-                                      namespaces, where co-located is defined as running
-                                      on a node whose value of the label with key
-                                      topologyKey matches that of any node on which
-                                      any of the selected pods is running. Empty topologyKey
-                                      is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              weight:
-                                description: weight associated with matching the corresponding
-                                  podAffinityTerm, in the range 1-100.
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host. If
+                                  specified, this must be a valid port number, 0 < x
+                                  < 65536. If HostNetwork is specified, this must match
+                                  ContainerPort. Most containers do not need this.
                                 format: int32
                                 type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this
-                            field are not met at scheduling time, the pod will not
-                            be scheduled onto the node. If the affinity requirements
-                            specified by this field cease to be met at some point
-                            during pod execution (e.g. due to a pod label update),
-                            the system may or may not try to eventually evict the
-                            pod from its node. When there are multiple elements, the
-                            lists of nodes corresponding to each podAffinityTerm are
-                            intersected, i.e. all terms must be satisfied.
-                          items:
-                            description: Defines a set of pods (namely those matching
-                              the labelSelector relative to the given namespace(s))
-                              that this pod should be co-located (affinity) or not
-                              co-located (anti-affinity) with, where co-located is
-                              defined as running on a node whose value of the label
-                              with key <topologyKey> matches that of any node on which
-                              a pod of the set of pods is running
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                              - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                    podAntiAffinity:
-                      description: Describes pod anti-affinity scheduling rules (e.g.
-                        avoid putting this pod in the same node, zone, etc. as some
-                        other pod(s)).
-                      properties:
-                        preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods
-                            to nodes that satisfy the anti-affinity expressions specified
-                            by this field, but it may choose a node that violates
-                            one or more of the expressions. The node that is most
-                            preferred is the one with the greatest sum of weights,
-                            i.e. for each node that meets all of the scheduling requirements
-                            (resource request, requiredDuringScheduling anti-affinity
-                            expressions, etc.), compute a sum by iterating through
-                            the elements of this field and adding "weight" to the
-                            sum if the node has pods which matches the corresponding
-                            podAffinityTerm; the node(s) with the highest sum are
-                            the most preferred.
-                          items:
-                            description: The weights of all of the matched WeightedPodAffinityTerm
-                              fields are added per-node to find the most preferred
-                              node(s)
-                            properties:
-                              podAffinityTerm:
-                                description: Required. A pod affinity term, associated
-                                  with the corresponding weight.
-                                properties:
-                                  labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of
-                                          label selector requirements. The requirements
-                                          are ANDed.
-                                        items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that
-                                                the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
-                                    items:
-                                      type: string
-                                    type: array
-                                  topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified
-                                      namespaces, where co-located is defined as running
-                                      on a node whose value of the label with key
-                                      topologyKey matches that of any node on which
-                                      any of the selected pods is running. Empty topologyKey
-                                      is not allowed.
-                                    type: string
-                                required:
-                                  - topologyKey
-                                type: object
-                              weight:
-                                description: weight associated with matching the corresponding
-                                  podAffinityTerm, in the range 1-100.
-                                format: int32
-                                type: integer
-                            required:
-                              - podAffinityTerm
-                              - weight
-                            type: object
-                          type: array
-                        requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the anti-affinity requirements specified
-                            by this field are not met at scheduling time, the pod
-                            will not be scheduled onto the node. If the anti-affinity
-                            requirements specified by this field cease to be met at
-                            some point during pod execution (e.g. due to a pod label
-                            update), the system may or may not try to eventually evict
-                            the pod from its node. When there are multiple elements,
-                            the lists of nodes corresponding to each podAffinityTerm
-                            are intersected, i.e. all terms must be satisfied.
-                          items:
-                            description: Defines a set of pods (namely those matching
-                              the labelSelector relative to the given namespace(s))
-                              that this pod should be co-located (affinity) or not
-                              co-located (anti-affinity) with, where co-located is
-                              defined as running on a node whose value of the label
-                              with key <topologyKey> matches that of any node on which
-                              a pod of the set of pods is running
-                            properties:
-                              labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods.
-                                properties:
-                                  matchExpressions:
-                                    description: matchExpressions is a list of label
-                                      selector requirements. The requirements are
-                                      ANDed.
-                                    items:
-                                      description: A label selector requirement is
-                                        a selector that contains values, a key, and
-                                        an operator that relates the key and values.
-                                      properties:
-                                        key:
-                                          description: key is the label key that the
-                                            selector applies to.
-                                          type: string
-                                        operator:
-                                          description: operator represents a key's
-                                            relationship to a set of values. Valid
-                                            operators are In, NotIn, Exists and DoesNotExist.
-                                          type: string
-                                        values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If
-                                            the operator is Exists or DoesNotExist,
-                                            the values array must be empty. This array
-                                            is replaced during a strategic merge patch.
-                                          items:
-                                            type: string
-                                          type: array
-                                      required:
-                                        - key
-                                        - operator
-                                      type: object
-                                    type: array
-                                  matchLabels:
-                                    additionalProperties:
-                                      type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value".
-                                      The requirements are ANDed.
-                                    type: object
-                                type: object
-                              namespaces:
-                                description: namespaces specifies which namespaces
-                                  the labelSelector applies to (matches against);
-                                  null or empty list means "this pod's namespace"
-                                items:
-                                  type: string
-                                type: array
-                              topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods
-                                  matching the labelSelector in the specified namespaces,
-                                  where co-located is defined as running on a node
-                                  whose value of the label with key topologyKey matches
-                                  that of any node on which any of the selected pods
-                                  is running. Empty topologyKey is not allowed.
-                                type: string
-                            required:
-                              - topologyKey
-                            type: object
-                          type: array
-                      type: object
-                  type: object
-                annotations:
-                  additionalProperties:
-                    type: string
-                  description: Annotations specifies the annotations to attach to
-                    pods the operator creates
-                  type: object
-                initContainers:
-                  description: InitContainers defines init containers of the pod.
-                    A typical use case could be using an init container to download
-                    a remote jar to a local path.
-                  items:
-                    description: A single application container that you want to run
-                      within a pod. The Container API from the core group is not used
-                      directly to avoid unneeded fields and reduce the size of the
-                      CRD. New fields could be added as needed.
-                    properties:
-                      args:
-                        description: Arguments to the entrypoint.
-                        items:
-                          type: string
-                        type: array
-                      command:
-                        description: Entrypoint array. Not executed within a shell.
-                        items:
-                          type: string
-                        type: array
-                      env:
-                        description: List of environment variables to set in the container.
-                        items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
-                          properties:
-                            name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
-                              type: string
-                            value:
-                              description: 'Variable references $(VAR_NAME) are expanded
-                                using the previous defined environment variables in
-                                the container and any service environment variables.
-                                If a variable cannot be resolved, the reference in
-                                the input string will be unchanged. The $(VAR_NAME)
-                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
-                                Escaped references will never be expanded, regardless
-                                of whether the variable exists or not. Defaults to
-                                "".'
-                              type: string
-                            valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
-                              properties:
-                                configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
-                                  properties:
-                                    key:
-                                      description: The key to select.
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
-                                fieldRef:
-                                  description: 'Selects a field of the pod: supports
-                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                    spec.serviceAccountName, status.hostIP, status.podIP,
-                                    status.podIPs.'
-                                  properties:
-                                    apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
-                                      type: string
-                                    fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
-                                      type: string
-                                  required:
-                                    - fieldPath
-                                  type: object
-                                resourceFieldRef:
-                                  description: 'Selects a resource of the container:
-                                    only resources limits and requests (limits.cpu,
-                                    limits.memory, limits.ephemeral-storage, requests.cpu,
-                                    requests.memory and requests.ephemeral-storage)
-                                    are currently supported.'
-                                  properties:
-                                    containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
-                                      type: string
-                                    divisor:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    resource:
-                                      description: 'Required: resource to select'
-                                      type: string
-                                  required:
-                                    - resource
-                                  type: object
-                                secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
-                                  properties:
-                                    key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
-                              type: object
-                          required:
-                            - name
-                          type: object
-                        type: array
-                      envFrom:
-                        description: List of sources to populate environment variables
-                          in the container.
-                        items:
-                          description: EnvFromSource represents the source of a set
-                            of ConfigMaps
-                          properties:
-                            configMapRef:
-                              description: The ConfigMap to select from
-                              properties:
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap must
-                                    be defined
-                                  type: boolean
-                              type: object
-                            prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
-                              type: string
-                            secretRef:
-                              description: The Secret to select from
-                              properties:
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret must be
-                                    defined
-                                  type: boolean
-                              type: object
-                          type: object
-                        type: array
-                      image:
-                        description: Docker image name.
-                        type: string
-                      imagePullPolicy:
-                        description: Image pull policy.
-                        type: string
-                      livenessProbe:
-                        description: Periodic probe of container liveness.
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      name:
-                        description: Name of the container specified as a DNS_LABEL.
-                          Each container in a pod must have a unique name (DNS_LABEL).
-                        type: string
-                      ports:
-                        description: List of ports to expose from the container.
-                        items:
-                          description: ContainerPort represents a network port in
-                            a single container.
-                          properties:
-                            containerPort:
-                              description: Number of port to expose on the pod's IP
-                                address. This must be a valid port number, 0 < x <
-                                65536.
-                              format: int32
-                              type: integer
-                            hostIP:
-                              description: What host IP to bind the external port
-                                to.
-                              type: string
-                            hostPort:
-                              description: Number of port to expose on the host. If
-                                specified, this must be a valid port number, 0 < x
-                                < 65536. If HostNetwork is specified, this must match
-                                ContainerPort. Most containers do not need this.
-                              format: int32
-                              type: integer
-                            name:
-                              description: If specified, this must be an IANA_SVC_NAME
-                                and unique within the pod. Each named port in a pod
-                                must have a unique name. Name for the port that can
-                                be referred to by services.
-                              type: string
-                            protocol:
-                              description: Protocol for port. Must be UDP, TCP, or
-                                SCTP. Defaults to "TCP".
-                              type: string
-                          required:
-                            - containerPort
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                          - containerPort
-                        x-kubernetes-list-type: map
-                      readinessProbe:
-                        description: 'Periodic probe of container service readiness.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      resources:
-                        description: Compute Resources required by this container.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                        type: object
-                      startupProbe:
-                        description: StartupProbe indicates that the Pod has successfully
-                          initialized.
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      volumeMounts:
-                        description: Pod volumes to mount into the container's filesystem.
-                        items:
-                          description: VolumeMount describes a mounting of a Volume
-                            within a container.
-                          properties:
-                            mountPath:
-                              description: Path within the container at which the
-                                volume should be mounted.  Must not contain ':'.
-                              type: string
-                            mountPropagation:
-                              description: mountPropagation determines how mounts
-                                are propagated from the host to container and the
-                                other way around. When not set, MountPropagationNone
-                                is used. This field is beta in 1.10.
-                              type: string
-                            name:
-                              description: This must match the Name of a Volume.
-                              type: string
-                            readOnly:
-                              description: Mounted read-only if true, read-write otherwise
-                                (false or unspecified). Defaults to false.
-                              type: boolean
-                            subPath:
-                              description: Path within the volume from which the container's
-                                volume should be mounted. Defaults to "" (volume's
-                                root).
-                              type: string
-                            subPathExpr:
-                              description: Expanded path within the volume from which
-                                the container's volume should be mounted. Behaves
-                                similarly to SubPath but environment variable references
-                                $(VAR_NAME) are expanded using the container's environment.
-                                Defaults to "" (volume's root). SubPathExpr and SubPath
-                                are mutually exclusive.
-                              type: string
-                          required:
-                            - mountPath
-                            - name
-                          type: object
-                        type: array
-                      workingDir:
-                        description: Container's working directory.
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-                jvmOptions:
-                  description: JVMOptions defines JVM parameters
-                  properties:
-                    extraOptions:
-                      items:
-                        type: string
-                      type: array
-                    gcLoggingOptions:
-                      items:
-                        type: string
-                      type: array
-                    gcOptions:
-                      items:
-                        type: string
-                      type: array
-                    memoryOptions:
-                      items:
-                        type: string
-                      type: array
-                  type: object
-                labels:
-                  additionalProperties:
-                    type: string
-                  description: Labels specifies the labels to attach to pod the operator
-                    creates for the zookeeper cluster.
-                  type: object
-                nodeSelector:
-                  additionalProperties:
-                    type: string
-                  description: NodeSelector specifies a map of key-value pairs. For
-                    a pod to be eligible to run on a node, the node must have each
-                    of the indicated key-value pairs as labels.
-                  type: object
-                resources:
-                  description: Resources specifies the resource requirements of a
-                    pod to run in the cluster
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                          - type: integer
-                          - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                securityContext:
-                  description: 'SecurityContext specifies the security context for
-                    the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
-                  properties:
-                    fsGroup:
-                      description: "A special supplemental group that applies to all
-                        containers in a pod. Some volume types allow the Kubelet to
-                        change the ownership of that volume to be owned by the pod:
-                        \n 1. The owning GID will be the FSGroup 2. The setgid bit
-                        is set (new files created in the volume will be owned by FSGroup)
-                        3. The permission bits are OR'd with rw-rw---- \n If unset,
-                        the Kubelet will not modify the ownership and permissions
-                        of any volume."
-                      format: int64
-                      type: integer
-                    fsGroupChangePolicy:
-                      description: 'fsGroupChangePolicy defines behavior of changing
-                        ownership and permission of the volume before being exposed
-                        inside Pod. This field will only apply to volume types which
-                        support fsGroup based ownership(and permissions). It will
-                        have no effect on ephemeral volume types such as: secret,
-                        configmaps and emptydir. Valid values are "OnRootMismatch"
-                        and "Always". If not specified defaults to "Always".'
-                      type: string
-                    runAsGroup:
-                      description: The GID to run the entrypoint of the container
-                        process. Uses runtime default if unset. May also be set in
-                        SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence for
-                        that container.
-                      format: int64
-                      type: integer
-                    runAsNonRoot:
-                      description: Indicates that the container must run as a non-root
-                        user. If true, the Kubelet will validate the image at runtime
-                        to ensure that it does not run as UID 0 (root) and fail to
-                        start the container if it does. If unset or false, no such
-                        validation will be performed. May also be set in SecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence.
-                      type: boolean
-                    runAsUser:
-                      description: The UID to run the entrypoint of the container
-                        process. Defaults to user specified in image metadata if unspecified.
-                        May also be set in SecurityContext.  If set in both SecurityContext
-                        and PodSecurityContext, the value specified in SecurityContext
-                        takes precedence for that container.
-                      format: int64
-                      type: integer
-                    seLinuxOptions:
-                      description: The SELinux context to be applied to all containers.
-                        If unspecified, the container runtime will allocate a random
-                        SELinux context for each container.  May also be set in SecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence for that container.
-                      properties:
-                        level:
-                          description: Level is SELinux level label that applies to
-                            the container.
-                          type: string
-                        role:
-                          description: Role is a SELinux role label that applies to
-                            the container.
-                          type: string
-                        type:
-                          description: Type is a SELinux type label that applies to
-                            the container.
-                          type: string
-                        user:
-                          description: User is a SELinux user label that applies to
-                            the container.
-                          type: string
-                      type: object
-                    seccompProfile:
-                      description: The seccomp options to use by the containers in
-                        this pod.
-                      properties:
-                        localhostProfile:
-                          description: localhostProfile indicates a profile defined
-                            in a file on the node should be used. The profile must
-                            be preconfigured on the node to work. Must be a descending
-                            path, relative to the kubelet's configured seccomp profile
-                            location. Must only be set if type is "Localhost".
-                          type: string
-                        type:
-                          description: "type indicates which kind of seccomp profile
-                            will be applied. Valid options are: \n Localhost - a profile
-                            defined in a file on the node should be used. RuntimeDefault
-                            - the container runtime default profile should be used.
-                            Unconfined - no profile should be applied."
-                          type: string
-                      required:
-                        - type
-                      type: object
-                    supplementalGroups:
-                      description: A list of groups applied to the first process run
-                        in each container, in addition to the container's primary
-                        GID.  If unspecified, no groups will be added to any container.
-                      items:
-                        format: int64
-                        type: integer
-                      type: array
-                    sysctls:
-                      description: Sysctls hold a list of namespaced sysctls used
-                        for the pod. Pods with unsupported sysctls (by the container
-                        runtime) might fail to launch.
-                      items:
-                        description: Sysctl defines a kernel parameter to be set
-                        properties:
-                          name:
-                            description: Name of a property to set
-                            type: string
-                          value:
-                            description: Value of a property to set
-                            type: string
-                        required:
-                          - name
-                          - value
-                        type: object
-                      type: array
-                    windowsOptions:
-                      description: The Windows specific settings applied to all containers.
-                        If unspecified, the options within a container's SecurityContext
-                        will be used. If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence.
-                      properties:
-                        gmsaCredentialSpec:
-                          description: GMSACredentialSpec is where the GMSA admission
-                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                            inlines the contents of the GMSA credential spec named
-                            by the GMSACredentialSpecName field.
-                          type: string
-                        gmsaCredentialSpecName:
-                          description: GMSACredentialSpecName is the name of the GMSA
-                            credential spec to use.
-                          type: string
-                        runAsUserName:
-                          description: The UserName in Windows to run the entrypoint
-                            of the container process. Defaults to the user specified
-                            in image metadata if unspecified. May also be set in PodSecurityContext.
-                            If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence.
-                          type: string
-                      type: object
-                  type: object
-                sidecars:
-                  description: Sidecars defines sidecar containers running alongside
-                    with the main function container in the pod.
-                  items:
-                    description: A single application container that you want to run
-                      within a pod. The Container API from the core group is not used
-                      directly to avoid unneeded fields and reduce the size of the
-                      CRD. New fields could be added as needed.
-                    properties:
-                      args:
-                        description: Arguments to the entrypoint.
-                        items:
-                          type: string
-                        type: array
-                      command:
-                        description: Entrypoint array. Not executed within a shell.
-                        items:
-                          type: string
-                        type: array
-                      env:
-                        description: List of environment variables to set in the container.
-                        items:
-                          description: EnvVar represents an environment variable present
-                            in a Container.
-                          properties:
-                            name:
-                              description: Name of the environment variable. Must
-                                be a C_IDENTIFIER.
-                              type: string
-                            value:
-                              description: 'Variable references $(VAR_NAME) are expanded
-                                using the previous defined environment variables in
-                                the container and any service environment variables.
-                                If a variable cannot be resolved, the reference in
-                                the input string will be unchanged. The $(VAR_NAME)
-                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
-                                Escaped references will never be expanded, regardless
-                                of whether the variable exists or not. Defaults to
-                                "".'
-                              type: string
-                            valueFrom:
-                              description: Source for the environment variable's value.
-                                Cannot be used if value is not empty.
-                              properties:
-                                configMapKeyRef:
-                                  description: Selects a key of a ConfigMap.
-                                  properties:
-                                    key:
-                                      description: The key to select.
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the ConfigMap or
-                                        its key must be defined
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
-                                fieldRef:
-                                  description: 'Selects a field of the pod: supports
-                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                    spec.serviceAccountName, status.hostIP, status.podIP,
-                                    status.podIPs.'
-                                  properties:
-                                    apiVersion:
-                                      description: Version of the schema the FieldPath
-                                        is written in terms of, defaults to "v1".
-                                      type: string
-                                    fieldPath:
-                                      description: Path of the field to select in
-                                        the specified API version.
-                                      type: string
-                                  required:
-                                    - fieldPath
-                                  type: object
-                                resourceFieldRef:
-                                  description: 'Selects a resource of the container:
-                                    only resources limits and requests (limits.cpu,
-                                    limits.memory, limits.ephemeral-storage, requests.cpu,
-                                    requests.memory and requests.ephemeral-storage)
-                                    are currently supported.'
-                                  properties:
-                                    containerName:
-                                      description: 'Container name: required for volumes,
-                                        optional for env vars'
-                                      type: string
-                                    divisor:
-                                      anyOf:
-                                        - type: integer
-                                        - type: string
-                                      description: Specifies the output format of
-                                        the exposed resources, defaults to "1"
-                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                      x-kubernetes-int-or-string: true
-                                    resource:
-                                      description: 'Required: resource to select'
-                                      type: string
-                                  required:
-                                    - resource
-                                  type: object
-                                secretKeyRef:
-                                  description: Selects a key of a secret in the pod's
-                                    namespace
-                                  properties:
-                                    key:
-                                      description: The key of the secret to select
-                                        from.  Must be a valid secret key.
-                                      type: string
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                    optional:
-                                      description: Specify whether the Secret or its
-                                        key must be defined
-                                      type: boolean
-                                  required:
-                                    - key
-                                  type: object
-                              type: object
-                          required:
-                            - name
-                          type: object
-                        type: array
-                      envFrom:
-                        description: List of sources to populate environment variables
-                          in the container.
-                        items:
-                          description: EnvFromSource represents the source of a set
-                            of ConfigMaps
-                          properties:
-                            configMapRef:
-                              description: The ConfigMap to select from
-                              properties:
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap must
-                                    be defined
-                                  type: boolean
-                              type: object
-                            prefix:
-                              description: An optional identifier to prepend to each
-                                key in the ConfigMap. Must be a C_IDENTIFIER.
-                              type: string
-                            secretRef:
-                              description: The Secret to select from
-                              properties:
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret must be
-                                    defined
-                                  type: boolean
-                              type: object
-                          type: object
-                        type: array
-                      image:
-                        description: Docker image name.
-                        type: string
-                      imagePullPolicy:
-                        description: Image pull policy.
-                        type: string
-                      livenessProbe:
-                        description: Periodic probe of container liveness.
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      name:
-                        description: Name of the container specified as a DNS_LABEL.
-                          Each container in a pod must have a unique name (DNS_LABEL).
-                        type: string
-                      ports:
-                        description: List of ports to expose from the container.
-                        items:
-                          description: ContainerPort represents a network port in
-                            a single container.
-                          properties:
-                            containerPort:
-                              description: Number of port to expose on the pod's IP
-                                address. This must be a valid port number, 0 < x <
-                                65536.
-                              format: int32
-                              type: integer
-                            hostIP:
-                              description: What host IP to bind the external port
-                                to.
-                              type: string
-                            hostPort:
-                              description: Number of port to expose on the host. If
-                                specified, this must be a valid port number, 0 < x
-                                < 65536. If HostNetwork is specified, this must match
-                                ContainerPort. Most containers do not need this.
-                              format: int32
-                              type: integer
-                            name:
-                              description: If specified, this must be an IANA_SVC_NAME
-                                and unique within the pod. Each named port in a pod
-                                must have a unique name. Name for the port that can
-                                be referred to by services.
-                              type: string
-                            protocol:
-                              description: Protocol for port. Must be UDP, TCP, or
-                                SCTP. Defaults to "TCP".
-                              type: string
-                          required:
-                            - containerPort
-                          type: object
-                        type: array
-                        x-kubernetes-list-map-keys:
-                          - containerPort
-                        x-kubernetes-list-type: map
-                      readinessProbe:
-                        description: 'Periodic probe of container service readiness.
-                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      resources:
-                        description: Compute Resources required by this container.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                                - type: integer
-                                - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                            type: object
-                        type: object
-                      startupProbe:
-                        description: StartupProbe indicates that the Pod has successfully
-                          initialized.
-                        properties:
-                          exec:
-                            description: One and only one of the following should
-                              be specified. Exec specifies the action to take.
-                            properties:
-                              command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for
-                                  the command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|',
-                                  etc) won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
-                                items:
-                                  type: string
-                                type: array
-                            type: object
-                          failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          httpGet:
-                            description: HTTPGet specifies the http request to perform.
-                            properties:
-                              host:
-                                description: Host name to connect to, defaults to
-                                  the pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
-                                type: string
-                              httpHeaders:
-                                description: Custom headers to set in the request.
-                                  HTTP allows repeated headers.
-                                items:
-                                  description: HTTPHeader describes a custom header
-                                    to be used in HTTP probes
-                                  properties:
-                                    name:
-                                      description: The header field name
-                                      type: string
-                                    value:
-                                      description: The header field value
-                                      type: string
-                                  required:
-                                    - name
-                                    - value
-                                  type: object
-                                type: array
-                              path:
-                                description: Path to access on the HTTP server.
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Name or number of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                              scheme:
-                                description: Scheme to use for connecting to the host.
-                                  Defaults to HTTP.
-                                type: string
-                            required:
-                              - port
-                            type: object
-                          initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                              started before liveness probes are initiated. More info:
-                              https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                          periodSeconds:
-                            description: How often (in seconds) to perform the probe.
-                              Default to 10 seconds. Minimum value is 1.
-                            format: int32
-                            type: integer
-                          successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
-                            format: int32
-                            type: integer
-                          tcpSocket:
-                            description: 'TCPSocket specifies an action involving
-                              a TCP port. TCP hooks not yet supported TODO: implement
-                              a realistic TCP lifecycle hook'
-                            properties:
-                              host:
-                                description: 'Optional: Host name to connect to, defaults
-                                  to the pod IP.'
-                                type: string
-                              port:
-                                anyOf:
-                                  - type: integer
-                                  - type: string
-                                description: Number or name of the port to access
-                                  on the container. Number must be in the range 1
-                                  to 65535. Name must be an IANA_SVC_NAME.
-                                x-kubernetes-int-or-string: true
-                            required:
-                              - port
-                            type: object
-                          timeoutSeconds:
-                            description: 'Number of seconds after which the probe
-                              times out. Defaults to 1 second. Minimum value is 1.
-                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                            format: int32
-                            type: integer
-                        type: object
-                      volumeMounts:
-                        description: Pod volumes to mount into the container's filesystem.
-                        items:
-                          description: VolumeMount describes a mounting of a Volume
-                            within a container.
-                          properties:
-                            mountPath:
-                              description: Path within the container at which the
-                                volume should be mounted.  Must not contain ':'.
-                              type: string
-                            mountPropagation:
-                              description: mountPropagation determines how mounts
-                                are propagated from the host to container and the
-                                other way around. When not set, MountPropagationNone
-                                is used. This field is beta in 1.10.
-                              type: string
-                            name:
-                              description: This must match the Name of a Volume.
-                              type: string
-                            readOnly:
-                              description: Mounted read-only if true, read-write otherwise
-                                (false or unspecified). Defaults to false.
-                              type: boolean
-                            subPath:
-                              description: Path within the volume from which the container's
-                                volume should be mounted. Defaults to "" (volume's
-                                root).
-                              type: string
-                            subPathExpr:
-                              description: Expanded path within the volume from which
-                                the container's volume should be mounted. Behaves
-                                similarly to SubPath but environment variable references
-                                $(VAR_NAME) are expanded using the container's environment.
-                                Defaults to "" (volume's root). SubPathExpr and SubPath
-                                are mutually exclusive.
-                              type: string
-                          required:
-                            - mountPath
-                            - name
-                          type: object
-                        type: array
-                      workingDir:
-                        description: Container's working directory.
-                        type: string
-                    required:
-                      - name
-                    type: object
-                  type: array
-                terminationGracePeriodSeconds:
-                  description: TerminationGracePeriodSeconds is the amount of time
-                    that kubernetes will give for a pod before terminating it.
-                  format: int64
-                  type: integer
-                tolerations:
-                  description: Tolerations specifies the tolerations of a Pod
-                  items:
-                    description: The pod this Toleration is attached to tolerates
-                      any taint that matches the triple <key,value,effect> using the
-                      matching operator <operator>.
-                    properties:
-                      effect:
-                        description: Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
-                        type: string
-                      key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match
-                          all values and all keys.
-                        type: string
-                      operator:
-                        description: Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to
-                          Equal. Exists is equivalent to wildcard for value, so that
-                          a pod can tolerate all taints of a particular category.
-                        type: string
-                      tolerationSeconds:
-                        description: TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default,
-                          it is not set, which means tolerate the taint forever (do
-                          not evict). Zero and negative values will be treated as
-                          0 (evict immediately) by the system.
-                        format: int64
-                        type: integer
-                      value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
-                        type: string
-                    type: object
-                  type: array
-                vars:
-                  description: Vars specifies the environment variables of a Pod
-                  items:
-                    description: EnvVar represents an environment variable present
-                      in a Container.
-                    properties:
-                      name:
-                        description: Name of the environment variable. Must be a C_IDENTIFIER.
-                        type: string
-                      value:
-                        description: 'Variable references $(VAR_NAME) are expanded
-                          using the previous defined environment variables in the
-                          container and any service environment variables. If a variable
-                          cannot be resolved, the reference in the input string will
-                          be unchanged. The $(VAR_NAME) syntax can be escaped with
-                          a double $$, ie: $$(VAR_NAME). Escaped references will never
-                          be expanded, regardless of whether the variable exists or
-                          not. Defaults to "".'
-                        type: string
-                      valueFrom:
-                        description: Source for the environment variable's value.
-                          Cannot be used if value is not empty.
-                        properties:
-                          configMapKeyRef:
-                            description: Selects a key of a ConfigMap.
-                            properties:
-                              key:
-                                description: The key to select.
-                                type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a pod
+                                  must have a unique name. Name for the port that can
+                                  be referred to by services.
                                 type: string
-                              optional:
-                                description: Specify whether the ConfigMap or its
-                                  key must be defined
-                                type: boolean
-                            required:
-                              - key
-                            type: object
-                          fieldRef:
-                            description: 'Selects a field of the pod: supports metadata.name,
-                              metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                              spec.nodeName, spec.serviceAccountName, status.hostIP,
-                              status.podIP, status.podIPs.'
-                            properties:
-                              apiVersion:
-                                description: Version of the schema the FieldPath is
-                                  written in terms of, defaults to "v1".
-                                type: string
-                              fieldPath:
-                                description: Path of the field to select in the specified
-                                  API version.
+                              protocol:
+                                description: Protocol for port. Must be UDP, TCP, or
+                                  SCTP. Defaults to "TCP".
                                 type: string
                             required:
-                              - fieldPath
+                              - containerPort
                             type: object
-                          resourceFieldRef:
-                            description: 'Selects a resource of the container: only
-                              resources limits and requests (limits.cpu, limits.memory,
-                              limits.ephemeral-storage, requests.cpu, requests.memory
-                              and requests.ephemeral-storage) are currently supported.'
-                            properties:
-                              containerName:
-                                description: 'Container name: required for volumes,
-                                  optional for env vars'
-                                type: string
-                              divisor:
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - containerPort
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: Compute Resources required by this container.
+                          properties:
+                            limits:
+                              additionalProperties:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Specifies the output format of the exposed
-                                  resources, defaults to "1"
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              resource:
-                                description: 'Required: resource to select'
-                                type: string
-                            required:
-                              - resource
-                            type: object
-                          secretKeyRef:
-                            description: Selects a key of a secret in the pod's namespace
+                              description: 'Limits describes the maximum amount of compute
+                                resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of
+                                compute resources required. If Requests is omitted for
+                                a container, it defaults to Limits if that is explicitly
+                                specified, otherwise to an implementation-defined value.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: StartupProbe indicates that the Pod has successfully
+                            initialized.
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
                             properties:
-                              key:
-                                description: The key of the secret to select from.  Must
-                                  be a valid secret key.
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                description: This must match the Name of a Volume.
                                 type: string
-                              optional:
-                                description: Specify whether the Secret or its key
-                                  must be defined
+                              readOnly:
+                                description: Mounted read-only if true, read-write otherwise
+                                  (false or unspecified). Defaults to false.
                                 type: boolean
+                              subPath:
+                                description: Path within the volume from which the container's
+                                  volume should be mounted. Defaults to "" (volume's
+                                  root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from which
+                                  the container's volume should be mounted. Behaves
+                                  similarly to SubPath but environment variable references
+                                  $(VAR_NAME) are expanded using the container's environment.
+                                  Defaults to "" (volume's root). SubPathExpr and SubPath
+                                  are mutually exclusive.
+                                type: string
                             required:
-                              - key
+                              - mountPath
+                              - name
                             type: object
-                        type: object
-                    required:
-                      - name
-                    type: object
-                  type: array
-                volumes:
-                  description: Volumes defines extra volumes of the pod.
-                  items:
-                    description: Volume represents a named volume in a pod that may
-                      be accessed by any container in the pod. The Volume API from
-                      the core group is not used directly to avoid unneeded fields
-                      defined in `VolumeSource` and reduce the size of the CRD. New
-                      fields in VolumeSource could be added as needed.
+                          type: array
+                        workingDir:
+                          description: Container's working directory.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    type: array
+                  jvmOptions:
+                    description: JVMOptions defines JVM parameters
                     properties:
-                      configMap:
-                        description: ConfigMap represents a configMap that should
-                          populate this volume
-                        properties:
-                          defaultMode:
-                            description: 'Optional: mode bits used to set permissions
-                              on created files by default. Must be an octal value
-                              between 0000 and 0777 or a decimal value between 0 and
-                              511. YAML accepts both octal and decimal values, JSON
-                              requires decimal values for mode bits. Defaults to 0644.
-                              Directories within the path are not affected by this
-                              setting. This might be in conflict with other options
-                              that affect the file mode, like fsGroup, and the result
-                              can be other mode bits set.'
-                            format: int32
-                            type: integer
-                          items:
-                            description: If unspecified, each key-value pair in the
-                              Data field of the referenced ConfigMap will be projected
-                              into the volume as a file whose name is the key and
-                              content is the value. If specified, the listed keys
-                              will be projected into the specified paths, and unlisted
-                              keys will not be present. If a key is specified which
-                              is not present in the ConfigMap, the volume setup will
-                              error unless it is marked optional. Paths must be relative
-                              and may not contain the '..' path or start with '..'.
-                            items:
-                              description: Maps a string key to a path within a volume.
-                              properties:
-                                key:
-                                  description: The key to project.
-                                  type: string
-                                mode:
-                                  description: 'Optional: mode bits used to set permissions
-                                    on this file. Must be an octal value between 0000
-                                    and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON
-                                    requires decimal values for mode bits. If not
-                                    specified, the volume defaultMode will be used.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
-                                  format: int32
-                                  type: integer
-                                path:
-                                  description: The relative path of the file to map
-                                    the key to. May not be an absolute path. May not
-                                    contain the path element '..'. May not start with
-                                    the string '..'.
-                                  type: string
-                              required:
-                                - key
-                                - path
-                              type: object
-                            type: array
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                              TODO: Add other useful fields. apiVersion, kind, uid?'
-                            type: string
-                          optional:
-                            description: Specify whether the ConfigMap or its keys
-                              must be defined
-                            type: boolean
-                        type: object
-                      name:
-                        description: 'Volume''s name. Must be a DNS_LABEL and unique
-                          within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      secret:
-                        description: Secret represents a secret that should populate
-                          this volume.
-                        properties:
-                          defaultMode:
-                            description: 'Optional: mode bits used to set permissions
-                              on created files by default. Must be an octal value
-                              between 0000 and 0777 or a decimal value between 0 and
-                              511. YAML accepts both octal and decimal values, JSON
-                              requires decimal values for mode bits. Defaults to 0644.
-                              Directories within the path are not affected by this
-                              setting. This might be in conflict with other options
-                              that affect the file mode, like fsGroup, and the result
-                              can be other mode bits set.'
-                            format: int32
-                            type: integer
-                          items:
-                            description: If unspecified, each key-value pair in the
-                              Data field of the referenced Secret will be projected
-                              into the volume as a file whose name is the key and
-                              content is the value. If specified, the listed keys
-                              will be projected into the specified paths, and unlisted
-                              keys will not be present. If a key is specified which
-                              is not present in the Secret, the volume setup will
-                              error unless it is marked optional. Paths must be relative
-                              and may not contain the '..' path or start with '..'.
-                            items:
-                              description: Maps a string key to a path within a volume.
-                              properties:
-                                key:
-                                  description: The key to project.
-                                  type: string
-                                mode:
-                                  description: 'Optional: mode bits used to set permissions
-                                    on this file. Must be an octal value between 0000
-                                    and 0777 or a decimal value between 0 and 511.
-                                    YAML accepts both octal and decimal values, JSON
-                                    requires decimal values for mode bits. If not
-                                    specified, the volume defaultMode will be used.
-                                    This might be in conflict with other options that
-                                    affect the file mode, like fsGroup, and the result
-                                    can be other mode bits set.'
-                                  format: int32
-                                  type: integer
-                                path:
-                                  description: The relative path of the file to map
-                                    the key to. May not be an absolute path. May not
-                                    contain the path element '..'. May not start with
-                                    the string '..'.
-                                  type: string
-                              required:
-                                - key
-                                - path
-                              type: object
-                            type: array
-                          optional:
-                            description: Specify whether the Secret or its keys must
-                              be defined
-                            type: boolean
-                          secretName:
-                            description: 'Name of the secret in the pod''s namespace
-                              to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                            type: string
-                        type: object
-                    required:
-                      - name
+                      extraOptions:
+                        items:
+                          type: string
+                        type: array
+                      gcLoggingOptions:
+                        items:
+                          type: string
+                        type: array
+                      gcOptions:
+                        items:
+                          type: string
+                        type: array
+                      memoryOptions:
+                        items:
+                          type: string
+                        type: array
                     type: object
-                  type: array
-              type: object
-            replicas:
-              description: Replicas is the expected size of the zookeeper cluster.
-                The zookeeper operator will eventually make the size of the running
-                cluster equal to the expected size.
-              format: int32
-              type: integer
-          type: object
-        status:
-          description: ZooKeeperClusterStatus defines the observed state of ZooKeeperCluster
-          properties:
-            conditions:
-              description: Conditions represent observations of the ZookeeperCluster's
-                state
-              items:
-                description: "Condition represents an observation of an object's state.
-                  Conditions are an extension mechanism intended to be used when the
-                  details of an observation are not a priori known or would not apply
-                  to all instances of a given Kind. \n Conditions should be added
-                  to explicitly convey properties that users and components care about
-                  rather than requiring those properties to be inferred from other
-                  observations. Once defined, the meaning of a Condition can not be
-                  changed arbitrarily - it becomes part of the API, and has the same
-                  backwards- and forwards-compatibility concerns of any other part
-                  of the API."
-                properties:
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    description: ConditionReason is intended to be a one-word, CamelCase
-                      representation of the category of cause of the current status.
-                      It is intended to be used in concise output, such as one-line
-                      kubectl get output, and in summarizing occurrences of causes.
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    description: "ConditionType is the type of the condition and is
-                      typically a CamelCased word or short phrase. \n Condition types
-                      should indicate state in the \"abnormal-true\" polarity. For
-                      example, if the condition indicates when a policy is invalid,
-                      the \"is valid\" case is probably the norm, so the condition
-                      should be called \"Invalid\"."
-                    type: string
-                required:
-                  - status
-                  - type
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: Labels specifies the labels to attach to pod the operator
+                      creates for the zookeeper cluster.
+                    type: object
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    description: NodeSelector specifies a map of key-value pairs. For
+                      a pod to be eligible to run on a node, the node must have each
+                      of the indicated key-value pairs as labels.
+                    type: object
+                  resources:
+                    description: Resources specifies the resource requirements of a
+                      pod to run in the cluster
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  securityContext:
+                    description: 'SecurityContext specifies the security context for
+                      the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
+                    properties:
+                      fsGroup:
+                        description: "A special supplemental group that applies to all
+                          containers in a pod. Some volume types allow the Kubelet to
+                          change the ownership of that volume to be owned by the pod:
+                          \n 1. The owning GID will be the FSGroup 2. The setgid bit
+                          is set (new files created in the volume will be owned by FSGroup)
+                          3. The permission bits are OR'd with rw-rw---- \n If unset,
+                          the Kubelet will not modify the ownership and permissions
+                          of any volume."
+                        format: int64
+                        type: integer
+                      fsGroupChangePolicy:
+                        description: 'fsGroupChangePolicy defines behavior of changing
+                          ownership and permission of the volume before being exposed
+                          inside Pod. This field will only apply to volume types which
+                          support fsGroup based ownership(and permissions). It will
+                          have no effect on ephemeral volume types such as: secret,
+                          configmaps and emptydir. Valid values are "OnRootMismatch"
+                          and "Always". If not specified defaults to "Always".'
+                        type: string
+                      runAsGroup:
+                        description: The GID to run the entrypoint of the container
+                          process. Uses runtime default if unset. May also be set in
+                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence for
+                          that container.
+                        format: int64
+                        type: integer
+                      runAsNonRoot:
+                        description: Indicates that the container must run as a non-root
+                          user. If true, the Kubelet will validate the image at runtime
+                          to ensure that it does not run as UID 0 (root) and fail to
+                          start the container if it does. If unset or false, no such
+                          validation will be performed. May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence.
+                        type: boolean
+                      runAsUser:
+                        description: The UID to run the entrypoint of the container
+                          process. Defaults to user specified in image metadata if unspecified.
+                          May also be set in SecurityContext.  If set in both SecurityContext
+                          and PodSecurityContext, the value specified in SecurityContext
+                          takes precedence for that container.
+                        format: int64
+                        type: integer
+                      seLinuxOptions:
+                        description: The SELinux context to be applied to all containers.
+                          If unspecified, the container runtime will allocate a random
+                          SELinux context for each container.  May also be set in SecurityContext.  If
+                          set in both SecurityContext and PodSecurityContext, the value
+                          specified in SecurityContext takes precedence for that container.
+                        properties:
+                          level:
+                            description: Level is SELinux level label that applies to
+                              the container.
+                            type: string
+                          role:
+                            description: Role is a SELinux role label that applies to
+                              the container.
+                            type: string
+                          type:
+                            description: Type is a SELinux type label that applies to
+                              the container.
+                            type: string
+                          user:
+                            description: User is a SELinux user label that applies to
+                              the container.
+                            type: string
+                        type: object
+                      seccompProfile:
+                        description: The seccomp options to use by the containers in
+                          this pod.
+                        properties:
+                          localhostProfile:
+                            description: localhostProfile indicates a profile defined
+                              in a file on the node should be used. The profile must
+                              be preconfigured on the node to work. Must be a descending
+                              path, relative to the kubelet's configured seccomp profile
+                              location. Must only be set if type is "Localhost".
+                            type: string
+                          type:
+                            description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a profile
+                              defined in a file on the node should be used. RuntimeDefault
+                              - the container runtime default profile should be used.
+                              Unconfined - no profile should be applied."
+                            type: string
+                        required:
+                          - type
+                        type: object
+                      supplementalGroups:
+                        description: A list of groups applied to the first process run
+                          in each container, in addition to the container's primary
+                          GID.  If unspecified, no groups will be added to any container.
+                        items:
+                          format: int64
+                          type: integer
+                        type: array
+                      sysctls:
+                        description: Sysctls hold a list of namespaced sysctls used
+                          for the pod. Pods with unsupported sysctls (by the container
+                          runtime) might fail to launch.
+                        items:
+                          description: Sysctl defines a kernel parameter to be set
+                          properties:
+                            name:
+                              description: Name of a property to set
+                              type: string
+                            value:
+                              description: Value of a property to set
+                              type: string
+                          required:
+                            - name
+                            - value
+                          type: object
+                        type: array
+                      windowsOptions:
+                        description: The Windows specific settings applied to all containers.
+                          If unspecified, the options within a container's SecurityContext
+                          will be used. If set in both SecurityContext and PodSecurityContext,
+                          the value specified in SecurityContext takes precedence.
+                        properties:
+                          gmsaCredentialSpec:
+                            description: GMSACredentialSpec is where the GMSA admission
+                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                              inlines the contents of the GMSA credential spec named
+                              by the GMSACredentialSpecName field.
+                            type: string
+                          gmsaCredentialSpecName:
+                            description: GMSACredentialSpecName is the name of the GMSA
+                              credential spec to use.
+                            type: string
+                          runAsUserName:
+                            description: The UserName in Windows to run the entrypoint
+                              of the container process. Defaults to the user specified
+                              in image metadata if unspecified. May also be set in PodSecurityContext.
+                              If set in both SecurityContext and PodSecurityContext,
+                              the value specified in SecurityContext takes precedence.
+                            type: string
+                        type: object
+                    type: object
+                  sidecars:
+                    description: Sidecars defines sidecar containers running alongside
+                      with the main function container in the pod.
+                    items:
+                      description: A single application container that you want to run
+                        within a pod. The Container API from the core group is not used
+                        directly to avoid unneeded fields and reduce the size of the
+                        CRD. New fields could be added as needed.
+                      properties:
+                        args:
+                          description: Arguments to the entrypoint.
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          description: Entrypoint array. Not executed within a shell.
+                          items:
+                            type: string
+                          type: array
+                        env:
+                          description: List of environment variables to set in the container.
+                          items:
+                            description: EnvVar represents an environment variable present
+                              in a Container.
+                            properties:
+                              name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
+                                type: string
+                              value:
+                                description: 'Variable references $(VAR_NAME) are expanded
+                                  using the previous defined environment variables in
+                                  the container and any service environment variables.
+                                  If a variable cannot be resolved, the reference in
+                                  the input string will be unchanged. The $(VAR_NAME)
+                                  syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                  Escaped references will never be expanded, regardless
+                                  of whether the variable exists or not. Defaults to
+                                  "".'
+                                type: string
+                              valueFrom:
+                                description: Source for the environment variable's value.
+                                  Cannot be used if value is not empty.
+                                properties:
+                                  configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
+                                    properties:
+                                      key:
+                                        description: The key to select.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the ConfigMap or
+                                          its key must be defined
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                  fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                      - fieldPath
+                                    type: object
+                                  resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for volumes,
+                                          optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                          - type: integer
+                                          - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                      - resource
+                                    type: object
+                                  secretKeyRef:
+                                    description: Selects a key of a secret in the pod's
+                                      namespace
+                                    properties:
+                                      key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
+                                        type: string
+                                      name:
+                                        description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
+                                        type: string
+                                      optional:
+                                        description: Specify whether the Secret or its
+                                          key must be defined
+                                        type: boolean
+                                    required:
+                                      - key
+                                    type: object
+                                type: object
+                            required:
+                              - name
+                            type: object
+                          type: array
+                        envFrom:
+                          description: List of sources to populate environment variables
+                            in the container.
+                          items:
+                            description: EnvFromSource represents the source of a set
+                              of ConfigMaps
+                            properties:
+                              configMapRef:
+                                description: The ConfigMap to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap must
+                                      be defined
+                                    type: boolean
+                                type: object
+                              prefix:
+                                description: An optional identifier to prepend to each
+                                  key in the ConfigMap. Must be a C_IDENTIFIER.
+                                type: string
+                              secretRef:
+                                description: The Secret to select from
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret must be
+                                      defined
+                                    type: boolean
+                                type: object
+                            type: object
+                          type: array
+                        image:
+                          description: Docker image name.
+                          type: string
+                        imagePullPolicy:
+                          description: Image pull policy.
+                          type: string
+                        livenessProbe:
+                          description: Periodic probe of container liveness.
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        name:
+                          description: Name of the container specified as a DNS_LABEL.
+                            Each container in a pod must have a unique name (DNS_LABEL).
+                          type: string
+                        ports:
+                          description: List of ports to expose from the container.
+                          items:
+                            description: ContainerPort represents a network port in
+                              a single container.
+                            properties:
+                              containerPort:
+                                description: Number of port to expose on the pod's IP
+                                  address. This must be a valid port number, 0 < x <
+                                  65536.
+                                format: int32
+                                type: integer
+                              hostIP:
+                                description: What host IP to bind the external port
+                                  to.
+                                type: string
+                              hostPort:
+                                description: Number of port to expose on the host. If
+                                  specified, this must be a valid port number, 0 < x
+                                  < 65536. If HostNetwork is specified, this must match
+                                  ContainerPort. Most containers do not need this.
+                                format: int32
+                                type: integer
+                              name:
+                                description: If specified, this must be an IANA_SVC_NAME
+                                  and unique within the pod. Each named port in a pod
+                                  must have a unique name. Name for the port that can
+                                  be referred to by services.
+                                type: string
+                              protocol:
+                                description: Protocol for port. Must be UDP, TCP, or
+                                  SCTP. Defaults to "TCP".
+                                type: string
+                            required:
+                              - containerPort
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - containerPort
+                          x-kubernetes-list-type: map
+                        readinessProbe:
+                          description: 'Periodic probe of container service readiness.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        resources:
+                          description: Compute Resources required by this container.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute
+                                resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of
+                                compute resources required. If Requests is omitted for
+                                a container, it defaults to Limits if that is explicitly
+                                specified, otherwise to an implementation-defined value.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                              type: object
+                          type: object
+                        startupProbe:
+                          description: StartupProbe indicates that the Pod has successfully
+                            initialized.
+                          properties:
+                            exec:
+                              description: One and only one of the following should
+                                be specified. Exec specifies the action to take.
+                              properties:
+                                command:
+                                  description: Command is the command line to execute
+                                    inside the container, the working directory for
+                                    the command  is root ('/') in the container's filesystem.
+                                    The command is simply exec'd, it is not run inside
+                                    a shell, so traditional shell instructions ('|',
+                                    etc) won't work. To use a shell, you need to explicitly
+                                    call out to that shell. Exit status of 0 is treated
+                                    as live/healthy and non-zero is unhealthy.
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            failureThreshold:
+                              description: Minimum consecutive failures for the probe
+                                to be considered failed after having succeeded. Defaults
+                                to 3. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            httpGet:
+                              description: HTTPGet specifies the http request to perform.
+                              properties:
+                                host:
+                                  description: Host name to connect to, defaults to
+                                    the pod IP. You probably want to set "Host" in httpHeaders
+                                    instead.
+                                  type: string
+                                httpHeaders:
+                                  description: Custom headers to set in the request.
+                                    HTTP allows repeated headers.
+                                  items:
+                                    description: HTTPHeader describes a custom header
+                                      to be used in HTTP probes
+                                    properties:
+                                      name:
+                                        description: The header field name
+                                        type: string
+                                      value:
+                                        description: The header field value
+                                        type: string
+                                    required:
+                                      - name
+                                      - value
+                                    type: object
+                                  type: array
+                                path:
+                                  description: Path to access on the HTTP server.
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Name or number of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                                scheme:
+                                  description: Scheme to use for connecting to the host.
+                                    Defaults to HTTP.
+                                  type: string
+                              required:
+                                - port
+                              type: object
+                            initialDelaySeconds:
+                              description: 'Number of seconds after the container has
+                                started before liveness probes are initiated. More info:
+                                https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                            periodSeconds:
+                              description: How often (in seconds) to perform the probe.
+                                Default to 10 seconds. Minimum value is 1.
+                              format: int32
+                              type: integer
+                            successThreshold:
+                              description: Minimum consecutive successes for the probe
+                                to be considered successful after having failed. Defaults
+                                to 1. Must be 1 for liveness and startup. Minimum value
+                                is 1.
+                              format: int32
+                              type: integer
+                            tcpSocket:
+                              description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
+                              properties:
+                                host:
+                                  description: 'Optional: Host name to connect to, defaults
+                                    to the pod IP.'
+                                  type: string
+                                port:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Number or name of the port to access
+                                    on the container. Number must be in the range 1
+                                    to 65535. Name must be an IANA_SVC_NAME.
+                                  x-kubernetes-int-or-string: true
+                              required:
+                                - port
+                              type: object
+                            timeoutSeconds:
+                              description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is 1.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                              format: int32
+                              type: integer
+                          type: object
+                        volumeMounts:
+                          description: Pod volumes to mount into the container's filesystem.
+                          items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
+                            properties:
+                              mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
+                                type: string
+                              mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
+                                type: string
+                              name:
+                                description: This must match the Name of a Volume.
+                                type: string
+                              readOnly:
+                                description: Mounted read-only if true, read-write otherwise
+                                  (false or unspecified). Defaults to false.
+                                type: boolean
+                              subPath:
+                                description: Path within the volume from which the container's
+                                  volume should be mounted. Defaults to "" (volume's
+                                  root).
+                                type: string
+                              subPathExpr:
+                                description: Expanded path within the volume from which
+                                  the container's volume should be mounted. Behaves
+                                  similarly to SubPath but environment variable references
+                                  $(VAR_NAME) are expanded using the container's environment.
+                                  Defaults to "" (volume's root). SubPathExpr and SubPath
+                                  are mutually exclusive.
+                                type: string
+                            required:
+                              - mountPath
+                              - name
+                            type: object
+                          type: array
+                        workingDir:
+                          description: Container's working directory.
+                          type: string
+                      required:
+                        - name
+                      type: object
+                    type: array
+                  terminationGracePeriodSeconds:
+                    description: TerminationGracePeriodSeconds is the amount of time
+                      that kubernetes will give for a pod before terminating it.
+                    format: int64
+                    type: integer
+                  tolerations:
+                    description: Tolerations specifies the tolerations of a Pod
+                    items:
+                      description: The pod this Toleration is attached to tolerates
+                        any taint that matches the triple <key,value,effect> using the
+                        matching operator <operator>.
+                      properties:
+                        effect:
+                          description: Effect indicates the taint effect to match. Empty
+                            means match all taint effects. When specified, allowed values
+                            are NoSchedule, PreferNoSchedule and NoExecute.
+                          type: string
+                        key:
+                          description: Key is the taint key that the toleration applies
+                            to. Empty means match all taint keys. If the key is empty,
+                            operator must be Exists; this combination means to match
+                            all values and all keys.
+                          type: string
+                        operator:
+                          description: Operator represents a key's relationship to the
+                            value. Valid operators are Exists and Equal. Defaults to
+                            Equal. Exists is equivalent to wildcard for value, so that
+                            a pod can tolerate all taints of a particular category.
+                          type: string
+                        tolerationSeconds:
+                          description: TolerationSeconds represents the period of time
+                            the toleration (which must be of effect NoExecute, otherwise
+                            this field is ignored) tolerates the taint. By default,
+                            it is not set, which means tolerate the taint forever (do
+                            not evict). Zero and negative values will be treated as
+                            0 (evict immediately) by the system.
+                          format: int64
+                          type: integer
+                        value:
+                          description: Value is the taint value the toleration matches
+                            to. If the operator is Exists, the value should be empty,
+                            otherwise just a regular string.
+                          type: string
+                      type: object
+                    type: array
+                  vars:
+                    description: Vars specifies the environment variables of a Pod
+                    items:
+                      description: EnvVar represents an environment variable present
+                        in a Container.
+                      properties:
+                        name:
+                          description: Name of the environment variable. Must be a C_IDENTIFIER.
+                          type: string
+                        value:
+                          description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a variable
+                            cannot be resolved, the reference in the input string will
+                            be unchanged. The $(VAR_NAME) syntax can be escaped with
+                            a double $$, ie: $$(VAR_NAME). Escaped references will never
+                            be expanded, regardless of whether the variable exists or
+                            not. Defaults to "".'
+                          type: string
+                        valueFrom:
+                          description: Source for the environment variable's value.
+                            Cannot be used if value is not empty.
+                          properties:
+                            configMapKeyRef:
+                              description: Selects a key of a ConfigMap.
+                              properties:
+                                key:
+                                  description: The key to select.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the ConfigMap or its
+                                    key must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                            fieldRef:
+                              description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                spec.nodeName, spec.serviceAccountName, status.hostIP,
+                                status.podIP, status.podIPs.'
+                              properties:
+                                apiVersion:
+                                  description: Version of the schema the FieldPath is
+                                    written in terms of, defaults to "v1".
+                                  type: string
+                                fieldPath:
+                                  description: Path of the field to select in the specified
+                                    API version.
+                                  type: string
+                              required:
+                                - fieldPath
+                              type: object
+                            resourceFieldRef:
+                              description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
+                              properties:
+                                containerName:
+                                  description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                  type: string
+                                divisor:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  description: Specifies the output format of the exposed
+                                    resources, defaults to "1"
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                resource:
+                                  description: 'Required: resource to select'
+                                  type: string
+                              required:
+                                - resource
+                              type: object
+                            secretKeyRef:
+                              description: Selects a key of a secret in the pod's namespace
+                              properties:
+                                key:
+                                  description: The key of the secret to select from.  Must
+                                    be a valid secret key.
+                                  type: string
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: Specify whether the Secret or its key
+                                    must be defined
+                                  type: boolean
+                              required:
+                                - key
+                              type: object
+                          type: object
+                      required:
+                        - name
+                      type: object
+                    type: array
+                  volumes:
+                    description: Volumes defines extra volumes of the pod.
+                    items:
+                      description: Volume represents a named volume in a pod that may
+                        be accessed by any container in the pod. The Volume API from
+                        the core group is not used directly to avoid unneeded fields
+                        defined in `VolumeSource` and reduce the size of the CRD. New
+                        fields in VolumeSource could be added as needed.
+                      properties:
+                        configMap:
+                          description: ConfigMap represents a configMap that should
+                            populate this volume
+                          properties:
+                            defaultMode:
+                              description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0 and
+                                511. YAML accepts both octal and decimal values, JSON
+                                requires decimal values for mode bits. Defaults to 0644.
+                                Directories within the path are not affected by this
+                                setting. This might be in conflict with other options
+                                that affect the file mode, like fsGroup, and the result
+                                can be other mode bits set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: If unspecified, each key-value pair in the
+                                Data field of the referenced ConfigMap will be projected
+                                into the volume as a file whose name is the key and
+                                content is the value. If specified, the listed keys
+                                will be projected into the specified paths, and unlisted
+                                keys will not be present. If a key is specified which
+                                is not present in the ConfigMap, the volume setup will
+                                error unless it is marked optional. Paths must be relative
+                                and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a volume.
+                                properties:
+                                  key:
+                                    description: The key to project.
+                                    type: string
+                                  mode:
+                                    description: 'Optional: mode bits used to set permissions
+                                      on this file. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON
+                                      requires decimal values for mode bits. If not
+                                      specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that
+                                      affect the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: The relative path of the file to map
+                                      the key to. May not be an absolute path. May not
+                                      contain the path element '..'. May not start with
+                                      the string '..'.
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                type: object
+                              type: array
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its keys
+                                must be defined
+                              type: boolean
+                          type: object
+                        name:
+                          description: 'Volume''s name. Must be a DNS_LABEL and unique
+                            within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                          type: string
+                        secret:
+                          description: Secret represents a secret that should populate
+                            this volume.
+                          properties:
+                            defaultMode:
+                              description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0 and
+                                511. YAML accepts both octal and decimal values, JSON
+                                requires decimal values for mode bits. Defaults to 0644.
+                                Directories within the path are not affected by this
+                                setting. This might be in conflict with other options
+                                that affect the file mode, like fsGroup, and the result
+                                can be other mode bits set.'
+                              format: int32
+                              type: integer
+                            items:
+                              description: If unspecified, each key-value pair in the
+                                Data field of the referenced Secret will be projected
+                                into the volume as a file whose name is the key and
+                                content is the value. If specified, the listed keys
+                                will be projected into the specified paths, and unlisted
+                                keys will not be present. If a key is specified which
+                                is not present in the Secret, the volume setup will
+                                error unless it is marked optional. Paths must be relative
+                                and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a volume.
+                                properties:
+                                  key:
+                                    description: The key to project.
+                                    type: string
+                                  mode:
+                                    description: 'Optional: mode bits used to set permissions
+                                      on this file. Must be an octal value between 0000
+                                      and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON
+                                      requires decimal values for mode bits. If not
+                                      specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that
+                                      affect the file mode, like fsGroup, and the result
+                                      can be other mode bits set.'
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: The relative path of the file to map
+                                      the key to. May not be an absolute path. May not
+                                      contain the path element '..'. May not start with
+                                      the string '..'.
+                                    type: string
+                                required:
+                                  - key
+                                  - path
+                                type: object
+                              type: array
+                            optional:
+                              description: Specify whether the Secret or its keys must
+                                be defined
+                              type: boolean
+                            secretName:
+                              description: 'Name of the secret in the pod''s namespace
+                                to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              type: string
+                          type: object
+                      required:
+                        - name
+                      type: object
+                    type: array
                 type: object
-              type: array
-            externalServiceEndpoint:
-              description: ExternalServiceEndpoint is the external service endpoint
-                (ip:port)
-              type: string
-            internalServiceEndpoint:
-              description: InternalServiceEndpoint is the internal service endpoint
-                (ip:port)
-              type: string
-            numReadyServers:
-              description: NumReadyServers is the number of zookeeper servers in the
-                cluster that are in ready status
-              format: int32
-              type: integer
-            observedGeneration:
-              description: ObservedGeneration is the most recent generation observed
-                for this cluster. It corresponds to the metadata generation, which
-                is updated on mutation by the API Server.
-              format: int64
-              type: integer
-            readyReplicas:
-              description: ReadyReplicas is the number of ready zookeeper servers
-                in the cluster
-              format: int32
-              type: integer
-            replicas:
-              description: Replicas is the number of desired zookeeper servers in
-                the cluster
-              format: int32
-              type: integer
-            servers:
-              description: Servers is the list of servers in the zookeeper cluster
-              properties:
-                notReady:
-                  items:
-                    type: string
-                  type: array
-                ready:
-                  items:
-                    type: string
-                  type: array
-              required:
-                - notReady
-                - ready
-              type: object
-            updatedReplicas:
-              description: UpdatedReplicas is the number of zookeeper servers that
-                has been updated to the latest configuration
-              format: int32
-              type: integer
-          required:
-            - conditions
-            - externalServiceEndpoint
-            - internalServiceEndpoint
-            - numReadyServers
-            - replicas
-            - servers
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+              replicas:
+                description: Replicas is the expected size of the zookeeper cluster.
+                  The zookeeper operator will eventually make the size of the running
+                  cluster equal to the expected size.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: ZooKeeperClusterStatus defines the observed state of ZooKeeperCluster
+            properties:
+              conditions:
+                description: Conditions represent observations of the ZookeeperCluster's
+                  state
+                items:
+                  description: "Condition represents an observation of an object's state.
+                    Conditions are an extension mechanism intended to be used when the
+                    details of an observation are not a priori known or would not apply
+                    to all instances of a given Kind. \n Conditions should be added
+                    to explicitly convey properties that users and components care about
+                    rather than requiring those properties to be inferred from other
+                    observations. Once defined, the meaning of a Condition can not be
+                    changed arbitrarily - it becomes part of the API, and has the same
+                    backwards- and forwards-compatibility concerns of any other part
+                    of the API."
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      description: ConditionReason is intended to be a one-word, CamelCase
+                        representation of the category of cause of the current status.
+                        It is intended to be used in concise output, such as one-line
+                        kubectl get output, and in summarizing occurrences of causes.
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: "ConditionType is the type of the condition and is
+                        typically a CamelCased word or short phrase. \n Condition types
+                        should indicate state in the \"abnormal-true\" polarity. For
+                        example, if the condition indicates when a policy is invalid,
+                        the \"is valid\" case is probably the norm, so the condition
+                        should be called \"Invalid\"."
+                      type: string
+                  required:
+                    - status
+                    - type
+                  type: object
+                type: array
+              externalServiceEndpoint:
+                description: ExternalServiceEndpoint is the external service endpoint
+                  (ip:port)
+                type: string
+              internalServiceEndpoint:
+                description: InternalServiceEndpoint is the internal service endpoint
+                  (ip:port)
+                type: string
+              numReadyServers:
+                description: NumReadyServers is the number of zookeeper servers in the
+                  cluster that are in ready status
+                format: int32
+                type: integer
+              observedGeneration:
+                description: ObservedGeneration is the most recent generation observed
+                  for this cluster. It corresponds to the metadata generation, which
+                  is updated on mutation by the API Server.
+                format: int64
+                type: integer
+              readyReplicas:
+                description: ReadyReplicas is the number of ready zookeeper servers
+                  in the cluster
+                format: int32
+                type: integer
+              replicas:
+                description: Replicas is the number of desired zookeeper servers in
+                  the cluster
+                format: int32
+                type: integer
+              servers:
+                description: Servers is the list of servers in the zookeeper cluster
+                properties:
+                  notReady:
+                    items:
+                      type: string
+                    type: array
+                  ready:
+                    items:
+                      type: string
+                    type: array
+                required:
+                  - notReady
+                  - ready
+                type: object
+              updatedReplicas:
+                description: UpdatedReplicas is the number of zookeeper servers that
+                  has been updated to the latest configuration
+                format: int32
+                type: integer
+            required:
+              - conditions
+              - externalServiceEndpoint
+              - internalServiceEndpoint
+              - numReadyServers
+              - replicas
+              - servers
+            type: object
+        type: object
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
Signed-off-by: Eric Shen <ericshenyuhao@outlook.com>

### Motivation

Fix issue: https://github.com/streamnative/charts/issues/318

CRD v1beta1 is removed in k8s v1.22 [API removals for Kubernetes v1.22](https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/#api-changes), so we need to migrate the crd to v1.

### Changes

Migrate the CRDs in function-mesh-operator and pulsar-operator from v1beta1 to v1.

```
$ kc version
Client Version: version.Info{Major:"1", Minor:"22", GitVersion:"v1.22.1", GitCommit:"632ed300f2c34f6d6d15ca4cef3d3c7073412212", GitTreeState:"clean", BuildDate:"2021-08-19T15:45:37Z", GoVersion:"go1.16.7", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"22", GitVersion:"v1.22.1", GitCommit:"632ed300f2c34f6d6d15ca4cef3d3c7073412212", GitTreeState:"clean", BuildDate:"2021-08-25T19:54:13Z", GoVersion:"go1.16.7", Compiler:"gc", Platform:"linux/amd64"}

$ kc get crds
NAME                                            CREATED AT
bookkeeperclusters.bookkeeper.streamnative.io   2021-10-06T23:09:38Z
functionmeshes.compute.functionmesh.io          2021-10-06T23:10:16Z
functions.compute.functionmesh.io               2021-10-06T23:10:28Z
pulsarbrokers.pulsar.streamnative.io            2021-10-06T23:09:46Z
pulsarproxies.pulsar.streamnative.io            2021-10-06T23:09:52Z
sinks.compute.functionmesh.io                   2021-10-06T23:10:35Z
sources.compute.functionmesh.io                 2021-10-06T23:10:40Z
zookeeperclusters.zookeeper.streamnative.io     2021-10-06T23:09:58Z
```