### PR TITLE
Support datadog integration for vault.

### DIFF
--- a/charts/sn-platform/templates/vault/_vault.tpl
+++ b/charts/sn-platform/templates/vault/_vault.tpl
@@ -22,7 +22,31 @@ Inject vault token values to pod through env variables
 {{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-console-admin-passwd
 {{- end }}
 
-
+{{/*Define vault datadog annotation*/}}
+{{- define "pulsar.vault.datadog.annotation" -}}
+{{- if .Values.datadog.components.vault.enabled }}
+ad.datadoghq.com/vault.check_names: |
+  ["vault"]
+ad.datadoghq.com/vault.init_configs: |
+  [{}]
+ad.datadoghq.com/vault.instances: |
+  [
+    {
+      "api_url": "http://%%host%%:8200/v1",
+      {{- if .Values.datadog.components.vault.auth.enabled }}
+      "client_token": {{ .Values.datadog.components.vault.auth.token }}
+      {{- else }}
+      "no_token": true
+      {{- end }}
+      {{- if .Values.datadog.components.vault.tags }}
+      "tags": [
+{{ toYaml .Values.datadog.components.vault.tags | indent 8 }}
+       ]
+       {{- end }}
+    }
+  ]
+{{- end }}
+{{- end }}
 
 {{- define "pulsar.vault-unseal-secret-key-name" -}}
 {{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-unseal-keys

--- a/charts/sn-platform/templates/vault/vault-statefulset.yaml
+++ b/charts/sn-platform/templates/vault/vault-statefulset.yaml
@@ -32,9 +32,23 @@ spec:
   serviceType: {{ .Values.vault.serviceType }}
 
   statsdDisabled: true
-
-
+  
+  {{- if .Values.monitoring.datadog }}
+  vaultAnnotations:
+{{- include "pulsar.vault.datadog.annotation" . | nindent 4 }}
+  {{- end }}
 {{- if and .Values.volumes.persistence .Values.vault.volume.persistence}}
+
+  {{- if .Values.vault.tolerations }}
+  tolerations:
+{{ toYaml .Values.vault.tolerations | indent 4 }}
+  {{- end }}
+
+  {{- if .Values.vault.nodeSelector }}
+  nodeSelector:
+{{ toYaml .Values.vault.nodeSelector | indent 4 }}
+  {{- end }}
+  
   volumeClaimTemplates:
   - metadata:
       name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-{{ .Values.vault.volume.name }}"

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1699,6 +1699,14 @@ datadog:
       metrics: [
         "\"_*\""
       ]
+    vault:
+      enabled: true
+      auth:
+        enabled: false
+        token: ""
+      tags: {}
+    prometheus:
+      enabled: false
 
 ## Monitoring Stack: Grafana
 ## templates/grafana-statefulset.yaml
@@ -2141,6 +2149,8 @@ vault:
     created: true
     name: ""
   serviceType: "ClusterIP"
+  tolerations: []
+  nodeSelector: {}
   volumeClaimTemplates: []
   unsealConfig: {}
   volumeMounts:


### PR DESCRIPTION
Add annotation on vault to support integrate with datadog and allow setting additional toleration and nodeSelector info on vault pod.