### PR TITLE
Release pulsar-operator to 0.8.21

### DIFF
--- a/charts/pulsar-operator/Chart.yaml
+++ b/charts/pulsar-operator/Chart.yaml
@@ -18,10 +18,10 @@
 #
 
 apiVersion: v1
-appVersion: "0.8.17"
+appVersion: "0.8.21"
 description: Apache Pulsar Operators Helm chart for Kubernetes
 name: pulsar-operator
-version: 0.8.17
+version: 0.8.21
 home: https://streamnative.io
 sources:
 - https://github.com/streamnative/pulsar-operators

--- a/charts/pulsar-operator/values.yaml
+++ b/charts/pulsar-operator/values.yaml
@@ -40,7 +40,7 @@ components:
 ## Control what images to use for each component
 images:
   registry: "docker.io"
-  tag: "v0.8.17"
+  tag: "v0.8.21"
 
   zookeeper:
     registry: ""


### PR DESCRIPTION
Upgrade pulsar-operator image to v0.8.21 for the new feature
- proxy external service support extra types ClusterIP, NodePort
- Istio app labeling support