### PR TITLE
Fix the image tag of pulsar init job is empty

### DIFF
--- a/charts/sn-platform/templates/pulsar-cluster-initialize.yaml
+++ b/charts/sn-platform/templates/pulsar-cluster-initialize.yaml
@@ -83,7 +83,7 @@ spec:
       # This initContainer will wait for bookkeeper initnewcluster to complete
       # before initializing pulsar metadata
       - name: pulsar-bookkeeper-verify-clusterid
-        image: "{{ .Values.images.pulsar_metadata.repository }}:{{ .Values.pulsar_metadata.tag }}"
+        image: "{{ .Values.images.pulsar_metadata.repository }}:{{ .Values.images.pulsar_metadata.tag }}"
         imagePullPolicy: {{ .Values.images.pulsar_metadata.pullPolicy }}
         command: ["sh", "-c"]
         args:

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -249,11 +249,11 @@ images:
     tag: v0.8.15
     pullPolicy: IfNotPresent
   bookkeeper_operator:
-    repository: streamnative/pulsar-operator
+    repository: streamnative/bookkeeper-operator
     tag: v0.8.15
     pullPolicy: IfNotPresent
   zookeeper_operator:
-    repository: streamnative/pulsar-operator
+    repository: streamnative/zookeeper-operator
     tag: v0.8.15
     pullPolicy: IfNotPresent
   cert_manager_controller:
@@ -261,11 +261,11 @@ images:
     tag: v1.3.1
     pullPolicy: IfNotPresent
   cert_manager_cainjector:
-    repository: quay.io/jetstack/cert-manager-controller
+    repository: quay.io/jetstack/cert-manager-cainjector
     tag: v1.3.1
     pullPolicy: IfNotPresent
   cert_manager_webhook:
-    repository: quay.io/jetstack/cert-manager-controller
+    repository: quay.io/jetstack/cert-manager-webhook
     tag: v1.3.1
     pullPolicy: IfNotPresent
   vault_operator:


### PR DESCRIPTION
The installation gets blocked because of the image error

```shell
test-pulsar-sn-platform-bookie-0            0/1     Init:0/1                0          2m24s
test-pulsar-sn-platform-bookie-1            0/1     Init:0/1                0          2m24s
test-pulsar-sn-platform-bookie-2            0/1     Init:0/1                0          2m24s
test-pulsar-sn-platform-bookie-init-b5mdd   1/1     Running                 0          2m23s
test-pulsar-sn-platform-broker-0            0/1     Init:0/2                0          2m24s
test-pulsar-sn-platform-proxy-0             0/1     Init:0/2                0          2m24s
test-pulsar-sn-platform-pulsar-init-6jzq6   0/1     Init:InvalidImageName   0          2m23s
test-pulsar-sn-platform-recovery-0          0/1     Init:0/1                0          2m25s
test-pulsar-sn-platform-toolset-0           1/1     Running                 0          2m24s
test-pulsar-sn-platform-zookeeper-0         1/1     Running                 0          2m23s
test-pulsar-sn-platform-zookeeper-1         1/1     Running                 0          2m23s
test-pulsar-sn-platform-zookeeper-2         1/1     Running                 0          2m23s
```