### PR TITLE
Improve azure ad configuration

### DIFF
--- a/charts/sn-platform/templates/grafana/grafana-statefulset.yaml
+++ b/charts/sn-platform/templates/grafana/grafana-statefulset.yaml
@@ -92,7 +92,6 @@ spec:
         {{- if .Values.grafana.azureAuthEnabled }}
         - name: GF_AUTH_AZUREAD_ENABLED
           value: "true"
-        {{- end }}
         - name: GF_AUTH_AZUREAD_CLIENT_ID
           valueFrom:
             secretKeyRef:
@@ -103,6 +102,7 @@ spec:
             secretKeyRef:
               name: "{{ template "pulsar.fullname" . }}-{{ .Values.grafana.component }}-azuread-secret"
               key: GF_AUTH_AZUREAD_CLIENT_SECRET
+        {{- end }}
         - name: GRAFANA_ADMIN_USER
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
If the `azureAuthEnabled` option is false or not set, should not try to load the secret, because the secret has not been created.