### PR TITLE
Use the NIOServerCnxnFactory for zookeeper in chars pulsar

### DIFF
--- a/charts/pulsar/templates/zookeeper/zookeeper-configmap.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-configmap.yaml
@@ -34,8 +34,8 @@ data:
   PULSAR_PREFIX_dataLogDir: /pulsar/data/zookeeper-datalog
   {{- end }}
   {{- if .Values.zookeeper.useNettyIO }}
-  PULSAR_PREFIX_serverCnxnFactory: org.apache.zookeeper.server.NettyServerCnxnFactory
-  serverCnxnFactory: org.apache.zookeeper.server.NettyServerCnxnFactory
+  PULSAR_PREFIX_serverCnxnFactory: org.apache.zookeeper.server.NIOServerCnxnFactory
+  serverCnxnFactory: org.apache.zookeeper.server.NIOServerCnxnFactory
   {{- end }}
   # enable zookeeper tls
   {{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}


### PR DESCRIPTION
# Issue

I updated the version of components in chars `pulsar` to `2.9.0-candidate-4`, but I met an NPE problem when initializing the zookeeper cluster.

![image](https://user-images.githubusercontent.com/15029908/142847886-740c105b-de45-458a-a6b9-88ad858f7139.png)

refer to issue https://github.com/apache/pulsar/issues/11070

# Modify

For charts pulsar, use the `org.apache.zookeeper.server.NIOServerCnxnFactory` as the default serverCnxnFactory of the zookeeper.