### PR TITLE
fix(version): bump pulsar_metadata image version

### DIFF
--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -887,7 +887,7 @@ pulsar_metadata:
     # repository: apachepulsar/pulsar-all
     # tag: 2.5.0
     repository: streamnative/sn-platform
-    tag: "2.8.1.0"
+    tag: "2.8.1.4"
     pullPolicy: IfNotPresent
   ## set an existing configuration store
   # configurationStore:


### PR DESCRIPTION
Signed-off-by: Eric Shen <ericshenyuhao@outlook.com>

Bump the `pulsar_metadata` image version from 2.8.1.0 to 2.8.1.4