### PR TITLE
fix(charts): correct the pulsar manager image version

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -176,7 +176,7 @@ images:
     pullPolicy: IfNotPresent
   pulsar_manager:
     repository: streamnative/pulsar-manager
-    tag: 0.6.0
+    tag: 0.3.0
     pullPolicy: IfNotPresent
     hasCommand: false
   node_exporter:


### PR DESCRIPTION
Signed-off-by: Eric Shen <ericshenyuhao@outlook.com>

### Motivation

We don't have the 0.6.0 image tag for [streamnative/pulsar-manager](https://hub.docker.com/r/streamnative/pulsar-manager/tags), so correct the tag to 0.3.0