### PR TITLE
Fix issue that the pods of detector and console is not running if vault is false

### DIFF
--- a/charts/sn-platform/templates/detector/pulsar-detector-statefulset.yaml
+++ b/charts/sn-platform/templates/detector/pulsar-detector-statefulset.yaml
@@ -90,9 +90,11 @@ spec:
         - name: server
           containerPort: {{ .Values.pulsar_detector.port }}
         env:
+        {{- if .Values.components.vault }}
         - name: brokerClientAuthenticationParameters
           valueFrom:
               secretKeyRef:
                 name: {{ template "pulsar.vault-secret-key-name" . }}
                 key: brokerClientAuthenticationParameters
+        {{- end }}
 {{- end }}

--- a/charts/sn-platform/templates/streamnative-console/streamnative-console-statefulset.yaml
+++ b/charts/sn-platform/templates/streamnative-console/streamnative-console-statefulset.yaml
@@ -156,9 +156,11 @@ spec:
           - name: REDIRECT_PORT
             value: "{{ .Values.streamnative_console.configData.REDIRECT_PORT }}"
           {{- end }}
+          {{- if .Values.components.vault }}
           envFrom:
           - secretRef:
               name: {{ template "pulsar.vault-secret-key-name" . }}
+          {{- end }}
           {{- if .Values.streamnative_console.login.sso.google.enabled }}
           - secretRef:
               name: "{{ template "pulsar.fullname" . }}-{{ .Values.streamnative_console.component }}-google-oauth2-secret"


### PR DESCRIPTION
If components.vault is false, the pods of detector and console will get `CreateContainerConfigError` status, because vault related secret is not found.
![image](https://user-images.githubusercontent.com/93108425/144542915-b6fa2e5c-6715-4203-bc10-fe7d93085293.png)
