### PR TITLE
Allow sn-platform to disable auth without operator

### DIFF
--- a/charts/sn-platform/templates/broker/broker-statefulset.yaml
+++ b/charts/sn-platform/templates/broker/broker-statefulset.yaml
@@ -286,8 +286,10 @@ spec:
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
+        {{- if and .Values.auth.authentication.enabled .Values.auth.vault.enabled }}
         - secretRef:
             name: {{ template "pulsar.vault-secret-key-name" . }}
+        {{- end }}
         volumeMounts:
           {{- include "pulsar.broker.token.volumeMounts" . | nindent 10 }}
           {{- include "pulsar.broker.log.volumeMounts" . | nindent 10 }}

--- a/charts/sn-platform/templates/proxy/proxy-statefulset.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-statefulset.yaml
@@ -215,8 +215,10 @@ spec:
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
+        {{- if and .Values.auth.authentication.enabled .Values.auth.vault.enabled }}
         - secretRef:
             name: {{ template "pulsar.vault-secret-key-name" . }}
+        {{- end }}
         volumeMounts:
           {{- include "pulsar.proxy.log.volumeMounts" . | nindent 10 }}
           {{- include "pulsar.proxy.token.volumeMounts" . | nindent 10 }}


### PR DESCRIPTION
Add secretRef of vault key to broker & proxy pods only when auth & vault are both enabled.