### PR TITLE
Disable authentication for KoP by default.

### DIFF
--- a/charts/pulsar/templates/broker/broker-configmap.yaml
+++ b/charts/pulsar/templates/broker/broker-configmap.yaml
@@ -155,7 +155,7 @@ data:
   PULSAR_PREFIX_brokerEntryMetadataInterceptors: "org.apache.pulsar.common.intercept.AppendBrokerTimestampMetadataInterceptor,org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor"
   PULSAR_PREFIX_brokerDeleteInactiveTopicsEnabled: "false"
   PULSAR_PREFIX_allowAutoTopicCreationType: "partitioned"
-  {{- if .Values.auth.authentication.enabled }}
+  {{- if and .Values.auth.authentication.enabled .Values.kop.auth.enabled }}
   {{- if eq .Values.auth.authentication.provider "jwt" }}
   PULSAR_PREFIX_saslAllowedMechanisms: "PLAIN"
   {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -881,6 +881,8 @@ kop:
   ports:
     plaintext: 9092
     ssl: 9093
+  auth:
+    enabled: false
 
 ## Pulsar: MoP Protocol Handler
 mop:

--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -236,7 +236,7 @@ spec:
       authorizationEnabled: "true"
       authorizationProvider: "org.apache.pulsar.broker.authorization.PulsarAuthorizationProvider"
       {{- end }}
-      {{- if .Values.broker.kop.enabled }}
+      {{- if and .Values.broker.kop.enabled .Values.kop.auth.enabled }}
       PULSAR_PREFIX_saslAllowedMechanisms: "PLAIN"
       {{- end }}
   {{- if .Values.zookeeper.customTools.restore.enable }}

--- a/charts/sn-platform/templates/broker/broker-configmap.yaml
+++ b/charts/sn-platform/templates/broker/broker-configmap.yaml
@@ -140,7 +140,7 @@ data:
   {{- end }}
   {{- if .Values.components.kop }}
   messagingProtocols: "kafka"
-  {{- if .Values.auth.authentication.enabled }}
+  {{- if and .Values.auth.authentication.enabled .Values.kop.auth.enabled }}
   {{- if eq .Values.auth.authentication.provider "jwt" }}
   PULSAR_PREFIX_saslAllowedMechanisms: "PLAIN"
   {{- end }}

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1024,7 +1024,8 @@ kop:
   ports:
     plaintext: 9092
     ssl: 9093
-
+  auth:
+    enabled: false
 ## Pulsar: Broker cluster
 ## templates/broker-statefulset.yaml
 ##


### PR DESCRIPTION
In KoP doc, auth is disabled by default, so if we enable auth for KoP by default might cause
surprise for user following KoP doc.
ref: https://github.com/streamnative/kop/blob/master/docs/security.md