### PR TITLE
add support for overriding GF_AUTH_AZUREAD to grafana env

### DIFF
--- a/charts/pulsar/templates/grafana/grafana-admin-secret.yaml
+++ b/charts/pulsar/templates/grafana/grafana-admin-secret.yaml
@@ -32,4 +32,8 @@ stringData:
   GRAFANA_ADMIN_PASSWORD: {{ .Values.grafana.admin.password | default "pulsar" }}
   GRAFANA_ADMIN_USER: {{ .Values.grafana.admin.user | default "pulsar" }}
   {{- end }}
+  {{- if .Values.grafana.auth.azuread}}
+  GF_AUTH_AZUREAD_CLIENT_ID: {{ .Values.grafana.auth.azuread.client_id }}
+  GF_AUTH_AZUREAD_CLIENT_SECRET: {{ .Values.grafana.auth.azuread.client_secret }}
+  {{- end }}
 {{- end }}

--- a/charts/pulsar/templates/grafana/grafana-statefulset.yaml
+++ b/charts/pulsar/templates/grafana/grafana-statefulset.yaml
@@ -89,6 +89,18 @@ spec:
           value: http://{{ .Release.Name }}-{{ .Values.grafana.datasources.loki }}.{{ .Release.Namespace }}.svc.cluster.local:3100/
         - name: GF_LOKI_DATASOURCE_NAME
           value: {{ .Release.Name }}-{{ .Values.grafana.datasources.loki }}
+        - name: GF_AUTH_AZUREAD_ENABLED
+          value: "true"
+        - name: GF_AUTH_AZUREAD_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: "{{ template "pulsar.fullname" . }}-{{ .Values.grafana.component }}-secret"
+              key: GF_AUTH_AZUREAD_CLIENT_ID
+        - name: GF_AUTH_AZUREAD_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: "{{ template "pulsar.fullname" . }}-{{ .Values.grafana.component }}-secret"
+              key: GF_AUTH_AZUREAD_CLIENT_SECRET
         - name: GRAFANA_ADMIN_USER
           valueFrom:
             secretKeyRef:

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1507,6 +1507,10 @@ grafana:
   admin:
     user: pulsar
     password: pulsar
+  auth:
+    azuread:
+      client_id: "theSSOClientID"
+      client_secret: "xxx"
 
 ## Monitoring Stack: node_exporteer
 ## templates/node-exporter.yaml


### PR DESCRIPTION
This adds support for overriding GF_AUTH_AZUREAD to grafana env, which will enable Oauth2 of Azure.

Issue see: [#336]

slack chat: [a_streamnative_lego](https://streamnative.slack.com/archives/C025JQZQ5S7/p1634551618242500)