### PR TITLE
[CI]Add doc label workflow

### DIFF
--- a/.github/workflows/documentbot.yml
+++ b/.github/workflows/documentbot.yml
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Auto Labeling
+
+on:
+  pull_request_target :
+    types:
+      - opened
+      - edited
+      - labeled
+
+  
+
+# A GitHub token created for a PR coming from a fork doesn't have
+# 'admin' or 'write' permission (which is required to add labels)
+# To avoid this issue, you can use the `scheduled` event and run
+# this action on a certain interval.And check the label about the
+# document.
+
+jobs:
+  labeling:
+    if: ${{ github.repository == 'streamnative/charts' }}
+    permissions:
+      pull-requests: write 
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: streamnative/github-workflow-libraries/doc-label-check@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          label-pattern: '- \[(.*?)\] ?`(.+?)`' # matches '- [x] `label`'


### PR DESCRIPTION

### Motivation

We want to keep the same doc label workflow as `apache/pulsar`

### Modifications

- Add `documentbot.yml` workflow

### Documentation

- [x] no-need-doc 

