### PR TITLE
Add default org and instance name for console

### DIFF
--- a/charts/sn-console/values.yaml
+++ b/charts/sn-console/values.yaml
@@ -95,9 +95,9 @@ service:
 ## https://docs.streamnative.io/platform/v1.2.0/operator-guides/configure/streamnative-console
 configData:
   # *required*: the organization name to show in the SN console
-  DEFAULT_ORGANIZATION: ""
+  DEFAULT_ORGANIZATION: "streamnative"
   # *required*: the instance name to display for the Pulsar clusters in SN console
-  INSTANCE_NAME: ""
+  INSTANCE_NAME: "pulsar"
   REDIRECT_SCHEME: ""
   REDIRECT_HOST: ""
   REDIRECT_PORT: ""

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1734,9 +1734,9 @@ streamnative_console:
   ## https://docs.streamnative.io/platform/v1.2.0/operator-guides/configure/streamnative-console
   configData:
     # *required*: the organization name to show in the SN console
-    DEFAULT_ORGANIZATION: ""
+    DEFAULT_ORGANIZATION: "streamnative"
     # *required*: the instance name to display for the Pulsar clusters in SN console
-    INSTANCE_NAME: ""
+    INSTANCE_NAME: "pulsar"
     GOOGLE_REDIRECT_URI: ""
     REDIRECT_SCHEME: ""
     REDIRECT_HOST: ""


### PR DESCRIPTION

When starting platform, some users often forget to configure the organization and instance name, so add a default value here, and you can override it in your custom values.yaml file