### PR TITLE
Add filesystem offloader configurations in sn-platform charts

### DIFF
--- a/charts/sn-platform/templates/broker/_broker.tpl
+++ b/charts/sn-platform/templates/broker/_broker.tpl
@@ -359,6 +359,24 @@ Define gcs offload options mounts
 {{- end }}
 {{- end }}
 
+{{/* Define the filesystem offload config volumes*/}}
+{{- define "pulsar.broker.offload.filesystem.config.volumes" }}
+{{- if .Values.broker.offload.filesystem.enabled }}
+- name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}-ofc"
+  configMap:
+    name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
+{{- end }}
+{{- end }}
+
+{{/*Define the filesystem offload config volume mount*/}}
+{{- define "pulsar.broker.offload.filesystem.config.volumeMounts" }}
+{{- if .Values.broker.offload.filesystem.enabled }}
+- name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}-ofc"
+  mountPath: "{{ template "pulsar.home" .}}/conf/filesystem-config.yaml"
+  subPath: filesystem-config.yaml
+{{- end }}
+{{- end }}
+
 {{/*Define broker service account*/}}
 {{- define "pulsar.broker.serviceAccount" -}}
 {{- if .Values.broker.serviceAccount.create -}}

--- a/charts/sn-platform/templates/broker/broker-configmap.yaml
+++ b/charts/sn-platform/templates/broker/broker-configmap.yaml
@@ -150,6 +150,38 @@ data:
   PULSAR_PREFIX_kopSslTruststoreLocation: /pulsar/broker.truststore.jks
   {{- end }}
   {{- end }}
+  {{- if and .Values.broker.offload.enabled .Values.broker.offload.filesystem.enabled }}
+  PULSAR_PREFIX_fileSystemProfilePath: "{{ .Values.broker.offload.filesystem.fileSystemProfilePath }}"
+  PULSAR_PREFIX_fileSystemURI: "{{ .Values.broker.offload.filesystem.fileSystemURI }}"
+  filesystem-config.yaml: |
+    <configuration>
+    <!--file system uri, necessary-->
+    <property>
+        <name>fs.defaultFS</name>
+        <value>{{ .Values.broker.offload.filesystem.fileDefaultFS }}</value>
+    </property>
+    <property>
+        <name>hadoop.tmp.dir</name>
+        <value>{{ .Values.broker.offload.filesystem.fileTmpDir }}</value>
+    </property>
+    <property>
+        <name>io.file.buffer.size</name>
+        <value>{{ .Values.broker.offload.filesystem.fileBufferSize }}</value>
+    </property>
+    <property>
+        <name>io.seqfile.compress.blocksize</name>
+        <value>{{ .Values.broker.offload.filesystem.ioSeqfileCompressBlocksize }}</value>
+    </property>
+    <property>
+        <name>io.seqfile.compression.type</name>
+        <value>{{ .Values.broker.offload.filesystem.ioSeqFileCompressionType }}</value>
+    </property>
+    <property>
+        <name>io.map.index.interval</name>
+        <value>{{ .Values.broker.offload.filesystem.ioMapIndexInteval }}</value>
+    </property>
+    </configuration>
+  {{- end }}
 {{ toYaml .Values.broker.configData | indent 2 }}
   # Include log configuration file, If you want to configure the log level and other configuration
   # items, you can modify the configmap, and eventually it will overwrite the log4j2.yaml file under conf

--- a/charts/sn-platform/templates/broker/broker-statefulset.yaml
+++ b/charts/sn-platform/templates/broker/broker-statefulset.yaml
@@ -297,6 +297,7 @@ spec:
           {{- include "pulsar.broker.runtime.volumeMounts" . | nindent 10 }}
           {{- include "pulsar.broker.offload.volumeMounts" . | nindent 10 }}
           {{- include "pulsar.function.worker.config.volumeMounts" . | nindent 10 }}
+          {{- include "pulsar.broker.offload.filesystem.config.volumeMounts" . | nindent 10 }}
 {{- with .Values.broker.extraVolumeMounts }}
 {{ toYaml . | indent 10 }}
 {{- end }}
@@ -307,6 +308,7 @@ spec:
       {{- include "pulsar.broker.runtime.volumes" . | nindent 6 }}
       {{- include "pulsar.broker.offload.volumes" . | nindent 6 }}
       {{- include "pulsar.function.worker.config.volumes" . | nindent 6 }}
+      {{- include "pulsar.broker.offload.filesystem.config.volumes" . | nindent 6 }}
 {{- with .Values.broker.extraVolumes }}
 {{ toYaml . | indent 6 }}
 {{- end }}

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1073,6 +1073,16 @@ broker:
       #   [secret name]
       # ```
       # secret: [k8s secret that stores AWS credentials]
+    filesystem:
+      enabled: false
+      fileSystemURI: "file:///pulsar/data"
+      fileSystemProfilePath: "/pulsar/conf/filesystem-config.yaml"
+      fileDefaultFS: ""
+      fileTmpDir: "pulsar"
+      fileBuffersize: "4096"
+      ioSeqfileCompressBlocksize: "1000000"
+      ioSeqFileCompressionType: "BLOCK"
+      ioMapIndexInteval: "128"
    ## Operator Controller
   ## templates/broker-cluster.yaml
   operator:


### PR DESCRIPTION
Fixes: #382 

---

*Motivation*

Allow enabling the filesystem offloader with helm charts.

*Modifications*

Add filesystem offloader configurations in the pulsar charts.