### PR TITLE
[sn-platform] Use broker service discovery instead of zookeeper based discovery

### DIFF
--- a/charts/sn-platform/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-cluster.yaml
@@ -133,13 +133,6 @@ spec:
     tls:
       enabled: {{ and (.Values.tls.enabled) (.Values.tls.proxy.enabled) }}
     custom:
-      zookeeperServers: "{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
-      {{- if .Values.pulsar_metadata.configurationStore }}
-      configurationStoreServers: "{{ .Values.pulsar_metadata.configurationStore }}{{ .Values.pulsar_metadata.configurationStoreMetadataPrefix }}"
-      {{- end }}
-      {{- if not .Values.pulsar_metadata.configurationStore }}
-      configurationStoreServers: "{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
-      {{- end }}
 {{ toYaml .Values.proxy.configData | indent 6 }}
       {{- if and (.Values.auth.vault.enabled) (.Values.auth.oauth.enabled) }}
       authenticationEnabled: "true"

--- a/charts/sn-platform/templates/proxy/proxy-configmap.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-configmap.yaml
@@ -31,16 +31,6 @@ metadata:
     "helm.sh/resource-policy": keep
     {{- end }}
 data:
-  # Metadata settings
-  zookeeperServers: "{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
-  {{- if .Values.pulsar_metadata.configurationStore }}
-  configurationStoreServers: "{{ .Values.pulsar_metadata.configurationStore }}{{ .Values.pulsar_metadata.configurationStoreMetadataPrefix }}"
-  {{- end }}
-  {{- if not .Values.pulsar_metadata.configurationStore }}
-  configurationStoreServers: "{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
-  {{- end }}
-
-
   # Proxy settings
   clusterName: {{ template "pulsar.cluster" . }}
   httpNumThreads: "8"


### PR DESCRIPTION
When running Pulsar on Kubernetes, using broker service URL-based discovery is more reliable than using the zookeeper-based one.