### PR TITLE
Prevent failures to launch SN console due to vault init failures

### DIFF
--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1935,7 +1935,7 @@ vault:
       cpu: "100m"
   volume:
     persistence: true
-    name: ""
+    name: "vault-volume"
     size: 10Gi
     local_storage: true
     # storageClassName: ""


### PR DESCRIPTION
When launching clusters, I had my console fail to come up because the vault-init job was erroring with errors like:

```
...vault-unseal-keys" not found   
```

That turned out to be because the vault statefulset wasn't able to launch containers, which was failing because of errors like:

```
 Warning  FailedCreate      41s (x19 over 6m41s)  statefulset-controller  create Pod pulsar-blt-sn-platform-vault-0 in StatefulSet pulsar-blt-sn-platform-vault failed error: Pod "pulsar-blt-sn-platform-vault-0" is inv │
│ alid: [spec.volumes[0].name: Invalid value: "pulsar-blt-sn-platform-vault-": a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-n │
│ ame',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?'), spec.containers[0].volumeMounts[0].name: Not found: "pulsar-blt-sn-platform-vault-", spec.initContainers[0].volumeMounts[0].name: Not  │
│ found: "pulsar-blt-sn-platform-vault-"]
```

The issue is that if, in your chart values YAML, you don't override volume settings for the `vault` section (or don't override that section at all), it creates a volume by splicing the default name, the empty string, onto a hyphen-delimited list; volume names which end in hyphen aren't allowed.

This PR defaults the vault volume name to something nonempty so that volumes can be created and SNP instances can launch.
