### PR TITLE
Support mount public key from secret file

### DIFF
--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -57,6 +57,11 @@ spec:
 {{- with .Values.broker.annotations }}
 {{ toYaml . | indent 6 }}
 {{- end }}
+    {{- if .Values.broker.readPublicKeyFromFile }}
+    secretRefs:
+    - mountPath: /pulsar/vault/v1/identity/oidc/.well-known/keys
+      secretName: {{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-public-key
+    {{- end }}
     {{- if and .Values.affinity.anti_affinity .Values.broker.affinity.anti_affinity }}
     affinity:
       podAntiAffinity:
@@ -211,7 +216,11 @@ spec:
       brokerClientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"
       PULSAR_PREFIX_chainAuthenticationEnabled: "true"
       PULSAR_PREFIX_vaultHost: {{ template "pulsar.vault.url" . }}
+      {{- if .Values.broker.readPublicKeyFromFile }}
+      PULSAR_PREFIX_OIDCPublicKeyPath: "file:///pulsar/vault/v1/identity/oidc/.well-known/keys/publicKey"
+      {{- else }}
       PULSAR_PREFIX_OIDCPublicKeyPath: "{{ template "pulsar.vault.url" . }}/v1/identity/oidc/.well-known/keys"
+      {{- end  }}
       PULSAR_PREFIX_oauthIssuerUrl: "{{ .Values.auth.oauth.oauthIssuerUrl }}"
       PULSAR_PREFIX_oauthAudience: "{{ .Values.auth.oauth.oauthAudience }}"
       PULSAR_PREFIX_oauthSubjectClaim: "{{ .Values.auth.oauth.oauthSubjectClaim }}"
@@ -226,7 +235,11 @@ spec:
       authenticationProviders: "io.streamnative.pulsar.broker.authentication.AuthenticationProviderOIDCToken"
       brokerClientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"
       PULSAR_PREFIX_vaultHost: {{ template "pulsar.vault.url" . }}
+      {{- if .Values.broker.readPublicKeyFromFile }}
+      PULSAR_PREFIX_OIDCPublicKeyPath: "file:///pulsar/vault/v1/identity/oidc/.well-known/keys/publicKey"
+      {{- else }}
       PULSAR_PREFIX_OIDCPublicKeyPath: "{{ template "pulsar.vault.url" . }}/v1/identity/oidc/.well-known/keys"
+      {{- end  }}
       superUserRoles: "admin"
       {{- end }}
       {{- if and (.Values.auth.authorization.enabled) (.Values.auth.oauth.enabled) }}

--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -59,8 +59,16 @@ spec:
 {{- end }}
     {{- if .Values.broker.readPublicKeyFromFile }}
     secretRefs:
+    {{- if .Values.broker.publicKeyPath }}
+    - mountPath: {{ .Values.broker.publicKeyPath }}
+    {{- else }}
     - mountPath: /pulsar/vault/v1/identity/oidc/.well-known/keys
+    {{- end }}
+      {{- if .Values.broker.publicKeySecret }}
+      secretName: {{ .Values.broker.publicKeySecret }}
+      {{- else }}
       secretName: {{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-public-key
+      {{- end }}
     {{- end }}
     {{- if and .Values.affinity.anti_affinity .Values.broker.affinity.anti_affinity }}
     affinity:
@@ -217,7 +225,11 @@ spec:
       PULSAR_PREFIX_chainAuthenticationEnabled: "true"
       PULSAR_PREFIX_vaultHost: {{ template "pulsar.vault.url" . }}
       {{- if .Values.broker.readPublicKeyFromFile }}
+      {{- if .Values.broker.publicKeyPath }}
+      PULSAR_PREFIX_OIDCPublicKeyPath: "file://{{ .Values.broker.publicKeyPath }}/publicKey"
+      {{- else }}
       PULSAR_PREFIX_OIDCPublicKeyPath: "file:///pulsar/vault/v1/identity/oidc/.well-known/keys/publicKey"
+      {{- end }}
       {{- else }}
       PULSAR_PREFIX_OIDCPublicKeyPath: "{{ template "pulsar.vault.url" . }}/v1/identity/oidc/.well-known/keys"
       {{- end  }}
@@ -236,7 +248,11 @@ spec:
       brokerClientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"
       PULSAR_PREFIX_vaultHost: {{ template "pulsar.vault.url" . }}
       {{- if .Values.broker.readPublicKeyFromFile }}
+      {{- if .Values.broker.publicKeyPath }}
+      PULSAR_PREFIX_OIDCPublicKeyPath: "file://{{ .Values.broker.publicKeyPath }}/publicKey"
+      {{- else }}
       PULSAR_PREFIX_OIDCPublicKeyPath: "file:///pulsar/vault/v1/identity/oidc/.well-known/keys/publicKey"
+      {{- end }}
       {{- else }}
       PULSAR_PREFIX_OIDCPublicKeyPath: "{{ template "pulsar.vault.url" . }}/v1/identity/oidc/.well-known/keys"
       {{- end  }}

--- a/charts/sn-platform/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-cluster.yaml
@@ -53,6 +53,11 @@ spec:
 {{- with .Values.proxy.annotations }}
 {{ toYaml . | indent 6 }}
 {{- end }}
+    {{- if .Values.proxy.readPublicKeyFromFile }}
+    secretRefs:
+    - mountPath: /pulsar/vault/v1/identity/oidc/.well-known/keys
+      secretName: {{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-public-key
+    {{- end }}
     {{- if and .Values.affinity.anti_affinity .Values.proxy.affinity.anti_affinity }}
     affinity:
       podAntiAffinity:
@@ -143,7 +148,11 @@ spec:
       brokerClientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"
       PULSAR_PREFIX_chainAuthenticationEnabled: "true"
       PULSAR_PREFIX_vaultHost: {{ template "pulsar.vault.url" . }}
+      {{- if .Values.proxy.readPublicKeyFromFile }}
+      PULSAR_PREFIX_OIDCPublicKeyPath: "file:///pulsar/vault/v1/identity/oidc/.well-known/keys/publicKey"
+      {{- else }}
       PULSAR_PREFIX_OIDCPublicKeyPath: "{{ template "pulsar.vault.url" . }}/v1/identity/oidc/.well-known/keys"
+      {{- end  }}
       PULSAR_PREFIX_oauthIssuerUrl: "{{ .Values.auth.oauth.oauthIssuerUrl }}"
       PULSAR_PREFIX_oauthAudience: "{{ .Values.auth.oauth.oauthAudience }}"
       PULSAR_PREFIX_oauthSubjectClaim: "{{ .Values.auth.oauth.oauthSubjectClaim }}"
@@ -157,7 +166,11 @@ spec:
       authenticationProviders: "io.streamnative.pulsar.broker.authentication.AuthenticationProviderOIDCToken"
       brokerClientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"
       PULSAR_PREFIX_vaultHost: {{ template "pulsar.vault.url" . }}
+      {{- if .Values.proxy.readPublicKeyFromFile }}
+      PULSAR_PREFIX_OIDCPublicKeyPath: "file:///pulsar/vault/v1/identity/oidc/.well-known/keys/publicKey"
+      {{- else }}
       PULSAR_PREFIX_OIDCPublicKeyPath: "{{ template "pulsar.vault.url" . }}/v1/identity/oidc/.well-known/keys"
+      {{- end  }}
       superUserRoles: "admin"
       {{- end }}
       {{- if and (.Values.auth.authorization.enabled) (.Values.auth.oauth.enabled) }}

--- a/charts/sn-platform/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-cluster.yaml
@@ -55,8 +55,16 @@ spec:
 {{- end }}
     {{- if .Values.proxy.readPublicKeyFromFile }}
     secretRefs:
+    {{- if .Values.proxy.publicKeyPath }}
+    - mountPath: {{ .Values.proxy.publicKeyPath }}
+    {{- else }}
     - mountPath: /pulsar/vault/v1/identity/oidc/.well-known/keys
+    {{- end }}
+      {{- if .Values.proxy.publicKeySecret }}
+      secretName: {{ .Values.proxy.publicKeySecret }}
+      {{- else }}
       secretName: {{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-public-key
+      {{- end }}
     {{- end }}
     {{- if and .Values.affinity.anti_affinity .Values.proxy.affinity.anti_affinity }}
     affinity:
@@ -149,7 +157,11 @@ spec:
       PULSAR_PREFIX_chainAuthenticationEnabled: "true"
       PULSAR_PREFIX_vaultHost: {{ template "pulsar.vault.url" . }}
       {{- if .Values.proxy.readPublicKeyFromFile }}
+      {{- if .Values.proxy.publicKeyPath }}
+      PULSAR_PREFIX_OIDCPublicKeyPath: "file://{{ .Values.proxy.publicKeyPath }}/publicKey"
+      {{- else }}
       PULSAR_PREFIX_OIDCPublicKeyPath: "file:///pulsar/vault/v1/identity/oidc/.well-known/keys/publicKey"
+      {{- end }}
       {{- else }}
       PULSAR_PREFIX_OIDCPublicKeyPath: "{{ template "pulsar.vault.url" . }}/v1/identity/oidc/.well-known/keys"
       {{- end  }}
@@ -167,7 +179,11 @@ spec:
       brokerClientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"
       PULSAR_PREFIX_vaultHost: {{ template "pulsar.vault.url" . }}
       {{- if .Values.proxy.readPublicKeyFromFile }}
+      {{- if .Values.proxy.publicKeyPath }}
+      PULSAR_PREFIX_OIDCPublicKeyPath: "file://{{ .Values.proxy.publicKeyPath }}/publicKey"
+      {{- else }}
       PULSAR_PREFIX_OIDCPublicKeyPath: "file:///pulsar/vault/v1/identity/oidc/.well-known/keys/publicKey"
+      {{- end }}
       {{- else }}
       PULSAR_PREFIX_OIDCPublicKeyPath: "{{ template "pulsar.vault.url" . }}/v1/identity/oidc/.well-known/keys"
       {{- end  }}

--- a/charts/sn-platform/templates/vault/vault-initialize.yaml
+++ b/charts/sn-platform/templates/vault/vault-initialize.yaml
@@ -56,7 +56,10 @@ spec:
            done;
            echo "vault is ready~";
 
-           cd /root/pulsar/create_pulsar_tokens && /usr/local/bin/zsh create_pulsar_tokens.sh -n {{ template "pulsar.namespace" . }} -k {{ .Release.Name }} -v {{ template "pulsar.vault.url" . }} -r $ROOT_TOKEN && cd /root/pulsar/init_vault_streamnative_console && /usr/local/bin/zsh startup.sh
+           cd /root/pulsar/create_pulsar_tokens && /usr/local/bin/zsh create_pulsar_tokens.sh -n {{ template "pulsar.namespace" . }} -k {{ .Release.Name }} -v {{ template "pulsar.vault.url" . }} -r $ROOT_TOKEN && cd /root/pulsar/init_vault_streamnative_console && /usr/local/bin/zsh startup.sh;
+           echo "Start init public key to secret";
+           publicKey=$(wget -qO- http://{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}:8200/v1/identity/oidc/.well-known/keys | base64 | tr -d \\n);
+           kubectl patch secret {{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-public-key --type='json' -p='[{"op":"replace","path":"/data/publicKey","value":"'$publicKey'"}]' -n {{ template "pulsar.namespace" . }};
         env:
         - name: NAMESPACE
           value: {{ template "pulsar.namespace" . }}

--- a/charts/sn-platform/templates/vault/vault-public-key-secret.yaml
+++ b/charts/sn-platform/templates/vault/vault-public-key-secret.yaml
@@ -1,0 +1,27 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+apiVersion: v1
+kind: Secret
+data:
+  publicKey: ""
+metadata:
+  name: {{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-public-key
+  namespace: {{ template "pulsar.namespace" . }}
+type: Opaque

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1207,6 +1207,8 @@ broker:
     keep: false
   labels: {}
   readPublicKeyFromFile: false
+  publicKeyPath: ""
+  publicKeySecret: ""
 
 ## Pulsar: Functions Worker
 ## templates/function-worker-configmap.yaml
@@ -1485,6 +1487,8 @@ proxy:
     keep: false
   labels: {}
   readPublicKeyFromFile: false
+  publicKeyPath: ""
+  publicKeySecret: ""
 
 ## Pulsar ToolSet
 ## templates/toolset-deployment.yaml

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1206,6 +1206,7 @@ broker:
   resourcePolicy:
     keep: false
   labels: {}
+  readPublicKeyFromFile: false
 
 ## Pulsar: Functions Worker
 ## templates/function-worker-configmap.yaml
@@ -1483,6 +1484,7 @@ proxy:
   resourcePolicy:
     keep: false
   labels: {}
+  readPublicKeyFromFile: false
 
 ## Pulsar ToolSet
 ## templates/toolset-deployment.yaml


### PR DESCRIPTION
Secret:

```
apiVersion: v1
data:
  publicKey: ""
kind: Secret
metadata:
  annotations:
    meta.helm.sh/release-name: pulsar
    meta.helm.sh/release-namespace: snpe
  labels:
    app.kubernetes.io/managed-by: Helm
  name: pulsar-sn-platform-vault-public-key
  namespace: snpe
type: Opaque
```

* Add an option `readPublicKeyFromFile` `publicKeyPath` and `publicKeySecret` to support reading public keys from secret file
* Add a secret for vault public key file