### PR TITLE
Fixed grafana root url

### DIFF
--- a/charts/sn-platform/templates/grafana/grafana-deployment.yaml
+++ b/charts/sn-platform/templates/grafana/grafana-deployment.yaml
@@ -97,7 +97,7 @@ spec:
         - name: GRAFANA_DOMAIN
           value: {{ template "pulsar.control_center_domain" . }}
         - name: GRAFANA_ROOT_URL
-          value: https://{{ template "pulsar.control_center_domain" . }}{{ template "pulsar.control_center_url" . }}{{ template "pulsar.control_center_path.grafana" . }}/
+          value: {{ template "pulsar.control_center_url" . }}{{ template "pulsar.control_center_path.grafana" . }}/
         - name: GRAFANA_SERVE_FROM_SUB_PATH
           value: "true"
 {{- else }}

--- a/charts/sn-platform/templates/grafana/grafana-statefulset.yaml
+++ b/charts/sn-platform/templates/grafana/grafana-statefulset.yaml
@@ -109,7 +109,7 @@ spec:
         - name: GRAFANA_DOMAIN
           value: {{ template "pulsar.control_center_domain" . }}
         - name: GRAFANA_ROOT_URL
-          value: https://{{ template "pulsar.control_center_domain" . }}{{ template "pulsar.control_center_url" . }}{{ template "pulsar.control_center_path.grafana" . }}/
+          value: {{ template "pulsar.control_center_url" . }}{{ template "pulsar.control_center_path.grafana" . }}/
         - name: GRAFANA_SERVE_FROM_SUB_PATH
           value: "true"
 {{- else }}


### PR DESCRIPTION

The grafana control_center_domain url is the same as the control_center_url in most cases, and only one of them should be used