### PR TITLE
[sn-platform]Upgrade nginx ingress controller to v1.1.1 for k8s v1.22+

### DIFF
--- a/charts/sn-platform/templates/control-center/_control_center.tpl
+++ b/charts/sn-platform/templates/control-center/_control_center.tpl
@@ -85,6 +85,15 @@ pulsar controller ingress target port for http endpoint
     {{- default .Capabilities.KubeVersion.Version .Values.kubeVersionOverride -}}
 {{- end -}}
 
+{{/* Check Kubernetes version is less than v1.22 */}}
+{{- define "pulsar.kubeVersion.isLessThanV122" -}}
+    {{- if semverCompare "< 1.22-0" (include "pulsar.kubeVersion" .) -}}
+        {{- print "true" -}}
+    {{- else -}}
+        {{- print "false" -}}
+    {{- end -}}
+{{- end -}}
+
 
 {{/* Check Ingress API version is stable or not */}}
 {{- define "pulsar.ingress.isStable" -}}
@@ -92,5 +101,14 @@ pulsar controller ingress target port for http endpoint
         {{- print "true" -}}
     {{- else -}}
         {{- print "false" -}}
+    {{- end -}}
+{{- end -}}
+
+
+{{- define "pulsar.ingress.image" -}}
+    {{- if and (eq (include "pulsar.kubeVersion.isLessThanV122" .) "false") (semverCompare "< 1.0.0" .Values.images.nginx_ingress_controller.tag )}}
+        {{- print "k8s.gcr.io/ingress-nginx/controller:v1.1.1"}}
+    {{- else -}}
+        {{- printf "%s:%s" .Values.images.nginx_ingress_controller.repository .Values.images.nginx_ingress_controller.tag -}}
     {{- end -}}
 {{- end -}}

--- a/charts/sn-platform/templates/control-center/_control_center.tpl
+++ b/charts/sn-platform/templates/control-center/_control_center.tpl
@@ -105,6 +105,15 @@ pulsar controller ingress target port for http endpoint
 {{- end -}}
 
 
+{{/* 
+Get ingress image according to the k8s version.
+
+When k8s version is higher or equal than v1.22, ingress image should use version v1.x.x,
+otherwise it should use the default version 0.26.2 that defines in values.yaml.
+
+If k8s version is higher or equal than v1.22, but the .Values.images.nginx_ingress_controller.tag is less than v1.x.x,
+it will use k8s.gcr.io/ingress-nginx/controller:v1.1.1 as default to make ingress work.
+*/}}
 {{- define "pulsar.ingress.image" -}}
     {{- if and (eq (include "pulsar.kubeVersion.isLessThanV122" .) "false") (semverCompare "< 1.0.0" .Values.images.nginx_ingress_controller.tag )}}
         {{- print "k8s.gcr.io/ingress-nginx/controller:v1.1.1"}}

--- a/charts/sn-platform/templates/control-center/ingress-controller-deployment.yaml
+++ b/charts/sn-platform/templates/control-center/ingress-controller-deployment.yaml
@@ -18,6 +18,7 @@
 #
 
 {{- if .Values.ingress.controller.enabled }}
+{{- $isKubeVersionLessThanV122 := eq (include "pulsar.kubeVersion.isLessThanV122" .) "true" }}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -60,7 +61,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.ingress.controller.gracePeriod }}
       containers:
       - name: nginx-ingress-controller
-        image: "{{ .Values.images.nginx_ingress_controller.repository }}:{{ .Values.images.nginx_ingress_controller.tag }}"
+        image: {{ include "pulsar.ingress.image" .}}
         imagePullPolicy: {{ .Values.images.nginx_ingress_controller.pullPolicy }}
         args:
         - /nginx-ingress-controller
@@ -76,8 +77,13 @@ spec:
               - ALL
             add:
               - NET_BIND_SERVICE
+          {{- if $isKubeVersionLessThanV122 }}
           # www-data -> 33
           runAsUser: 33
+          {{- else }}
+          # www-data -> 101, use image v1.1.1 will need this user permission
+          runAsUser: 101
+          {{- end }}
         env:
         - name: POD_NAME
           valueFrom:

--- a/charts/sn-platform/templates/control-center/ingress-controller-rbac.yaml
+++ b/charts/sn-platform/templates/control-center/ingress-controller-rbac.yaml
@@ -113,6 +113,8 @@ rules:
       # This has to be adapted if you change either parameter
       # when launching the nginx-ingress-controller.
       - "ingress-controller-leader-nginx"
+      # Upgrade to v1.1.1, controller will update this configmap
+      - "ingress-controller-leader"
     verbs:
       - get
       - update


### PR DESCRIPTION
# Motivation
To support installing the chart sn-platform in k8s v1.22+, the [PR](https://github.com/streamnative/charts/pull/447) had upgraded the deprecated apiVersion `extensions/v1beta1` of `Ingress` to `networking.k8s.io/v1`. But according to the [doc](https://kubernetes.io/blog/2021/07/26/update-with-ingress-nginx/), it will also need to upgrade the version of ingress nginx to `v1.x.x` for k8s v1.22. 

# Modifications
This PR is going to upgrade the ingress nginx image to use [v1.1.1](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.1.1) when the k8s version is v1.22+, and keep using `0.26.2` for the older versions.

According to the doc, only v1.1.1 supports k8s v1.23, so use this version directly.

But this pr will not use the new feature  `IngressClass` for now,  keep using the annotation `kubernetes.io/ingress.class: nginx`. 

