### PR TITLE
Upgrade deprecated Ingress apiVersion extensions/v1beta1 to networking.k8s.io/v1

### DIFF
--- a/charts/sn-platform/templates/control-center/_control_center.tpl
+++ b/charts/sn-platform/templates/control-center/_control_center.tpl
@@ -79,3 +79,18 @@ pulsar controller ingress target port for http endpoint
 {{- print "http" -}}
 {{- end -}}
 {{- end -}}
+
+{{/* Allow kubernetes version to be overridend */}}
+{{- define "pulsar.kubeVersion" -}}
+    {{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
+{{- end -}}
+
+
+{{/* Check Ingress API version is stable or not */}}
+{{- define "pulsar.ingress.isStable" -}}
+    {{- if and (.Capabilities.APIVersions.Has "networking.k8s.io/v1") (semverCompare ">= 1.19-0" (include "pulsar.kubeVersion" .)) -}}
+        {{- print "true" -}}
+    {{- else -}}
+        {{- print "false" -}}
+    {{- end -}}
+{{- end -}}

--- a/charts/sn-platform/templates/control-center/control-center-ingress.yaml
+++ b/charts/sn-platform/templates/control-center/control-center-ingress.yaml
@@ -19,10 +19,17 @@
 
 {{- if .Values.ingress.control_center.enabled }}
 {{- $fullName := include "pulsar.fullname" . -}}
+{{- $isIngressAPIStable := eq (include "pulsar.ingress.isStable" .) "true" -}}
 
 {{/* COMMENT */}}
 
+
+
+{{- if $isIngressAPIStable }}
 apiVersion: networking.k8s.io/v1
+{{- else }}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.ingress.control_center.component }}-ingress"
@@ -62,39 +69,63 @@ spec:
         paths:
           {{- if and .Values.monitoring.grafana .Values.ingress.control_center.endpoints.grafana }}
           - path: /grafana
+            {{- if $isIngressAPIStable }}
             pathType: {{ .Values.grafana.pathType | default "ImplementationSpecific" }}
             backend:
               service:
                 name: "{{ $fullName }}-{{ .Values.grafana.component }}"
                 port:
                   number: {{ .Values.grafana.port }}
+            {{- else }}
+            backend:
+              serviceName: "{{ $fullName }}-{{ .Values.grafana.component }}"
+              servicePort: {{ .Values.grafana.port }}
+            {{- end }}
           {{- end }}
           {{- if and .Values.monitoring.alert_manager .Values.ingress.control_center.endpoints.alertmanager }}
           - path: /alerts
+            {{- if $isIngressAPIStable }}
             pathType: {{ .Values.alert_manager.pathType | default "ImplementationSpecific" }}
             backend:
               service:
                 name: "{{ $fullName }}-{{ .Values.alert_manager.component }}"
                 port:
                   number: {{ .Values.alert_manager.port }}
+            {{- else }}
+            backend:
+                serviceName: "{{ $fullName }}-{{ .Values.alert_manager.component }}"
+                servicePort: {{ .Values.alert_manager.port }}
+            {{- end }}
           {{- end }}
           {{- if and .Values.monitoring.prometheus .Values.ingress.control_center.endpoints.prometheus }}
           - path: /prometheus
+            {{- if $isIngressAPIStable }}
             pathType: {{ .Values.prometheus.pathType | default "ImplementationSpecific" }}
             backend:
               service:
                 name: "{{ $fullName }}-{{ .Values.prometheus.component }}"
                 port:
                   number: {{ .Values.prometheus.port }}
+            {{- else }}
+            backend:
+              serviceName: "{{ $fullName }}-{{ .Values.prometheus.component }}"
+              servicePort: {{ .Values.prometheus.port }}
+            {{- end }}
           {{- end }}
           {{- if .Values.components.streamnative_console }}
           - path: /
+            {{- if $isIngressAPIStable }}
             pathType: {{ .Values.streamnative_console.pathType | default "ImplementationSpecific" }}
             backend:
               service:
                 name: "{{ $fullName }}-{{ .Values.streamnative_console.component }}"
                 port: 
                   number: {{ .Values.streamnative_console.ports.frontend }}
+            {{- else }}
+            backend:
+              serviceName: "{{ $fullName }}-{{ .Values.streamnative_console.component }}"
+              servicePort: {{ .Values.streamnative_console.ports.frontend }}
+            {{- end }}
           {{- else }}
           - path: /
             backend:

