### PR TITLE
add support for custom urls to detector

### DIFF
--- a/charts/sn-platform/templates/detector/_detector.tpl
+++ b/charts/sn-platform/templates/detector/_detector.tpl
@@ -11,3 +11,21 @@
 {{ .Values.pulsar_detector.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*Define pulsar detector service url, the TCP port*/}}
+{{- define "pulsar.detector.serviceUrl" -}}
+{{- if .Values.pulsar_detector.serviceUrl -}}
+{{ .Values.pulsar_detector.serviceUrl -}}
+{{- else -}}
+{{ template "pulsar.broker.service.url" . }}
+{{- end -}}
+{{- end -}}
+
+{{/*Define pulsar detector webservice url, the admin API*/}}
+{{- define "pulsar.detector.webServiceUrl" -}}
+{{- if .Values.pulsar_detector.webServiceUrl -}}
+{{ .Values.pulsar_detector.webServiceUrl -}}
+{{- else -}}
+{{ template "pulsar.web.service.url" . }}
+{{- end -}}
+{{- end -}}

--- a/charts/sn-platform/templates/detector/pulsar-detector-statefulset.yaml
+++ b/charts/sn-platform/templates/detector/pulsar-detector-statefulset.yaml
@@ -84,7 +84,7 @@ spec:
         command: ["sh", "-c"]
         args:
         - >
-          bin/pulsar-detector -service-url {{ template "pulsar.broker.service.url" . }} -webservice-url {{ template "pulsar.web.service.url" . }} {{- if .Values.auth.authentication.enabled }} -auth-plugin token -auth-params "{\"token\":\"$brokerClientAuthenticationParameters\"}" {{- end }} ;
+          bin/pulsar-detector -service-url {{ template "pulsar.detector.serviceUrl" . }} -webservice-url {{ template "pulsar.detector.webServiceUrl" . }} {{- if .Values.auth.authentication.enabled }} -auth-plugin token -auth-params "{\"token\":\"$brokerClientAuthenticationParameters\"}" {{- end }} ;
         ports:
         # prometheus needs to access /metrics endpoint
         - name: server


### PR DESCRIPTION
We want the detector to be able to use different endpoints, potentially even "hairpin" back to external endpoint.

We should make this automatic and do the best thing based on other values, for but now just starting with custom endpoints.

