### PR TITLE
Fix issue that pod broker and pulsar-detector will get error if initialize is false as default

### DIFF
--- a/charts/sn-platform/templates/vault/vault-configmap.yaml
+++ b/charts/sn-platform/templates/vault/vault-configmap.yaml
@@ -18,7 +18,6 @@
 #
 
 {{- if .Values.components.vault }}
-{{- if .Values.initialize }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -41,5 +40,4 @@ metadata:
 data:
 {{ (.Files.Glob "conf/vault/init_vault_streamnative_console/*").AsConfig | indent 2 }}
 
-{{- end }}
 {{- end }}

--- a/charts/sn-platform/templates/vault/vault-initialize.yaml
+++ b/charts/sn-platform/templates/vault/vault-initialize.yaml
@@ -17,7 +17,6 @@
 # under the License.
 #
 
-{{- if .Values.initialize }}
 {{- if .Values.components.vault }}
 apiVersion: batch/v1
 kind: Job
@@ -76,5 +75,4 @@ spec:
       {{- include "pulsar.vault.createPulsarTokens.volumes" . | nindent 6 }}
       {{- include "pulsar.vault.initStreamNativeConsole.volumes" . | nindent 6 }}
       restartPolicy: Never
-{{- end }}
 {{- end }}


### PR DESCRIPTION
Vault has a job and configmap are controlled by `.Values.initialize`, if initialize is false, the pod broker and pulsar-detector will get status `reateContainerConfigError` because the secret `xxx-vault-secret-env-injection` is not generated.

I think the vault related resources should only be controlled by `.Values.components.vault`

```shell
Events:
  Type     Reason     Age               From               Message
  ----     ------     ----              ----               -------
  Normal   Scheduled  73s               default-scheduler  Successfully assigned fswang/pulsar-sn-platform-broker-0 to gke-sn-seagull-test-default-node-pool-6e1e7002-hkb7
  Normal   Pulled     73s               kubelet            Container image "streamnative/sn-platform:2.8.1.5-oauth2" already present on machine
  Normal   Created    73s               kubelet            Created container init-sysctl
  Normal   Started    72s               kubelet            Started container init-sysctl
  Normal   Pulled     5s (x7 over 72s)  kubelet            Container image "streamnative/sn-platform:2.8.1.5-oauth2" already present on machine
  Warning  Failed     5s (x7 over 72s)  kubelet            Error: secret "pulsar-sn-platform-vault-secret-env-injection" not found
```
```shell
$ k -n fswang get pods
NAME                                        READY   STATUS                       RESTARTS   AGE
pulsar-sn-platform-alert-manager-0          2/2     Running                      0          4m7s
pulsar-sn-platform-bookie-0                 1/1     Running                      0          3m24s
pulsar-sn-platform-bookie-1                 1/1     Running                      0          3m24s
pulsar-sn-platform-bookie-2                 1/1     Running                      0          3m24s
pulsar-sn-platform-bookie-3                 1/1     Running                      0          3m23s
pulsar-sn-platform-broker-0                 0/1     CreateContainerConfigError   0          3m34s
pulsar-sn-platform-broker-1                 0/1     CreateContainerConfigError   0          3m34s
pulsar-sn-platform-broker-2                 0/1     CreateContainerConfigError   0          3m34s
```