--- a/charts/sn-platform/templates/control-center/control-center-ingress.yaml
+++ b/charts/sn-platform/templates/control-center/control-center-ingress.yaml
@@ -22,7 +22,7 @@
 
 {{/* COMMENT */}}
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.ingress.control_center.component }}-ingress"
@@ -62,32 +62,46 @@ spec:
         paths:
           {{- if and .Values.monitoring.grafana .Values.ingress.control_center.endpoints.grafana }}
           - path: /grafana
+            pathType: {{ .Values.grafana.pathType | default "ImplementationSpecific" }}
             backend:
-              serviceName: "{{ $fullName }}-{{ .Values.grafana.component }}"
-              servicePort: {{ .Values.grafana.port }}
+              service:
+                name: "{{ $fullName }}-{{ .Values.grafana.component }}"
+                port:
+                  number: {{ .Values.grafana.port }}
           {{- end }}
           {{- if and .Values.monitoring.alert_manager .Values.ingress.control_center.endpoints.alertmanager }}
           - path: /alerts
+            pathType: {{ .Values.alert_manager.pathType | default "ImplementationSpecific" }}
             backend:
-              serviceName: "{{ $fullName }}-{{ .Values.alert_manager.component }}"
-              servicePort: {{ .Values.alert_manager.port }}
+              service:
+                name: "{{ $fullName }}-{{ .Values.alert_manager.component }}"
+                port:
+                  number: {{ .Values.alert_manager.port }}
           {{- end }}
           {{- if and .Values.monitoring.prometheus .Values.ingress.control_center.endpoints.prometheus }}
           - path: /prometheus
+            pathType: {{ .Values.prometheus.pathType | default "ImplementationSpecific" }}
             backend:
-              serviceName: "{{ $fullName }}-{{ .Values.prometheus.component }}"
-              servicePort: {{ .Values.prometheus.port }}
+              service:
+                name: "{{ $fullName }}-{{ .Values.prometheus.component }}"
+                port:
+                  number: {{ .Values.prometheus.port }}
           {{- end }}
           {{- if .Values.components.streamnative_console }}
           - path: /
+            pathType: {{ .Values.streamnative_console.pathType | default "ImplementationSpecific" }}
             backend:
-              serviceName: "{{ $fullName }}-{{ .Values.streamnative_console.component }}"
-              servicePort: {{ .Values.streamnative_console.ports.frontend }}
+              service:
+                name: "{{ $fullName }}-{{ .Values.streamnative_console.component }}"
+                port: 
+                  number: {{ .Values.streamnative_console.ports.frontend }}
           {{- else }}
           - path: /
             backend:
-              serviceName: default
-              servicePort: 80
+              service:
+                name: default
+                port: 
+                  number: 80
           {{- end }}
       {{- if .Values.ingress.control_center.external_domain }}
       host: {{ template "pulsar.control_center_domain" . }}


### PR DESCRIPTION
Resolve https://github.com/streamnative/data-plane-epics/issues/1


When installing sn-platform by the chart, it will get these warnings
```shell
W0126 15:01:15.043974   85780 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
W0126 15:01:15.213499   85780 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
W0126 15:01:24.922246   85780 warnings.go:70] extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
W0126 15:01:47.110670   85780 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
W0126 15:01:47.197697   85780 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
W0126 15:01:51.309045   85780 warnings.go:70] extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
```

Especially, Ingress apiVersion `extensions/v1beta1` will be unavailable in v1.22+.  

This PR will not fix the warning about PodDisruptionBudget。

For chart compatibility, when Kubernetes version is less than v1.19, it will still use `extensions/v1beta1` for `Ingress`, when it's greater or equal to v1.19, it will use `networking.k8s.io/v1`
| kind |  apiVersion | kubeVersion |
| :-: | :-: | :-: |
| Ingress | `extensions/v1beta1` | < v1.19 |
| Ingress | `networking.k8s.io/v1` | >= v1.19 |

## Test cases
- install it into k8s v1.21 and v1.22
- install it into k8s v1.18
- upgrade from sn-platform:1.2.30 in k8s v1.18
- upgrade from sn-platform:1.2.30 in k8s v1.21 