### PR TITLE
Allow customize Pulsar Cluster name for operator deployment.

### DIFF
--- a/charts/pulsar-operator/crds/bookkeeper.streamnative.io_bookkeeperclusters.yaml
+++ b/charts/pulsar-operator/crds/bookkeeper.streamnative.io_bookkeeperclusters.yaml
@@ -39,141 +39,84 @@ spec:
       name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: BookKeeperCluster is the Schema for the bookkeeperclusters API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
             spec:
-              description: BookKeeperClusterSpec defines the desired state of BookKeeperCluster
               properties:
                 apiObjects:
-                  description: APIObjects allows precise control over how components
-                    (services, statefulset and so on) should be managed
                   properties:
                     autoRecoveryConfigMap:
-                      description: AutoRecoveryConfigMap defines the autoRecovery configmap
-                        resource template.
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata used to customize
-                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels of the resource.
                               type: object
                             name:
-                              description: Name of the resource within a namespace.
-                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
-                          description: UpdatePolicy defines which field to update.
                           items:
-                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     autoRecoveryHeadlessService:
-                      description: AutoRecoveryHeadlessService defines the service resource
-                        template for autoRecovery headless service.
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata used to customize
-                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels of the resource.
                               type: object
                             name:
-                              description: Name of the resource within a namespace.
-                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
-                          description: UpdatePolicy defines which field to update.
                           items:
-                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     autoRecoveryStatefulSet:
-                      description: AutoRecoveryStatefulSet defines the statefulset resource
-                        template for adopting existing autoRecovery statefulset.
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata used to customize
-                          the name, labels, annotations of the object. More info:
-                          https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels of the resource.
                               type: object
                             name:
-                              description: Name of the resource within a namespace.
-                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
-                          description: UpdatePolicy defines which field to update.
                           items:
-                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                         volumeClaimTemplates:
-                          description: VolumeClaimTemplates is a list of claims that
-                            pods are allowed to reference. If a non-empty list is specified,
-                            the original values in the desired STS will be replaced.
                           items:
-                            description: PersistentVolumeClaim is a user's request for
-                              and claim to a persistent volume
                             properties:
                               apiVersion:
-                                description: 'APIVersion defines the versioned schema
-                                of this representation of an object. Servers should
-                                convert recognized schemas to the latest internal
-                                value, and may reject unrecognized values. More info:
-                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                                 type: string
                               kind:
-                                description: 'Kind is a string value representing the
-                                REST resource this object represents. Servers may
-                                infer this from the endpoint the client submits requests
-                                to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                 type: string
                               metadata:
-                                description: 'Standard object''s metadata. More info:
-                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                                 properties:
                                   annotations:
                                     additionalProperties:
@@ -193,55 +136,24 @@ spec:
                                     type: string
                                 type: object
                               spec:
-                                description: 'Spec defines the desired characteristics
-                                of a volume requested by a pod author. More info:
-                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                 properties:
                                   accessModes:
-                                    description: 'AccessModes contains the desired access
-                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                     items:
                                       type: string
                                     type: array
                                   dataSource:
-                                    description: 'This field can be used to specify
-                                    either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                                    - Beta) * An existing PVC (PersistentVolumeClaim)
-                                    * An existing custom resource/object that implements
-                                    data population (Alpha) In order to use VolumeSnapshot
-                                    object types, the appropriate feature gate must
-                                    be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
-                                    If the provisioner or an external controller can
-                                    support the specified data source, it will create
-                                    a new volume based on the contents of the specified
-                                    data source. If the specified data source is not
-                                    supported, the volume will not be created and
-                                    the failure will be reported as an event. In the
-                                    future, we plan to support more data source types
-                                    and the behavior of the provisioner may change.'
                                     properties:
                                       apiGroup:
-                                        description: APIGroup is the group for the resource
-                                          being referenced. If APIGroup is not specified,
-                                          the specified Kind must be in the core API
-                                          group. For any other third-party types, APIGroup
-                                          is required.
                                         type: string
                                       kind:
-                                        description: Kind is the type of resource being
-                                          referenced
                                         type: string
                                       name:
-                                        description: Name is the name of resource being
-                                          referenced
                                         type: string
                                     required:
                                       - kind
                                       - name
                                     type: object
                                   resources:
-                                    description: 'Resources represents the minimum resources
-                                    the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -250,8 +162,6 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount
-                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -260,46 +170,18 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                        amount of compute resources required. If Requests
-                                        is omitted for a container, it defaults to
-                                        Limits if that is explicitly specified, otherwise
-                                        to an implementation-defined value. More info:
-                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   selector:
-                                    description: A label query over volumes to consider
-                                      for binding.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -311,37 +193,18 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   storageClassName:
-                                    description: 'Name of the StorageClass required
-                                    by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                     type: string
                                   volumeMode:
-                                    description: volumeMode defines what type of volume
-                                      is required by the claim. Value of Filesystem
-                                      is implied when not included in claim spec.
                                     type: string
                                   volumeName:
-                                    description: VolumeName is the binding reference
-                                      to the PersistentVolume backing this claim.
                                     type: string
                                 type: object
                               status:
-                                description: 'Status represents the current information/status
-                                of a persistent volume claim. Read-only. More info:
-                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                 properties:
                                   accessModes:
-                                    description: 'AccessModes contains the actual access
-                                    modes the volume backing the PVC has. More info:
-                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                     items:
                                       type: string
                                     type: array
@@ -352,43 +215,23 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: Represents the actual resources of
-                                      the underlying volume.
                                     type: object
                                   conditions:
-                                    description: Current Condition of persistent volume
-                                      claim. If underlying persistent volume is being
-                                      resized then the Condition will be set to 'ResizeStarted'.
                                     items:
-                                      description: PersistentVolumeClaimCondition contails
-                                        details about state of pvc
                                       properties:
                                         lastProbeTime:
-                                          description: Last time we probed the condition.
                                           format: date-time
                                           type: string
                                         lastTransitionTime:
-                                          description: Last time the condition transitioned
-                                            from one status to another.
                                           format: date-time
                                           type: string
                                         message:
-                                          description: Human-readable message indicating
-                                            details about last transition.
                                           type: string
                                         reason:
-                                          description: Unique, this should be a short,
-                                            machine understandable string that gives
-                                            the reason for condition's last transition.
-                                            If it reports "ResizeStarted" that means
-                                            the underlying persistent volume is being
-                                            resized.
                                           type: string
                                         status:
                                           type: string
                                         type:
-                                          description: PersistentVolumeClaimConditionType
-                                            is a valid value of PersistentVolumeClaimCondition.Type
                                           type: string
                                       required:
                                         - status
@@ -396,50 +239,24 @@ spec:
                                       type: object
                                     type: array
                                   phase:
-                                    description: Phase represents the current phase
-                                      of PersistentVolumeClaim.
                                     type: string
                                 type: object
                             type: object
                           type: array
                         volumeMounts:
-                          description: VolumeMounts is a list of volumes to mount into
-                            the container's filesystem. If a non-empty list is specified,
-                            the original values of the main container in the desired
-                            STS will be replaced.
                           items:
-                            description: VolumeMount describes a mounting of a Volume
-                              within a container.
                             properties:
                               mountPath:
-                                description: Path within the container at which the
-                                  volume should be mounted.  Must not contain ':'.
                                 type: string
                               mountPropagation:
-                                description: mountPropagation determines how mounts
-                                  are propagated from the host to container and the
-                                  other way around. When not set, MountPropagationNone
-                                  is used. This field is beta in 1.10.
                                 type: string
                               name:
-                                description: This must match the Name of a Volume.
                                 type: string
                               readOnly:
-                                description: Mounted read-only if true, read-write otherwise
-                                  (false or unspecified). Defaults to false.
                                 type: boolean
                               subPath:
-                                description: Path within the volume from which the container's
-                                  volume should be mounted. Defaults to "" (volume's
-                                  root).
                                 type: string
                               subPathExpr:
-                                description: Expanded path within the volume from which
-                                  the container's volume should be mounted. Behaves
-                                  similarly to SubPath but environment variable references
-                                  $(VAR_NAME) are expanded using the container's environment.
-                                  Defaults to "" (volume's root). SubPathExpr and SubPath
-                                  are mutually exclusive.
                                 type: string
                             required:
                               - mountPath
@@ -448,59 +265,32 @@ spec:
                           type: array
                       type: object
                     bookieStatefulSet:
-                      description: BookieStatefulSet defines the statefulset resource
-                        template for bookie cluster.
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata used to customize
-                          the name, labels, annotations of the object. More info:
-                          https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels of the resource.
                               type: object
                             name:
-                              description: Name of the resource within a namespace.
-                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
-                          description: UpdatePolicy defines which field to update.
                           items:
-                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                         volumeClaimTemplates:
-                          description: VolumeClaimTemplates is a list of claims that
-                            pods are allowed to reference. If a non-empty list is specified,
-                            the original values in the desired STS will be replaced.
                           items:
-                            description: PersistentVolumeClaim is a user's request for
-                              and claim to a persistent volume
                             properties:
                               apiVersion:
-                                description: 'APIVersion defines the versioned schema
-                                of this representation of an object. Servers should
-                                convert recognized schemas to the latest internal
-                                value, and may reject unrecognized values. More info:
-                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                                 type: string
                               kind:
-                                description: 'Kind is a string value representing the
-                                REST resource this object represents. Servers may
-                                infer this from the endpoint the client submits requests
-                                to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                 type: string
                               metadata:
-                                description: 'Standard object''s metadata. More info:
-                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                                 properties:
                                   annotations:
                                     additionalProperties:
@@ -520,55 +310,24 @@ spec:
                                     type: string
                                 type: object
                               spec:
-                                description: 'Spec defines the desired characteristics
-                                of a volume requested by a pod author. More info:
-                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                 properties:
                                   accessModes:
-                                    description: 'AccessModes contains the desired access
-                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                     items:
                                       type: string
                                     type: array
                                   dataSource:
-                                    description: 'This field can be used to specify
-                                    either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                                    - Beta) * An existing PVC (PersistentVolumeClaim)
-                                    * An existing custom resource/object that implements
-                                    data population (Alpha) In order to use VolumeSnapshot
-                                    object types, the appropriate feature gate must
-                                    be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
-                                    If the provisioner or an external controller can
-                                    support the specified data source, it will create
-                                    a new volume based on the contents of the specified
-                                    data source. If the specified data source is not
-                                    supported, the volume will not be created and
-                                    the failure will be reported as an event. In the
-                                    future, we plan to support more data source types
-                                    and the behavior of the provisioner may change.'
                                     properties:
                                       apiGroup:
-                                        description: APIGroup is the group for the resource
-                                          being referenced. If APIGroup is not specified,
-                                          the specified Kind must be in the core API
-                                          group. For any other third-party types, APIGroup
-                                          is required.
                                         type: string
                                       kind:
-                                        description: Kind is the type of resource being
-                                          referenced
                                         type: string
                                       name:
-                                        description: Name is the name of resource being
-                                          referenced
                                         type: string
                                     required:
                                       - kind
                                       - name
                                     type: object
                                   resources:
-                                    description: 'Resources represents the minimum resources
-                                    the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -577,8 +336,6 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount
-                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -587,46 +344,18 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                        amount of compute resources required. If Requests
-                                        is omitted for a container, it defaults to
-                                        Limits if that is explicitly specified, otherwise
-                                        to an implementation-defined value. More info:
-                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   selector:
-                                    description: A label query over volumes to consider
-                                      for binding.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -638,37 +367,18 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   storageClassName:
-                                    description: 'Name of the StorageClass required
-                                    by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                     type: string
                                   volumeMode:
-                                    description: volumeMode defines what type of volume
-                                      is required by the claim. Value of Filesystem
-                                      is implied when not included in claim spec.
                                     type: string
                                   volumeName:
-                                    description: VolumeName is the binding reference
-                                      to the PersistentVolume backing this claim.
                                     type: string
                                 type: object
                               status:
-                                description: 'Status represents the current information/status
-                                of a persistent volume claim. Read-only. More info:
-                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                 properties:
                                   accessModes:
-                                    description: 'AccessModes contains the actual access
-                                    modes the volume backing the PVC has. More info:
-                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                     items:
                                       type: string
                                     type: array
@@ -679,43 +389,23 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: Represents the actual resources of
-                                      the underlying volume.
                                     type: object
                                   conditions:
-                                    description: Current Condition of persistent volume
-                                      claim. If underlying persistent volume is being
-                                      resized then the Condition will be set to 'ResizeStarted'.
                                     items:
-                                      description: PersistentVolumeClaimCondition contails
-                                        details about state of pvc
                                       properties:
                                         lastProbeTime:
-                                          description: Last time we probed the condition.
                                           format: date-time
                                           type: string
                                         lastTransitionTime:
-                                          description: Last time the condition transitioned
-                                            from one status to another.
                                           format: date-time
                                           type: string
                                         message:
-                                          description: Human-readable message indicating
-                                            details about last transition.
                                           type: string
                                         reason:
-                                          description: Unique, this should be a short,
-                                            machine understandable string that gives
-                                            the reason for condition's last transition.
-                                            If it reports "ResizeStarted" that means
-                                            the underlying persistent volume is being
-                                            resized.
                                           type: string
                                         status:
                                           type: string
                                         type:
-                                          description: PersistentVolumeClaimConditionType
-                                            is a valid value of PersistentVolumeClaimCondition.Type
                                           type: string
                                       required:
                                         - status
@@ -723,50 +413,24 @@ spec:
                                       type: object
                                     type: array
                                   phase:
-                                    description: Phase represents the current phase
-                                      of PersistentVolumeClaim.
                                     type: string
                                 type: object
                             type: object
                           type: array
                         volumeMounts:
-                          description: VolumeMounts is a list of volumes to mount into
-                            the container's filesystem. If a non-empty list is specified,
-                            the original values of the main container in the desired
-                            STS will be replaced.
                           items:
-                            description: VolumeMount describes a mounting of a Volume
-                              within a container.
                             properties:
                               mountPath:
-                                description: Path within the container at which the
-                                  volume should be mounted.  Must not contain ':'.
                                 type: string
                               mountPropagation:
-                                description: mountPropagation determines how mounts
-                                  are propagated from the host to container and the
-                                  other way around. When not set, MountPropagationNone
-                                  is used. This field is beta in 1.10.
                                 type: string
                               name:
-                                description: This must match the Name of a Volume.
                                 type: string
                               readOnly:
-                                description: Mounted read-only if true, read-write otherwise
-                                  (false or unspecified). Defaults to false.
                                 type: boolean
                               subPath:
-                                description: Path within the volume from which the container's
-                                  volume should be mounted. Defaults to "" (volume's
-                                  root).
                                 type: string
                               subPathExpr:
-                                description: Expanded path within the volume from which
-                                  the container's volume should be mounted. Behaves
-                                  similarly to SubPath but environment variable references
-                                  $(VAR_NAME) are expanded using the container's environment.
-                                  Defaults to "" (volume's root). SubPathExpr and SubPath
-                                  are mutually exclusive.
                                 type: string
                             required:
                               - mountPath
@@ -775,168 +439,103 @@ spec:
                           type: array
                       type: object
                     clientService:
-                      description: ClientService defines the Bookkeeper Client Service
-                        resource template.
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata used to customize
-                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels of the resource.
                               type: object
                             name:
-                              description: Name of the resource within a namespace.
-                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
-                          description: UpdatePolicy defines which field to update.
                           items:
-                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     configMap:
-                      description: ConfigMap defines the configmap resource template.
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata used to customize
-                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels of the resource.
                               type: object
                             name:
-                              description: Name of the resource within a namespace.
-                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
-                          description: UpdatePolicy defines which field to update.
                           items:
-                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     headlessService:
-                      description: HeadlessService defines the Bookkeeper Headless Service
-                        resource template.
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata used to customize
-                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels of the resource.
                               type: object
                             name:
-                              description: Name of the resource within a namespace.
-                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
-                          description: UpdatePolicy defines which field to update.
                           items:
-                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     pdb:
-                      description: PDB defines the podDisruptionBudget resource template.
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata used to customize
-                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels of the resource.
                               type: object
                             name:
-                              description: Name of the resource within a namespace.
-                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
-                          description: UpdatePolicy defines which field to update.
                           items:
-                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                   type: object
                 autoRecovery:
-                  description: AutoRecovery defines configurations of auto recovery
                   properties:
                     autoScalingPolicy:
-                      description: AutoScalingPolicy defines how BookKeeperCluster will
-                        be scaled up/down with given metrics and threshold
                       properties:
                         behavior:
-                          description: Behavior configures the scaling behavior of the
-                            target in both Up and Down directions (scaleUp and scaleDown
-                            fields respectively). If not set, the default HPAScalingRules
-                            for scale up and scale down are used.
                           properties:
                             scaleDown:
-                              description: scaleDown is scaling policy for scaling Down.
-                                If not set, the default value is to allow to scale down
-                                to minReplicas pods, with a 300 second stabilization
-                                window (i.e., the highest recommendation for the last
-                                300sec is used).
                               properties:
                                 policies:
-                                  description: policies is a list of potential scaling
-                                    polices which can be used during scaling. At least
-                                    one policy must be specified, otherwise the HPAScalingRules
-                                    will be discarded as invalid
                                   items:
-                                    description: HPAScalingPolicy is a single policy
-                                      which must hold true for a specified past interval.
                                     properties:
                                       periodSeconds:
-                                        description: PeriodSeconds specifies the window
-                                          of time for which the policy should hold true.
-                                          PeriodSeconds must be greater than zero and
-                                          less than or equal to 1800 (30 min).
                                         format: int32
                                         type: integer
                                       type:
-                                        description: Type is used to specify the scaling
-                                          policy.
                                         type: string
                                       value:
-                                        description: Value contains the amount of change
-                                          which is permitted by the policy. It must
-                                          be greater than zero
                                         format: int32
                                         type: integer
                                     required:
@@ -946,54 +545,22 @@ spec:
                                     type: object
                                   type: array
                                 selectPolicy:
-                                  description: selectPolicy is used to specify which
-                                    policy should be used. If not set, the default value
-                                    MaxPolicySelect is used.
                                   type: string
                                 stabilizationWindowSeconds:
-                                  description: 'StabilizationWindowSeconds is the number
-                                  of seconds for which past recommendations should
-                                  be considered while scaling up or scaling down.
-                                  StabilizationWindowSeconds must be greater than
-                                  or equal to zero and less than or equal to 3600
-                                  (one hour). If not set, use the default values:
-                                  - For scale up: 0 (i.e. no stabilization is done).
-                                  - For scale down: 300 (i.e. the stabilization window
-                                  is 300 seconds long).'
                                   format: int32
                                   type: integer
                               type: object
                             scaleUp:
-                              description: 'scaleUp is scaling policy for scaling Up.
-                              If not set, the default value is the higher of:   *
-                              increase no more than 4 pods per 60 seconds   * double
-                              the number of pods per 60 seconds No stabilization is
-                              used.'
                               properties:
                                 policies:
-                                  description: policies is a list of potential scaling
-                                    polices which can be used during scaling. At least
-                                    one policy must be specified, otherwise the HPAScalingRules
-                                    will be discarded as invalid
                                   items:
-                                    description: HPAScalingPolicy is a single policy
-                                      which must hold true for a specified past interval.
                                     properties:
                                       periodSeconds:
-                                        description: PeriodSeconds specifies the window
-                                          of time for which the policy should hold true.
-                                          PeriodSeconds must be greater than zero and
-                                          less than or equal to 1800 (30 min).
                                         format: int32
                                         type: integer
                                       type:
-                                        description: Type is used to specify the scaling
-                                          policy.
                                         type: string
                                       value:
-                                        description: Value contains the amount of change
-                                          which is permitted by the policy. It must
-                                          be greater than zero
                                         format: int32
                                         type: integer
                                     required:
@@ -1003,20 +570,8 @@ spec:
                                     type: object
                                   type: array
                                 selectPolicy:
-                                  description: selectPolicy is used to specify which
-                                    policy should be used. If not set, the default value
-                                    MaxPolicySelect is used.
                                   type: string
                                 stabilizationWindowSeconds:
-                                  description: 'StabilizationWindowSeconds is the number
-                                  of seconds for which past recommendations should
-                                  be considered while scaling up or scaling down.
-                                  StabilizationWindowSeconds must be greater than
-                                  or equal to zero and less than or equal to 3600
-                                  (one hour). If not set, use the default values:
-                                  - For scale up: 0 (i.e. no stabilization is done).
-                                  - For scale down: 300 (i.e. the stabilization window
-                                  is 300 seconds long).'
                                   format: int32
                                   type: integer
                               type: object
@@ -1025,68 +580,24 @@ spec:
                           format: int32
                           type: integer
                         metrics:
-                          description: 'Metrics contains the specifications for which
-                          to use to calculate the desired replica count (the maximum
-                          replica count across all metrics will be used). More info:
-                          https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling'
                           items:
-                            description: MetricSpec specifies how to scale based on
-                              a single metric (only `type` and one other matching field
-                              should be set at once).
                             properties:
                               external:
-                                description: external refers to a global metric that
-                                  is not associated with any Kubernetes object. It allows
-                                  autoscaling based on information coming from components
-                                  running outside of cluster (for example length of
-                                  queue in cloud messaging service, or QPS from loadbalancer
-                                  running outside of cluster).
                                 properties:
                                   metric:
-                                    description: metric identifies the target metric
-                                      by name and selector
                                     properties:
                                       name:
-                                        description: name is the name of the given metric
                                         type: string
                                       selector:
-                                        description: selector is the string-encoded
-                                          form of a standard kubernetes label selector
-                                          for the given metric When set, it is passed
-                                          as an additional parameter to the metrics
-                                          server for more specific metrics scoping.
-                                          When unset, just the metricName will be used
-                                          to gather metrics.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1098,49 +609,28 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                     required:
                                       - name
                                     type: object
                                   target:
-                                    description: target specifies the target value for
-                                      the given metric
                                     properties:
                                       averageUtilization:
-                                        description: averageUtilization is the target
-                                          value of the average of the resource metric
-                                          across all relevant pods, represented as a
-                                          percentage of the requested value of the resource
-                                          for the pods. Currently only valid for Resource
-                                          metric source type
                                         format: int32
                                         type: integer
                                       averageValue:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description: averageValue is the target value
-                                          of the average of the metric across all relevant
-                                          pods (as a quantity)
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       type:
-                                        description: type represents whether the metric
-                                          type is Utilization, Value, or AverageValue
                                         type: string
                                       value:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description: value is the target value of the
-                                          metric (as a quantity).
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     required:
@@ -1151,75 +641,33 @@ spec:
                                   - target
                                 type: object
                               object:
-                                description: object refers to a metric describing a
-                                  single kubernetes object (for example, hits-per-second
-                                  on an Ingress object).
                                 properties:
                                   describedObject:
-                                    description: CrossVersionObjectReference contains
-                                      enough information to let you identify the referred
-                                      resource.
                                     properties:
                                       apiVersion:
-                                        description: API version of the referent
                                         type: string
                                       kind:
-                                        description: 'Kind of the referent; More info:
-                                        https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
                                         type: string
                                       name:
-                                        description: 'Name of the referent; More info:
-                                        http://kubernetes.io/docs/user-guide/identifiers#names'
                                         type: string
                                     required:
                                       - kind
                                       - name
                                     type: object
                                   metric:
-                                    description: metric identifies the target metric
-                                      by name and selector
                                     properties:
                                       name:
-                                        description: name is the name of the given metric
                                         type: string
                                       selector:
-                                        description: selector is the string-encoded
-                                          form of a standard kubernetes label selector
-                                          for the given metric When set, it is passed
-                                          as an additional parameter to the metrics
-                                          server for more specific metrics scoping.
-                                          When unset, just the metricName will be used
-                                          to gather metrics.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1231,49 +679,28 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                     required:
                                       - name
                                     type: object
                                   target:
-                                    description: target specifies the target value for
-                                      the given metric
                                     properties:
                                       averageUtilization:
-                                        description: averageUtilization is the target
-                                          value of the average of the resource metric
-                                          across all relevant pods, represented as a
-                                          percentage of the requested value of the resource
-                                          for the pods. Currently only valid for Resource
-                                          metric source type
                                         format: int32
                                         type: integer
                                       averageValue:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description: averageValue is the target value
-                                          of the average of the metric across all relevant
-                                          pods (as a quantity)
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       type:
-                                        description: type represents whether the metric
-                                          type is Utilization, Value, or AverageValue
                                         type: string
                                       value:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description: value is the target value of the
-                                          metric (as a quantity).
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     required:
@@ -1285,56 +712,21 @@ spec:
                                   - target
                                 type: object
                               pods:
-                                description: pods refers to a metric describing each
-                                  pod in the current scale target (for example, transactions-processed-per-second).  The
-                                  values will be averaged together before being compared
-                                  to the target value.
                                 properties:
                                   metric:
-                                    description: metric identifies the target metric
-                                      by name and selector
                                     properties:
                                       name:
-                                        description: name is the name of the given metric
                                         type: string
                                       selector:
-                                        description: selector is the string-encoded
-                                          form of a standard kubernetes label selector
-                                          for the given metric When set, it is passed
-                                          as an additional parameter to the metrics
-                                          server for more specific metrics scoping.
-                                          When unset, just the metricName will be used
-                                          to gather metrics.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1346,49 +738,28 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                     required:
                                       - name
                                     type: object
                                   target:
-                                    description: target specifies the target value for
-                                      the given metric
                                     properties:
                                       averageUtilization:
-                                        description: averageUtilization is the target
-                                          value of the average of the resource metric
-                                          across all relevant pods, represented as a
-                                          percentage of the requested value of the resource
-                                          for the pods. Currently only valid for Resource
-                                          metric source type
                                         format: int32
                                         type: integer
                                       averageValue:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description: averageValue is the target value
-                                          of the average of the metric across all relevant
-                                          pods (as a quantity)
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       type:
-                                        description: type represents whether the metric
-                                          type is Utilization, Value, or AverageValue
                                         type: string
                                       value:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description: value is the target value of the
-                                          metric (as a quantity).
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     required:
@@ -1399,50 +770,26 @@ spec:
                                   - target
                                 type: object
                               resource:
-                                description: resource refers to a resource metric (such
-                                  as those specified in requests and limits) known to
-                                  Kubernetes describing each pod in the current scale
-                                  target (e.g. CPU or memory). Such metrics are built
-                                  in to Kubernetes, and have special scaling options
-                                  on top of those available to normal per-pod metrics
-                                  using the "pods" source.
                                 properties:
                                   name:
-                                    description: name is the name of the resource in
-                                      question.
                                     type: string
                                   target:
-                                    description: target specifies the target value for
-                                      the given metric
                                     properties:
                                       averageUtilization:
-                                        description: averageUtilization is the target
-                                          value of the average of the resource metric
-                                          across all relevant pods, represented as a
-                                          percentage of the requested value of the resource
-                                          for the pods. Currently only valid for Resource
-                                          metric source type
                                         format: int32
                                         type: integer
                                       averageValue:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description: averageValue is the target value
-                                          of the average of the metric across all relevant
-                                          pods (as a quantity)
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       type:
-                                        description: type represents whether the metric
-                                          type is Utilization, Value, or AverageValue
                                         type: string
                                       value:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description: value is the target value of the
-                                          metric (as a quantity).
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     required:
@@ -1453,9 +800,6 @@ spec:
                                   - target
                                 type: object
                               type:
-                                description: type is the type of metric source.  It
-                                  should be one of "Object", "Pods" or "Resource", each
-                                  mapping to a matching field in the object.
                                 type: string
                             required:
                               - type
@@ -1464,77 +808,32 @@ spec:
                         minReplicas:
                           format: int32
                           type: integer
+                      required:
+                        - maxReplicas
                       type: object
                     conf:
                       additionalProperties:
                         type: string
-                      description: Conf defines the configuration of auto recovery bookies
                       type: object
                     pod:
-                      description: Pod defines the policy for creating an auto recovery
-                        pod for the cluster
                       properties:
                         affinity:
-                          description: Affinity specifies the scheduling constraints
-                            of a pod
                           properties:
                             nodeAffinity:
-                              description: Describes node affinity scheduling rules
-                                for the pod.
                               properties:
                                 preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule
-                                    pods to nodes that satisfy the affinity expressions
-                                    specified by this field, but it may choose a node
-                                    that violates one or more of the expressions. The
-                                    node that is most preferred is the one with the
-                                    greatest sum of weights, i.e. for each node that
-                                    meets all of the scheduling requirements (resource
-                                    request, requiredDuringScheduling affinity expressions,
-                                    etc.), compute a sum by iterating through the elements
-                                    of this field and adding "weight" to the sum if
-                                    the node matches the corresponding matchExpressions;
-                                    the node(s) with the highest sum are the most preferred.
                                   items:
-                                    description: An empty preferred scheduling term
-                                      matches all objects with implicit weight 0 (i.e.
-                                      it's a no-op). A null preferred scheduling term
-                                      matches no objects (i.e. is also a no-op).
                                     properties:
                                       preference:
-                                        description: A node selector term, associated
-                                          with the corresponding weight.
                                         properties:
                                           matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
                                             items:
-                                              description: A node selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: The label key that the
-                                                    selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
                                                   type: string
                                                 values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn,
-                                                    the values array must be non-empty.
-                                                    If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty.
-                                                    If the operator is Gt or Lt, the
-                                                    values array must have a single
-                                                    element, which will be interpreted
-                                                    as an integer. This array is replaced
-                                                    during a strategic merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1544,35 +843,13 @@ spec:
                                               type: object
                                             type: array
                                           matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
                                             items:
-                                              description: A node selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: The label key that the
-                                                    selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
                                                   type: string
                                                 values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn,
-                                                    the values array must be non-empty.
-                                                    If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty.
-                                                    If the operator is Gt or Lt, the
-                                                    values array must have a single
-                                                    element, which will be interpreted
-                                                    as an integer. This array is replaced
-                                                    during a strategic merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1583,9 +860,6 @@ spec:
                                             type: array
                                         type: object
                                       weight:
-                                        description: Weight associated with matching
-                                          the corresponding nodeSelectorTerm, in the
-                                          range 1-100.
                                         format: int32
                                         type: integer
                                     required:
@@ -1594,53 +868,18 @@ spec:
                                     type: object
                                   type: array
                                 requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified
-                                    by this field are not met at scheduling time, the
-                                    pod will not be scheduled onto the node. If the
-                                    affinity requirements specified by this field cease
-                                    to be met at some point during pod execution (e.g.
-                                    due to an update), the system may or may not try
-                                    to eventually evict the pod from its node.
                                   properties:
                                     nodeSelectorTerms:
-                                      description: Required. A list of node selector
-                                        terms. The terms are ORed.
                                       items:
-                                        description: A null or empty node selector term
-                                          matches no objects. The requirements of them
-                                          are ANDed. The TopologySelectorTerm type implements
-                                          a subset of the NodeSelectorTerm.
                                         properties:
                                           matchExpressions:
-                                            description: A list of node selector requirements
-                                              by node's labels.
                                             items:
-                                              description: A node selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: The label key that the
-                                                    selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
                                                   type: string
                                                 values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn,
-                                                    the values array must be non-empty.
-                                                    If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty.
-                                                    If the operator is Gt or Lt, the
-                                                    values array must have a single
-                                                    element, which will be interpreted
-                                                    as an integer. This array is replaced
-                                                    during a strategic merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1650,35 +889,13 @@ spec:
                                               type: object
                                             type: array
                                           matchFields:
-                                            description: A list of node selector requirements
-                                              by node's fields.
                                             items:
-                                              description: A node selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: The label key that the
-                                                    selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: Represents a key's relationship
-                                                    to a set of values. Valid operators
-                                                    are In, NotIn, Exists, DoesNotExist.
-                                                    Gt, and Lt.
                                                   type: string
                                                 values:
-                                                  description: An array of string values.
-                                                    If the operator is In or NotIn,
-                                                    the values array must be non-empty.
-                                                    If the operator is Exists or DoesNotExist,
-                                                    the values array must be empty.
-                                                    If the operator is Gt or Lt, the
-                                                    values array must have a single
-                                                    element, which will be interpreted
-                                                    as an integer. This array is replaced
-                                                    during a strategic merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1694,67 +911,22 @@ spec:
                                   type: object
                               type: object
                             podAffinity:
-                              description: Describes pod affinity scheduling rules (e.g.
-                                co-locate this pod in the same node, zone, etc. as some
-                                other pod(s)).
                               properties:
                                 preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule
-                                    pods to nodes that satisfy the affinity expressions
-                                    specified by this field, but it may choose a node
-                                    that violates one or more of the expressions. The
-                                    node that is most preferred is the one with the
-                                    greatest sum of weights, i.e. for each node that
-                                    meets all of the scheduling requirements (resource
-                                    request, requiredDuringScheduling affinity expressions,
-                                    etc.), compute a sum by iterating through the elements
-                                    of this field and adding "weight" to the sum if
-                                    the node has pods which matches the corresponding
-                                    podAffinityTerm; the node(s) with the highest sum
-                                    are the most preferred.
                                   items:
-                                    description: The weights of all of the matched WeightedPodAffinityTerm
-                                      fields are added per-node to find the most preferred
-                                      node(s)
                                     properties:
                                       podAffinityTerm:
-                                        description: Required. A pod affinity term,
-                                          associated with the corresponding weight.
                                         properties:
                                           labelSelector:
-                                            description: A label query over a set of
-                                              resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a list
-                                                  of label selector requirements. The
-                                                  requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a set
-                                                        of values. Valid operators are
-                                                        In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values array
-                                                        must be non-empty. If the operator
-                                                        is Exists or DoesNotExist, the
-                                                        values array must be empty.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -1766,42 +938,18 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map of
-                                                  {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description: namespaces specifies which
-                                              namespaces the labelSelector applies to
-                                              (matches against); null or empty list
-                                              means "this pod's namespace"
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located
-                                              (affinity) or not co-located (anti-affinity)
-                                              with the pods matching the labelSelector
-                                              in the specified namespaces, where co-located
-                                              is defined as running on a node whose
-                                              value of the label with key topologyKey
-                                              matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
                                             type: string
                                         required:
                                           - topologyKey
                                         type: object
                                       weight:
-                                        description: weight associated with matching
-                                          the corresponding podAffinityTerm, in the
-                                          range 1-100.
                                         format: int32
                                         type: integer
                                     required:
@@ -1810,59 +958,18 @@ spec:
                                     type: object
                                   type: array
                                 requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the affinity requirements specified
-                                    by this field are not met at scheduling time, the
-                                    pod will not be scheduled onto the node. If the
-                                    affinity requirements specified by this field cease
-                                    to be met at some point during pod execution (e.g.
-                                    due to a pod label update), the system may or may
-                                    not try to eventually evict the pod from its node.
-                                    When there are multiple elements, the lists of nodes
-                                    corresponding to each podAffinityTerm are intersected,
-                                    i.e. all terms must be satisfied.
                                   items:
-                                    description: Defines a set of pods (namely those
-                                      matching the labelSelector relative to the given
-                                      namespace(s)) that this pod should be co-located
-                                      (affinity) or not co-located (anti-affinity) with,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key <topologyKey>
-                                      matches that of any node on which a pod of the
-                                      set of pods is running
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1874,30 +981,13 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
@@ -1905,67 +995,22 @@ spec:
                                   type: array
                               type: object
                             podAntiAffinity:
-                              description: Describes pod anti-affinity scheduling rules
-                                (e.g. avoid putting this pod in the same node, zone,
-                                etc. as some other pod(s)).
                               properties:
                                 preferredDuringSchedulingIgnoredDuringExecution:
-                                  description: The scheduler will prefer to schedule
-                                    pods to nodes that satisfy the anti-affinity expressions
-                                    specified by this field, but it may choose a node
-                                    that violates one or more of the expressions. The
-                                    node that is most preferred is the one with the
-                                    greatest sum of weights, i.e. for each node that
-                                    meets all of the scheduling requirements (resource
-                                    request, requiredDuringScheduling anti-affinity
-                                    expressions, etc.), compute a sum by iterating through
-                                    the elements of this field and adding "weight" to
-                                    the sum if the node has pods which matches the corresponding
-                                    podAffinityTerm; the node(s) with the highest sum
-                                    are the most preferred.
                                   items:
-                                    description: The weights of all of the matched WeightedPodAffinityTerm
-                                      fields are added per-node to find the most preferred
-                                      node(s)
                                     properties:
                                       podAffinityTerm:
-                                        description: Required. A pod affinity term,
-                                          associated with the corresponding weight.
                                         properties:
                                           labelSelector:
-                                            description: A label query over a set of
-                                              resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a list
-                                                  of label selector requirements. The
-                                                  requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label
-                                                        key that the selector applies
-                                                        to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a set
-                                                        of values. Valid operators are
-                                                        In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values array
-                                                        must be non-empty. If the operator
-                                                        is Exists or DoesNotExist, the
-                                                        values array must be empty.
-                                                        This array is replaced during
-                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -1977,42 +1022,18 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map of
-                                                  {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description: namespaces specifies which
-                                              namespaces the labelSelector applies to
-                                              (matches against); null or empty list
-                                              means "this pod's namespace"
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located
-                                              (affinity) or not co-located (anti-affinity)
-                                              with the pods matching the labelSelector
-                                              in the specified namespaces, where co-located
-                                              is defined as running on a node whose
-                                              value of the label with key topologyKey
-                                              matches that of any node on which any
-                                              of the selected pods is running. Empty
-                                              topologyKey is not allowed.
                                             type: string
                                         required:
                                           - topologyKey
                                         type: object
                                       weight:
-                                        description: weight associated with matching
-                                          the corresponding podAffinityTerm, in the
-                                          range 1-100.
                                         format: int32
                                         type: integer
                                     required:
@@ -2021,59 +1042,18 @@ spec:
                                     type: object
                                   type: array
                                 requiredDuringSchedulingIgnoredDuringExecution:
-                                  description: If the anti-affinity requirements specified
-                                    by this field are not met at scheduling time, the
-                                    pod will not be scheduled onto the node. If the
-                                    anti-affinity requirements specified by this field
-                                    cease to be met at some point during pod execution
-                                    (e.g. due to a pod label update), the system may
-                                    or may not try to eventually evict the pod from
-                                    its node. When there are multiple elements, the
-                                    lists of nodes corresponding to each podAffinityTerm
-                                    are intersected, i.e. all terms must be satisfied.
                                   items:
-                                    description: Defines a set of pods (namely those
-                                      matching the labelSelector relative to the given
-                                      namespace(s)) that this pod should be co-located
-                                      (affinity) or not co-located (anti-affinity) with,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key <topologyKey>
-                                      matches that of any node on which a pod of the
-                                      set of pods is running
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -2085,30 +1065,13 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
@@ -2119,138 +1082,69 @@ spec:
                         annotations:
                           additionalProperties:
                             type: string
-                          description: Annotations specifies the annotations to attach
-                            to pods the operator creates
                           type: object
                         initContainers:
-                          description: InitContainers defines init containers of the
-                            pod. A typical use case could be using an init container
-                            to download a remote jar to a local path.
                           items:
-                            description: A single application container that you want
-                              to run within a pod. The Container API from the core group
-                              is not used directly to avoid unneeded fields and reduce
-                              the size of the CRD. New fields could be added as needed.
                             properties:
                               args:
-                                description: Arguments to the entrypoint.
                                 items:
                                   type: string
                                 type: array
                               command:
-                                description: Entrypoint array. Not executed within a
-                                  shell.
                                 items:
                                   type: string
                                 type: array
                               env:
-                                description: List of environment variables to set in
-                                  the container.
                                 items:
-                                  description: EnvVar represents an environment variable
-                                    present in a Container.
                                   properties:
                                     name:
-                                      description: Name of the environment variable.
-                                        Must be a C_IDENTIFIER.
                                       type: string
                                     value:
-                                      description: 'Variable references $(VAR_NAME)
-                                      are expanded using the previous defined environment
-                                      variables in the container and any service environment
-                                      variables. If a variable cannot be resolved,
-                                      the reference in the input string will be unchanged.
-                                      The $(VAR_NAME) syntax can be escaped with a
-                                      double $$, ie: $$(VAR_NAME). Escaped references
-                                      will never be expanded, regardless of whether
-                                      the variable exists or not. Defaults to "".'
                                       type: string
                                     valueFrom:
-                                      description: Source for the environment variable's
-                                        value. Cannot be used if value is not empty.
                                       properties:
                                         configMapKeyRef:
-                                          description: Selects a key of a ConfigMap.
                                           properties:
                                             key:
-                                              description: The key to select.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap
-                                                or its key must be defined
                                               type: boolean
                                           required:
                                             - key
                                           type: object
                                         fieldRef:
-                                          description: 'Selects a field of the pod:
-                                          supports metadata.name, metadata.namespace,
-                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                                          spec.nodeName, spec.serviceAccountName,
-                                          status.hostIP, status.podIP, status.podIPs.'
                                           properties:
                                             apiVersion:
-                                              description: Version of the schema the
-                                                FieldPath is written in terms of, defaults
-                                                to "v1".
                                               type: string
                                             fieldPath:
-                                              description: Path of the field to select
-                                                in the specified API version.
                                               type: string
                                           required:
                                             - fieldPath
                                           type: object
                                         resourceFieldRef:
-                                          description: 'Selects a resource of the container:
-                                          only resources limits and requests (limits.cpu,
-                                          limits.memory, limits.ephemeral-storage,
-                                          requests.cpu, requests.memory and requests.ephemeral-storage)
-                                          are currently supported.'
                                           properties:
                                             containerName:
-                                              description: 'Container name: required
-                                              for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                                 - type: integer
                                                 - type: string
-                                              description: Specifies the output format
-                                                of the exposed resources, defaults to
-                                                "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
-                                              description: 'Required: resource to select'
                                               type: string
                                           required:
                                             - resource
                                           type: object
                                         secretKeyRef:
-                                          description: Selects a key of a secret in
-                                            the pod's namespace
                                           properties:
                                             key:
-                                              description: The key of the secret to
-                                                select from.  Must be a valid secret
-                                                key.
                                               type: string
                                             name:
-                                              description: 'Name of the referent. More
-                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                              TODO: Add other useful fields. apiVersion,
-                                              kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret
-                                                or its key must be defined
                                               type: boolean
                                           required:
                                             - key
@@ -2261,100 +1155,52 @@ spec:
                                   type: object
                                 type: array
                               envFrom:
-                                description: List of sources to populate environment
-                                  variables in the container.
                                 items:
-                                  description: EnvFromSource represents the source of
-                                    a set of ConfigMaps
                                   properties:
                                     configMapRef:
-                                      description: The ConfigMap to select from
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap
-                                            must be defined
                                           type: boolean
                                       type: object
                                     prefix:
-                                      description: An optional identifier to prepend
-                                        to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                       type: string
                                     secretRef:
-                                      description: The Secret to select from
                                       properties:
                                         name:
-                                          description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                           type: string
                                         optional:
-                                          description: Specify whether the Secret must
-                                            be defined
                                           type: boolean
                                       type: object
                                   type: object
                                 type: array
                               image:
-                                description: Docker image name.
                                 type: string
                               imagePullPolicy:
-                                description: Image pull policy.
                                 type: string
                               livenessProbe:
-                                description: Periodic probe of container liveness.
                                 properties:
                                   exec:
-                                    description: One and only one of the following should
-                                      be specified. Exec specifies the action to take.
                                     properties:
                                       command:
-                                        description: Command is the command line to
-                                          execute inside the container, the working
-                                          directory for the command  is root ('/') in
-                                          the container's filesystem. The command is
-                                          simply exec'd, it is not run inside a shell,
-                                          so traditional shell instructions ('|', etc)
-                                          won't work. To use a shell, you need to explicitly
-                                          call out to that shell. Exit status of 0 is
-                                          treated as live/healthy and non-zero is unhealthy.
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   failureThreshold:
-                                    description: Minimum consecutive failures for the
-                                      probe to be considered failed after having succeeded.
-                                      Defaults to 3. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   httpGet:
-                                    description: HTTPGet specifies the http request
-                                      to perform.
                                     properties:
                                       host:
-                                        description: Host name to connect to, defaults
-                                          to the pod IP. You probably want to set "Host"
-                                          in httpHeaders instead.
                                         type: string
                                       httpHeaders:
-                                        description: Custom headers to set in the request.
-                                          HTTP allows repeated headers.
                                         items:
-                                          description: HTTPHeader describes a custom
-                                            header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
                                               type: string
                                             value:
-                                              description: The header field value
                                               type: string
                                           required:
                                             - name
@@ -2362,122 +1208,66 @@ spec:
                                           type: object
                                         type: array
                                       path:
-                                        description: Path to access on the HTTP server.
                                         type: string
                                       port:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description: Name or number of the port to access
-                                          on the container. Number must be in the range
-                                          1 to 65535. Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                       scheme:
-                                        description: Scheme to use for connecting to
-                                          the host. Defaults to HTTP.
                                         type: string
                                     required:
                                       - port
                                     type: object
                                   initialDelaySeconds:
-                                    description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     format: int32
                                     type: integer
                                   periodSeconds:
-                                    description: How often (in seconds) to perform the
-                                      probe. Default to 10 seconds. Minimum value is
-                                      1.
                                     format: int32
                                     type: integer
                                   successThreshold:
-                                    description: Minimum consecutive successes for the
-                                      probe to be considered successful after having
-                                      failed. Defaults to 1. Must be 1 for liveness
-                                      and startup. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   tcpSocket:
-                                    description: 'TCPSocket specifies an action involving
-                                    a TCP port. TCP hooks not yet supported TODO:
-                                    implement a realistic TCP lifecycle hook'
                                     properties:
                                       host:
-                                        description: 'Optional: Host name to connect
-                                        to, defaults to the pod IP.'
                                         type: string
                                       port:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description: Number or name of the port to access
-                                          on the container. Number must be in the range
-                                          1 to 65535. Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                     required:
                                       - port
                                     type: object
                                   timeoutSeconds:
-                                    description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     format: int32
                                     type: integer
                                 type: object
                               name:
-                                description: Name of the container specified as a DNS_LABEL.
-                                  Each container in a pod must have a unique name (DNS_LABEL).
                                 type: string
                               readinessProbe:
-                                description: 'Periodic probe of container service readiness.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 properties:
                                   exec:
-                                    description: One and only one of the following should
-                                      be specified. Exec specifies the action to take.
                                     properties:
                                       command:
-                                        description: Command is the command line to
-                                          execute inside the container, the working
-                                          directory for the command  is root ('/') in
-                                          the container's filesystem. The command is
-                                          simply exec'd, it is not run inside a shell,
-                                          so traditional shell instructions ('|', etc)
-                                          won't work. To use a shell, you need to explicitly
-                                          call out to that shell. Exit status of 0 is
-                                          treated as live/healthy and non-zero is unhealthy.
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   failureThreshold:
-                                    description: Minimum consecutive failures for the
-                                      probe to be considered failed after having succeeded.
-                                      Defaults to 3. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   httpGet:
-                                    description: HTTPGet specifies the http request
-                                      to perform.
                                     properties:
                                       host:
-                                        description: Host name to connect to, defaults
-                                          to the pod IP. You probably want to set "Host"
-                                          in httpHeaders instead.
                                         type: string
                                       httpHeaders:
-                                        description: Custom headers to set in the request.
-                                          HTTP allows repeated headers.
                                         items:
-                                          description: HTTPHeader describes a custom
-                                            header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
                                               type: string
                                             value:
-                                              description: The header field value
                                               type: string
                                           required:
                                             - name
@@ -2485,71 +1275,43 @@ spec:
                                           type: object
                                         type: array
                                       path:
-                                        description: Path to access on the HTTP server.
                                         type: string
                                       port:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description: Name or number of the port to access
-                                          on the container. Number must be in the range
-                                          1 to 65535. Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                       scheme:
-                                        description: Scheme to use for connecting to
-                                          the host. Defaults to HTTP.
                                         type: string
                                     required:
                                       - port
                                     type: object
                                   initialDelaySeconds:
-                                    description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     format: int32
                                     type: integer
                                   periodSeconds:
-                                    description: How often (in seconds) to perform the
-                                      probe. Default to 10 seconds. Minimum value is
-                                      1.
                                     format: int32
                                     type: integer
                                   successThreshold:
-                                    description: Minimum consecutive successes for the
-                                      probe to be considered successful after having
-                                      failed. Defaults to 1. Must be 1 for liveness
-                                      and startup. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   tcpSocket:
-                                    description: 'TCPSocket specifies an action involving
-                                    a TCP port. TCP hooks not yet supported TODO:
-                                    implement a realistic TCP lifecycle hook'
                                     properties:
                                       host:
-                                        description: 'Optional: Host name to connect
-                                        to, defaults to the pod IP.'
                                         type: string
                                       port:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description: Number or name of the port to access
-                                          on the container. Number must be in the range
-                                          1 to 65535. Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                     required:
                                       - port
                                     type: object
                                   timeoutSeconds:
-                                    description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     format: int32
                                     type: integer
                                 type: object
                               resources:
-                                description: Compute Resources required by this container.
                                 properties:
                                   limits:
                                     additionalProperties:
@@ -2558,8 +1320,6 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: 'Limits describes the maximum amount
-                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                     type: object
                                   requests:
                                     additionalProperties:
@@ -2568,62 +1328,30 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: 'Requests describes the minimum amount
-                                    of compute resources required. If Requests is
-                                    omitted for a container, it defaults to Limits
-                                    if that is explicitly specified, otherwise to
-                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                     type: object
                                 type: object
                               startupProbe:
-                                description: StartupProbe indicates that the Pod has
-                                  successfully initialized.
                                 properties:
                                   exec:
-                                    description: One and only one of the following should
-                                      be specified. Exec specifies the action to take.
                                     properties:
                                       command:
-                                        description: Command is the command line to
-                                          execute inside the container, the working
-                                          directory for the command  is root ('/') in
-                                          the container's filesystem. The command is
-                                          simply exec'd, it is not run inside a shell,
-                                          so traditional shell instructions ('|', etc)
-                                          won't work. To use a shell, you need to explicitly
-                                          call out to that shell. Exit status of 0 is
-                                          treated as live/healthy and non-zero is unhealthy.
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   failureThreshold:
-                                    description: Minimum consecutive failures for the
-                                      probe to be considered failed after having succeeded.
-                                      Defaults to 3. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   httpGet:
-                                    description: HTTPGet specifies the http request
-                                      to perform.
                                     properties:
                                       host:
-                                        description: Host name to connect to, defaults
-                                          to the pod IP. You probably want to set "Host"
-                                          in httpHeaders instead.
                                         type: string
                                       httpHeaders:
-                                        description: Custom headers to set in the request.
-                                          HTTP allows repeated headers.
                                         items:
-                                          description: HTTPHeader describes a custom
-                                            header to be used in HTTP probes
                                           properties:
                                             name:
-                                              description: The header field name
                                               type: string
                                             value:
-                                              description: The header field value
                                               type: string
                                           required:
                                             - name
@@ -2631,108 +1359,56 @@ spec:
                                           type: object
                                         type: array
                                       path:
-                                        description: Path to access on the HTTP server.
                                         type: string
                                       port:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description: Name or number of the port to access
-                                          on the container. Number must be in the range
-                                          1 to 65535. Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                       scheme:
-                                        description: Scheme to use for connecting to
-                                          the host. Defaults to HTTP.
                                         type: string
                                     required:
                                       - port
                                     type: object
                                   initialDelaySeconds:
-                                    description: 'Number of seconds after the container
-                                    has started before liveness probes are initiated.
-                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     format: int32
                                     type: integer
                                   periodSeconds:
-                                    description: How often (in seconds) to perform the
-                                      probe. Default to 10 seconds. Minimum value is
-                                      1.
                                     format: int32
                                     type: integer
                                   successThreshold:
-                                    description: Minimum consecutive successes for the
-                                      probe to be considered successful after having
-                                      failed. Defaults to 1. Must be 1 for liveness
-                                      and startup. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   tcpSocket:
-                                    description: 'TCPSocket specifies an action involving
-                                    a TCP port. TCP hooks not yet supported TODO:
-                                    implement a realistic TCP lifecycle hook'
                                     properties:
                                       host:
-                                        description: 'Optional: Host name to connect
-                                        to, defaults to the pod IP.'
                                         type: string
                                       port:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description: Number or name of the port to access
-                                          on the container. Number must be in the range
-                                          1 to 65535. Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                     required:
                                       - port
                                     type: object
                                   timeoutSeconds:
-                                    description: 'Number of seconds after which the
-                                    probe times out. Defaults to 1 second. Minimum
-                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     format: int32
                                     type: integer
                                 type: object
                               volumeMounts:
-                                description: Pod volumes to mount into the container's
-                                  filesystem.
                                 items:
-                                  description: VolumeMount describes a mounting of a
-                                    Volume within a container.
                                   properties:
                                     mountPath:
-                                      description: Path within the container at which
-                                        the volume should be mounted.  Must not contain
-                                        ':'.
                                       type: string
                                     mountPropagation:
-                                      description: mountPropagation determines how mounts
-                                        are propagated from the host to container and
-                                        the other way around. When not set, MountPropagationNone
-                                        is used. This field is beta in 1.10.
                                       type: string
                                     name:
-                                      description: This must match the Name of a Volume.
                                       type: string
                                     readOnly:
-                                      description: Mounted read-only if true, read-write
-                                        otherwise (false or unspecified). Defaults to
-                                        false.
                                       type: boolean
                                     subPath:
-                                      description: Path within the volume from which
-                                        the container's volume should be mounted. Defaults
-                                        to "" (volume's root).
                                       type: string
                                     subPathExpr:
-                                      description: Expanded path within the volume from
-                                        which the container's volume should be mounted.
-                                        Behaves similarly to SubPath but environment
-                                        variable references $(VAR_NAME) are expanded
-                                        using the container's environment. Defaults
-                                        to "" (volume's root). SubPathExpr and SubPath
-                                        are mutually exclusive.
                                       type: string
                                   required:
                                     - mountPath
@@ -2740,14 +1416,12 @@ spec:
                                   type: object
                                 type: array
                               workingDir:
-                                description: Container's working directory.
                                 type: string
                             required:
                               - name
                             type: object
                           type: array
                         jvmOptions:
-                          description: JVMOptions defines JVM parameters of Bookies
                           properties:
                             extraOptions:
                               items:
@@ -2769,19 +1443,12 @@ spec:
                         labels:
                           additionalProperties:
                             type: string
-                          description: Labels specifies the labels to attach to pod
-                            the operator creates for the bookkeeper cluster.
                           type: object
                         nodeSelector:
                           additionalProperties:
                             type: string
-                          description: NodeSelector specifies a map of key-value pairs.
-                            For a pod to be eligible to run on a node, the node must
-                            have each of the indicated key-value pairs as labels.
                           type: object
                         resources:
-                          description: Resources specifies the resource requirements
-                            of a pod to run in the cluster
                           properties:
                             limits:
                               additionalProperties:
@@ -2790,8 +1457,6 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                               type: object
                             requests:
                               additionalProperties:
@@ -2800,136 +1465,54 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                               type: object
                           type: object
                         securityContext:
-                          description: 'SecurityContext specifies the security context
-                          for the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
                           properties:
                             fsGroup:
-                              description: "A special supplemental group that applies
-                              to all containers in a pod. Some volume types allow
-                              the Kubelet to change the ownership of that volume to
-                              be owned by the pod: \n 1. The owning GID will be the
-                              FSGroup 2. The setgid bit is set (new files created
-                              in the volume will be owned by FSGroup) 3. The permission
-                              bits are OR'd with rw-rw---- \n If unset, the Kubelet
-                              will not modify the ownership and permissions of any
-                              volume."
                               format: int64
                               type: integer
                             fsGroupChangePolicy:
-                              description: 'fsGroupChangePolicy defines behavior of
-                              changing ownership and permission of the volume before
-                              being exposed inside Pod. This field will only apply
-                              to volume types which support fsGroup based ownership(and
-                              permissions). It will have no effect on ephemeral volume
-                              types such as: secret, configmaps and emptydir. Valid
-                              values are "OnRootMismatch" and "Always". If not specified
-                              defaults to "Always".'
                               type: string
                             runAsGroup:
-                              description: The GID to run the entrypoint of the container
-                                process. Uses runtime default if unset. May also be
-                                set in SecurityContext.  If set in both SecurityContext
-                                and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence for that container.
                               format: int64
                               type: integer
                             runAsNonRoot:
-                              description: Indicates that the container must run as
-                                a non-root user. If true, the Kubelet will validate
-                                the image at runtime to ensure that it does not run
-                                as UID 0 (root) and fail to start the container if it
-                                does. If unset or false, no such validation will be
-                                performed. May also be set in SecurityContext.  If set
-                                in both SecurityContext and PodSecurityContext, the
-                                value specified in SecurityContext takes precedence.
                               type: boolean
                             runAsUser:
-                              description: The UID to run the entrypoint of the container
-                                process. Defaults to user specified in image metadata
-                                if unspecified. May also be set in SecurityContext.  If
-                                set in both SecurityContext and PodSecurityContext,
-                                the value specified in SecurityContext takes precedence
-                                for that container.
                               format: int64
                               type: integer
                             seLinuxOptions:
-                              description: The SELinux context to be applied to all
-                                containers. If unspecified, the container runtime will
-                                allocate a random SELinux context for each container.  May
-                                also be set in SecurityContext.  If set in both SecurityContext
-                                and PodSecurityContext, the value specified in SecurityContext
-                                takes precedence for that container.
                               properties:
                                 level:
-                                  description: Level is SELinux level label that applies
-                                    to the container.
                                   type: string
                                 role:
-                                  description: Role is a SELinux role label that applies
-                                    to the container.
                                   type: string
                                 type:
-                                  description: Type is a SELinux type label that applies
-                                    to the container.
                                   type: string
                                 user:
-                                  description: User is a SELinux user label that applies
-                                    to the container.
                                   type: string
                               type: object
                             seccompProfile:
-                              description: The seccomp options to use by the containers
-                                in this pod.
                               properties:
                                 localhostProfile:
-                                  description: localhostProfile indicates a profile
-                                    defined in a file on the node should be used. The
-                                    profile must be preconfigured on the node to work.
-                                    Must be a descending path, relative to the kubelet's
-                                    configured seccomp profile location. Must only be
-                                    set if type is "Localhost".
                                   type: string
                                 type:
-                                  description: "type indicates which kind of seccomp
-                                  profile will be applied. Valid options are: \n Localhost
-                                  - a profile defined in a file on the node should
-                                  be used. RuntimeDefault - the container runtime
-                                  default profile should be used. Unconfined - no
-                                  profile should be applied."
                                   type: string
                               required:
                                 - type
                               type: object
                             supplementalGroups:
-                              description: A list of groups applied to the first process
-                                run in each container, in addition to the container's
-                                primary GID.  If unspecified, no groups will be added
-                                to any container.
                               items:
                                 format: int64
                                 type: integer
                               type: array
                             sysctls:
-                              description: Sysctls hold a list of namespaced sysctls
-                                used for the pod. Pods with unsupported sysctls (by
-                                the container runtime) might fail to launch.
                               items:
-                                description: Sysctl defines a kernel parameter to be
-                                  set
                                 properties:
                                   name:
-                                    description: Name of a property to set
                                     type: string
                                   value:
-                                    description: Value of a property to set
                                     type: string
                                 required:
                                   - name
@@ -2937,189 +1520,87 @@ spec:
                                 type: object
                               type: array
                             windowsOptions:
-                              description: The Windows specific settings applied to
-                                all containers. If unspecified, the options within a
-                                container's SecurityContext will be used. If set in
-                                both SecurityContext and PodSecurityContext, the value
-                                specified in SecurityContext takes precedence.
                               properties:
                                 gmsaCredentialSpec:
-                                  description: GMSACredentialSpec is where the GMSA
-                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                    inlines the contents of the GMSA credential spec
-                                    named by the GMSACredentialSpecName field.
                                   type: string
                                 gmsaCredentialSpecName:
-                                  description: GMSACredentialSpecName is the name of
-                                    the GMSA credential spec to use.
                                   type: string
                                 runAsUserName:
-                                  description: The UserName in Windows to run the entrypoint
-                                    of the container process. Defaults to the user specified
-                                    in image metadata if unspecified. May also be set
-                                    in PodSecurityContext. If set in both SecurityContext
-                                    and PodSecurityContext, the value specified in SecurityContext
-                                    takes precedence.
                                   type: string
                               type: object
                           type: object
                         serviceAccountName:
-                          description: ServiceAccountName is the name of the ServiceAccount
-                            to use to run pods.
                           type: string
                         terminationGracePeriodSeconds:
-                          description: TerminationGracePeriodSeconds is the amount of
-                            time that kubernetes will give for a pod before terminating
-                            it.
                           format: int64
                           type: integer
                         tolerations:
-                          description: Tolerations specifies the tolerations of a Pod
                           items:
-                            description: The pod this Toleration is attached to tolerates
-                              any taint that matches the triple <key,value,effect> using
-                              the matching operator <operator>.
                             properties:
                               effect:
-                                description: Effect indicates the taint effect to match.
-                                  Empty means match all taint effects. When specified,
-                                  allowed values are NoSchedule, PreferNoSchedule and
-                                  NoExecute.
                                 type: string
                               key:
-                                description: Key is the taint key that the toleration
-                                  applies to. Empty means match all taint keys. If the
-                                  key is empty, operator must be Exists; this combination
-                                  means to match all values and all keys.
                                 type: string
                               operator:
-                                description: Operator represents a key's relationship
-                                  to the value. Valid operators are Exists and Equal.
-                                  Defaults to Equal. Exists is equivalent to wildcard
-                                  for value, so that a pod can tolerate all taints of
-                                  a particular category.
                                 type: string
                               tolerationSeconds:
-                                description: TolerationSeconds represents the period
-                                  of time the toleration (which must be of effect NoExecute,
-                                  otherwise this field is ignored) tolerates the taint.
-                                  By default, it is not set, which means tolerate the
-                                  taint forever (do not evict). Zero and negative values
-                                  will be treated as 0 (evict immediately) by the system.
                                 format: int64
                                 type: integer
                               value:
-                                description: Value is the taint value the toleration
-                                  matches to. If the operator is Exists, the value should
-                                  be empty, otherwise just a regular string.
                                 type: string
                             type: object
                           type: array
                         vars:
-                          description: Vars specifies the environment variables of a
-                            Pod
                           items:
-                            description: EnvVar represents an environment variable present
-                              in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
                                 type: string
                               value:
-                                description: 'Variable references $(VAR_NAME) are expanded
-                                using the previous defined environment variables in
-                                the container and any service environment variables.
-                                If a variable cannot be resolved, the reference in
-                                the input string will be unchanged. The $(VAR_NAME)
-                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
-                                Escaped references will never be expanded, regardless
-                                of whether the variable exists or not. Defaults to
-                                "".'
                                 type: string
                               valueFrom:
-                                description: Source for the environment variable's value.
-                                  Cannot be used if value is not empty.
                                 properties:
                                   configMapKeyRef:
-                                    description: Selects a key of a ConfigMap.
                                     properties:
                                       key:
-                                        description: The key to select.
                                         type: string
                                       name:
-                                        description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap or
-                                          its key must be defined
                                         type: boolean
                                     required:
                                       - key
                                     type: object
                                   fieldRef:
-                                    description: 'Selects a field of the pod: supports
-                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                    spec.serviceAccountName, status.hostIP, status.podIP,
-                                    status.podIPs.'
                                     properties:
                                       apiVersion:
-                                        description: Version of the schema the FieldPath
-                                          is written in terms of, defaults to "v1".
                                         type: string
                                       fieldPath:
-                                        description: Path of the field to select in
-                                          the specified API version.
                                         type: string
                                     required:
                                       - fieldPath
                                     type: object
                                   resourceFieldRef:
-                                    description: 'Selects a resource of the container:
-                                    only resources limits and requests (limits.cpu,
-                                    limits.memory, limits.ephemeral-storage, requests.cpu,
-                                    requests.memory and requests.ephemeral-storage)
-                                    are currently supported.'
                                     properties:
                                       containerName:
-                                        description: 'Container name: required for volumes,
-                                        optional for env vars'
                                         type: string
                                       divisor:
                                         anyOf:
                                           - type: integer
                                           - type: string
-                                        description: Specifies the output format of
-                                          the exposed resources, defaults to "1"
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       resource:
-                                        description: 'Required: resource to select'
                                         type: string
                                     required:
                                       - resource
                                     type: object
                                   secretKeyRef:
-                                    description: Selects a key of a secret in the pod's
-                                      namespace
                                     properties:
                                       key:
-                                        description: The key of the secret to select
-                                          from.  Must be a valid secret key.
                                         type: string
                                       name:
-                                        description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the Secret or its
-                                          key must be defined
                                         type: boolean
                                     required:
                                       - key
@@ -3130,69 +1611,22 @@ spec:
                             type: object
                           type: array
                         volumes:
-                          description: Volumes defines extra volumes of the pod.
                           items:
-                            description: Volume represents a named volume in a pod that
-                              may be accessed by any container in the pod. The Volume
-                              API from the core group is not used directly to avoid
-                              unneeded fields defined in `VolumeSource` and reduce the
-                              size of the CRD. New fields in VolumeSource could be added
-                              as needed.
                             properties:
                               configMap:
-                                description: ConfigMap represents a configMap that should
-                                  populate this volume
                                 properties:
                                   defaultMode:
-                                    description: 'Optional: mode bits used to set permissions
-                                    on created files by default. Must be an octal
-                                    value between 0000 and 0777 or a decimal value
-                                    between 0 and 511. YAML accepts both octal and
-                                    decimal values, JSON requires decimal values for
-                                    mode bits. Defaults to 0644. Directories within
-                                    the path are not affected by this setting. This
-                                    might be in conflict with other options that affect
-                                    the file mode, like fsGroup, and the result can
-                                    be other mode bits set.'
                                     format: int32
                                     type: integer
                                   items:
-                                    description: If unspecified, each key-value pair
-                                      in the Data field of the referenced ConfigMap
-                                      will be projected into the volume as a file whose
-                                      name is the key and content is the value. If specified,
-                                      the listed keys will be projected into the specified
-                                      paths, and unlisted keys will not be present.
-                                      If a key is specified which is not present in
-                                      the ConfigMap, the volume setup will error unless
-                                      it is marked optional. Paths must be relative
-                                      and may not contain the '..' path or start with
-                                      '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: The key to project.
                                           type: string
                                         mode:
-                                          description: 'Optional: mode bits used to
-                                          set permissions on this file. Must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. If not specified,
-                                          the volume defaultMode will be used. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
                                           format: int32
                                           type: integer
                                         path:
-                                          description: The relative path of the file
-                                            to map the key to. May not be an absolute
-                                            path. May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                         - key
@@ -3200,73 +1634,26 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or its
-                                      keys must be defined
                                     type: boolean
                                 type: object
                               name:
-                                description: 'Volume''s name. Must be a DNS_LABEL and
-                                unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                 type: string
                               secret:
-                                description: Secret represents a secret that should
-                                  populate this volume.
                                 properties:
                                   defaultMode:
-                                    description: 'Optional: mode bits used to set permissions
-                                    on created files by default. Must be an octal
-                                    value between 0000 and 0777 or a decimal value
-                                    between 0 and 511. YAML accepts both octal and
-                                    decimal values, JSON requires decimal values for
-                                    mode bits. Defaults to 0644. Directories within
-                                    the path are not affected by this setting. This
-                                    might be in conflict with other options that affect
-                                    the file mode, like fsGroup, and the result can
-                                    be other mode bits set.'
                                     format: int32
                                     type: integer
                                   items:
-                                    description: If unspecified, each key-value pair
-                                      in the Data field of the referenced Secret will
-                                      be projected into the volume as a file whose name
-                                      is the key and content is the value. If specified,
-                                      the listed keys will be projected into the specified
-                                      paths, and unlisted keys will not be present.
-                                      If a key is specified which is not present in
-                                      the Secret, the volume setup will error unless
-                                      it is marked optional. Paths must be relative
-                                      and may not contain the '..' path or start with
-                                      '..'.
                                     items:
-                                      description: Maps a string key to a path within
-                                        a volume.
                                       properties:
                                         key:
-                                          description: The key to project.
                                           type: string
                                         mode:
-                                          description: 'Optional: mode bits used to
-                                          set permissions on this file. Must be an
-                                          octal value between 0000 and 0777 or a decimal
-                                          value between 0 and 511. YAML accepts both
-                                          octal and decimal values, JSON requires
-                                          decimal values for mode bits. If not specified,
-                                          the volume defaultMode will be used. This
-                                          might be in conflict with other options
-                                          that affect the file mode, like fsGroup,
-                                          and the result can be other mode bits set.'
                                           format: int32
                                           type: integer
                                         path:
-                                          description: The relative path of the file
-                                            to map the key to. May not be an absolute
-                                            path. May not contain the path element '..'.
-                                            May not start with the string '..'.
                                           type: string
                                       required:
                                         - key
@@ -3274,12 +1661,8 @@ spec:
                                       type: object
                                     type: array
                                   optional:
-                                    description: Specify whether the Secret or its keys
-                                      must be defined
                                     type: boolean
                                   secretName:
-                                    description: 'Name of the secret in the pod''s namespace
-                                    to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     type: string
                                 type: object
                             required:
@@ -3288,54 +1671,25 @@ spec:
                           type: array
                       type: object
                     replicas:
-                      description: Replicas defines the number of replicas of auto recovery
-                        bookies, defaults to 1, a value less or equal to 0 implies auto
-                        recovery is disabled for the cluster
                       format: int32
                       minimum: 0
                       type: integer
                   type: object
                 autoScalingPolicy:
-                  description: AutoScalingPolicy defines how Bookie will be scaled up/down
-                    with given metrics and threshold
                   properties:
                     behavior:
-                      description: Behavior configures the scaling behavior of the target
-                        in both Up and Down directions (scaleUp and scaleDown fields
-                        respectively). If not set, the default HPAScalingRules for scale
-                        up and scale down are used.
                       properties:
                         scaleDown:
-                          description: scaleDown is scaling policy for scaling Down.
-                            If not set, the default value is to allow to scale down
-                            to minReplicas pods, with a 300 second stabilization window
-                            (i.e., the highest recommendation for the last 300sec is
-                            used).
                           properties:
                             policies:
-                              description: policies is a list of potential scaling polices
-                                which can be used during scaling. At least one policy
-                                must be specified, otherwise the HPAScalingRules will
-                                be discarded as invalid
                               items:
-                                description: HPAScalingPolicy is a single policy which
-                                  must hold true for a specified past interval.
                                 properties:
                                   periodSeconds:
-                                    description: PeriodSeconds specifies the window
-                                      of time for which the policy should hold true.
-                                      PeriodSeconds must be greater than zero and less
-                                      than or equal to 1800 (30 min).
                                     format: int32
                                     type: integer
                                   type:
-                                    description: Type is used to specify the scaling
-                                      policy.
                                     type: string
                                   value:
-                                    description: Value contains the amount of change
-                                      which is permitted by the policy. It must be greater
-                                      than zero
                                     format: int32
                                     type: integer
                                 required:
@@ -3345,52 +1699,22 @@ spec:
                                 type: object
                               type: array
                             selectPolicy:
-                              description: selectPolicy is used to specify which policy
-                                should be used. If not set, the default value MaxPolicySelect
-                                is used.
                               type: string
                             stabilizationWindowSeconds:
-                              description: 'StabilizationWindowSeconds is the number
-                              of seconds for which past recommendations should be
-                              considered while scaling up or scaling down. StabilizationWindowSeconds
-                              must be greater than or equal to zero and less than
-                              or equal to 3600 (one hour). If not set, use the default
-                              values: - For scale up: 0 (i.e. no stabilization is
-                              done). - For scale down: 300 (i.e. the stabilization
-                              window is 300 seconds long).'
                               format: int32
                               type: integer
                           type: object
                         scaleUp:
-                          description: 'scaleUp is scaling policy for scaling Up. If
-                          not set, the default value is the higher of:   * increase
-                          no more than 4 pods per 60 seconds   * double the number
-                          of pods per 60 seconds No stabilization is used.'
                           properties:
                             policies:
-                              description: policies is a list of potential scaling polices
-                                which can be used during scaling. At least one policy
-                                must be specified, otherwise the HPAScalingRules will
-                                be discarded as invalid
                               items:
-                                description: HPAScalingPolicy is a single policy which
-                                  must hold true for a specified past interval.
                                 properties:
                                   periodSeconds:
-                                    description: PeriodSeconds specifies the window
-                                      of time for which the policy should hold true.
-                                      PeriodSeconds must be greater than zero and less
-                                      than or equal to 1800 (30 min).
                                     format: int32
                                     type: integer
                                   type:
-                                    description: Type is used to specify the scaling
-                                      policy.
                                     type: string
                                   value:
-                                    description: Value contains the amount of change
-                                      which is permitted by the policy. It must be greater
-                                      than zero
                                     format: int32
                                     type: integer
                                 required:
@@ -3400,19 +1724,8 @@ spec:
                                 type: object
                               type: array
                             selectPolicy:
-                              description: selectPolicy is used to specify which policy
-                                should be used. If not set, the default value MaxPolicySelect
-                                is used.
                               type: string
                             stabilizationWindowSeconds:
-                              description: 'StabilizationWindowSeconds is the number
-                              of seconds for which past recommendations should be
-                              considered while scaling up or scaling down. StabilizationWindowSeconds
-                              must be greater than or equal to zero and less than
-                              or equal to 3600 (one hour). If not set, use the default
-                              values: - For scale up: 0 (i.e. no stabilization is
-                              done). - For scale down: 300 (i.e. the stabilization
-                              window is 300 seconds long).'
                               format: int32
                               type: integer
                           type: object
@@ -3421,64 +1734,24 @@ spec:
                       format: int32
                       type: integer
                     metrics:
-                      description: 'Metrics contains the specifications for which to
-                      use to calculate the desired replica count (the maximum replica
-                      count across all metrics will be used). More info: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling'
                       items:
-                        description: MetricSpec specifies how to scale based on a single
-                          metric (only `type` and one other matching field should be
-                          set at once).
                         properties:
                           external:
-                            description: external refers to a global metric that is
-                              not associated with any Kubernetes object. It allows autoscaling
-                              based on information coming from components running outside
-                              of cluster (for example length of queue in cloud messaging
-                              service, or QPS from loadbalancer running outside of cluster).
                             properties:
                               metric:
-                                description: metric identifies the target metric by
-                                  name and selector
                                 properties:
                                   name:
-                                    description: name is the name of the given metric
                                     type: string
                                   selector:
-                                    description: selector is the string-encoded form
-                                      of a standard kubernetes label selector for the
-                                      given metric When set, it is passed as an additional
-                                      parameter to the metrics server for more specific
-                                      metrics scoping. When unset, just the metricName
-                                      will be used to gather metrics.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -3490,49 +1763,28 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                 required:
                                   - name
                                 type: object
                               target:
-                                description: target specifies the target value for the
-                                  given metric
                                 properties:
                                   averageUtilization:
-                                    description: averageUtilization is the target value
-                                      of the average of the resource metric across all
-                                      relevant pods, represented as a percentage of
-                                      the requested value of the resource for the pods.
-                                      Currently only valid for Resource metric source
-                                      type
                                     format: int32
                                     type: integer
                                   averageValue:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: averageValue is the target value of
-                                      the average of the metric across all relevant
-                                      pods (as a quantity)
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type:
-                                    description: type represents whether the metric
-                                      type is Utilization, Value, or AverageValue
                                     type: string
                                   value:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: value is the target value of the metric
-                                      (as a quantity).
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 required:
@@ -3543,70 +1795,33 @@ spec:
                               - target
                             type: object
                           object:
-                            description: object refers to a metric describing a single
-                              kubernetes object (for example, hits-per-second on an
-                              Ingress object).
                             properties:
                               describedObject:
-                                description: CrossVersionObjectReference contains enough
-                                  information to let you identify the referred resource.
                                 properties:
                                   apiVersion:
-                                    description: API version of the referent
                                     type: string
                                   kind:
-                                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
                                     type: string
                                   name:
-                                    description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                                     type: string
                                 required:
                                   - kind
                                   - name
                                 type: object
                               metric:
-                                description: metric identifies the target metric by
-                                  name and selector
                                 properties:
                                   name:
-                                    description: name is the name of the given metric
                                     type: string
                                   selector:
-                                    description: selector is the string-encoded form
-                                      of a standard kubernetes label selector for the
-                                      given metric When set, it is passed as an additional
-                                      parameter to the metrics server for more specific
-                                      metrics scoping. When unset, just the metricName
-                                      will be used to gather metrics.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -3618,49 +1833,28 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                 required:
                                   - name
                                 type: object
                               target:
-                                description: target specifies the target value for the
-                                  given metric
                                 properties:
                                   averageUtilization:
-                                    description: averageUtilization is the target value
-                                      of the average of the resource metric across all
-                                      relevant pods, represented as a percentage of
-                                      the requested value of the resource for the pods.
-                                      Currently only valid for Resource metric source
-                                      type
                                     format: int32
                                     type: integer
                                   averageValue:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: averageValue is the target value of
-                                      the average of the metric across all relevant
-                                      pods (as a quantity)
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type:
-                                    description: type represents whether the metric
-                                      type is Utilization, Value, or AverageValue
                                     type: string
                                   value:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: value is the target value of the metric
-                                      (as a quantity).
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 required:
@@ -3672,54 +1866,21 @@ spec:
                               - target
                             type: object
                           pods:
-                            description: pods refers to a metric describing each pod
-                              in the current scale target (for example, transactions-processed-per-second).  The
-                              values will be averaged together before being compared
-                              to the target value.
                             properties:
                               metric:
-                                description: metric identifies the target metric by
-                                  name and selector
                                 properties:
                                   name:
-                                    description: name is the name of the given metric
                                     type: string
                                   selector:
-                                    description: selector is the string-encoded form
-                                      of a standard kubernetes label selector for the
-                                      given metric When set, it is passed as an additional
-                                      parameter to the metrics server for more specific
-                                      metrics scoping. When unset, just the metricName
-                                      will be used to gather metrics.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -3731,49 +1892,28 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                 required:
                                   - name
                                 type: object
                               target:
-                                description: target specifies the target value for the
-                                  given metric
                                 properties:
                                   averageUtilization:
-                                    description: averageUtilization is the target value
-                                      of the average of the resource metric across all
-                                      relevant pods, represented as a percentage of
-                                      the requested value of the resource for the pods.
-                                      Currently only valid for Resource metric source
-                                      type
                                     format: int32
                                     type: integer
                                   averageValue:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: averageValue is the target value of
-                                      the average of the metric across all relevant
-                                      pods (as a quantity)
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type:
-                                    description: type represents whether the metric
-                                      type is Utilization, Value, or AverageValue
                                     type: string
                                   value:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: value is the target value of the metric
-                                      (as a quantity).
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 required:
@@ -3784,48 +1924,26 @@ spec:
                               - target
                             type: object
                           resource:
-                            description: resource refers to a resource metric (such
-                              as those specified in requests and limits) known to Kubernetes
-                              describing each pod in the current scale target (e.g.
-                              CPU or memory). Such metrics are built in to Kubernetes,
-                              and have special scaling options on top of those available
-                              to normal per-pod metrics using the "pods" source.
                             properties:
                               name:
-                                description: name is the name of the resource in question.
                                 type: string
                               target:
-                                description: target specifies the target value for the
-                                  given metric
                                 properties:
                                   averageUtilization:
-                                    description: averageUtilization is the target value
-                                      of the average of the resource metric across all
-                                      relevant pods, represented as a percentage of
-                                      the requested value of the resource for the pods.
-                                      Currently only valid for Resource metric source
-                                      type
                                     format: int32
                                     type: integer
                                   averageValue:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: averageValue is the target value of
-                                      the average of the metric across all relevant
-                                      pods (as a quantity)
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type:
-                                    description: type represents whether the metric
-                                      type is Utilization, Value, or AverageValue
                                     type: string
                                   value:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: value is the target value of the metric
-                                      (as a quantity).
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 required:
@@ -3836,9 +1954,6 @@ spec:
                               - target
                             type: object
                           type:
-                            description: type is the type of metric source.  It should
-                              be one of "Object", "Pods" or "Resource", each mapping
-                              to a matching field in the object.
                             type: string
                         required:
                           - type
@@ -3847,155 +1962,77 @@ spec:
                     minReplicas:
                       format: int32
                       type: integer
+                  required:
+                    - maxReplicas
                   type: object
                 conf:
                   additionalProperties:
                     type: string
-                  description: 'Conf defines the bookkeeper configuration. It will be
-                  used for generating the configuration file used by bookie process.
-                  Deprecated: use `config`'
                   type: object
                 config:
-                  description: Config defines the bookkeeper configuration
                   properties:
                     compactionRateByBytes:
-                      description: "CompactionRateByBytes is the rate at which compaction
-                      will read entries. The unit is adds per second. \n The default
-                      value is 52428800."
                       format: int64
                       minimum: 0
                       type: integer
                     custom:
                       additionalProperties:
                         type: string
-                      description: Custom accepts other configurations
                       type: object
                     fileInfoFormatVersionToWrite:
-                      description: "FileInfoFormatVersionToWrite is the fileinfo format
-                      version to write. Available formats are 0 and 1. \n The default
-                      value is 1"
                       format: int32
                       maximum: 1
                       minimum: 0
                       type: integer
                     gcWaitTime:
-                      description: "GCWaitTime is the interval to trigger next garbage
-                      collection, in milliseconds. \n The default value is 300000"
                       format: int32
                       minimum: 0
                       type: integer
                     isThrottleByBytes:
-                      description: "IsThrottleByBytes defines the throttle compaction
-                      by bytes or by entries. \n The default value is true."
                       type: boolean
                     journalFormatVersionToWrite:
-                      description: JournalFormatVersionToWrite is the journal format
-                        version to write. Available value are from 0 to 6. The default
-                        value is 6.
                       format: int32
                       maximum: 6
                       minimum: 0
                       type: integer
                     journalMaxBackups:
-                      description: "JournalMaxBackups is the max number of old journal
-                      file to kept. \n The default value is 0."
                       format: int32
                       minimum: 0
                       type: integer
                     persistBookieStatusEnabled:
-                      description: "PersistBookieStatusEnabled persists the bookie status
-                      locally on the disks. TODO: enable this after https://github.com/apache/bookkeeper/issues/2374
-                      is fixed. \n The default value is false."
                       type: boolean
                     useTransactionalCompaction:
-                      description: "UseTransactionalCompaction is the flag to enable/disable
-                      transactional compaction. If it is set to true, it will use
-                      transactional compaction, which uses new entry log files to
-                      store entries after compaction. \n The default value is true."
                       type: boolean
                   type: object
                 image:
-                  description: Image is the container image used to run bookie pods.
-                    default is apachepulsar/pulsar:latest
                   type: string
                 imagePullPolicy:
-                  description: Image pull policy, one of Always, Never, IfNotPresent,
-                    default to Always.
                   type: string
                 initialized:
-                  description: Initialized determines whether to create the job to initialize
-                    the cluster metadata.
                   type: boolean
                 labels:
                   additionalProperties:
                     type: string
-                  description: Labels specifies the labels to attach to the stateful
-                    set the operator creates for the bookkeeper cluster.
                   type: object
                 pod:
-                  description: Pod defines the policy for creating a bookkeeper pod
-                    for the cluster
                   properties:
                     affinity:
-                      description: Affinity specifies the scheduling constraints of
-                        a pod
                       properties:
                         nodeAffinity:
-                          description: Describes node affinity scheduling rules for
-                            the pod.
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node matches the corresponding matchExpressions;
-                                the node(s) with the highest sum are the most preferred.
                               items:
-                                description: An empty preferred scheduling term matches
-                                  all objects with implicit weight 0 (i.e. it's a no-op).
-                                  A null preferred scheduling term matches no objects
-                                  (i.e. is also a no-op).
                                 properties:
                                   preference:
-                                    description: A node selector term, associated with
-                                      the corresponding weight.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
                                         items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: The label key that the selector
-                                                applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -4005,35 +2042,13 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
                                         items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: The label key that the selector
-                                                applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -4044,8 +2059,6 @@ spec:
                                         type: array
                                     type: object
                                   weight:
-                                    description: Weight associated with matching the
-                                      corresponding nodeSelectorTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -4054,53 +2067,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to an update), the system
-                                may or may not try to eventually evict the pod from
-                                its node.
                               properties:
                                 nodeSelectorTerms:
-                                  description: Required. A list of node selector terms.
-                                    The terms are ORed.
                                   items:
-                                    description: A null or empty node selector term
-                                      matches no objects. The requirements of them are
-                                      ANDed. The TopologySelectorTerm type implements
-                                      a subset of the NodeSelectorTerm.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
                                         items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: The label key that the selector
-                                                applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -4110,35 +2088,13 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
                                         items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: The label key that the selector
-                                                applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -4154,65 +2110,22 @@ spec:
                               type: object
                           type: object
                         podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g.
-                            co-locate this pod in the same node, zone, etc. as some
-                            other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -4224,37 +2137,18 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -4263,56 +2157,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to a pod label update),
-                                the system may or may not try to eventually evict the
-                                pod from its node. When there are multiple elements,
-                                the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
                               items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -4324,29 +2180,13 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -4354,65 +2194,22 @@ spec:
                               type: array
                           type: object
                         podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules
-                            (e.g. avoid putting this pod in the same node, zone, etc.
-                            as some other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the anti-affinity expressions
-                                specified by this field, but it may choose a node that
-                                violates one or more of the expressions. The node that
-                                is most preferred is the one with the greatest sum of
-                                weights, i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                anti-affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -4424,37 +2221,18 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -4463,56 +2241,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified
-                                by this field are not met at scheduling time, the pod
-                                will not be scheduled onto the node. If the anti-affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a pod
-                                label update), the system may or may not try to eventually
-                                evict the pod from its node. When there are multiple
-                                elements, the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
                               items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -4524,29 +2264,13 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -4557,134 +2281,69 @@ spec:
                     annotations:
                       additionalProperties:
                         type: string
-                      description: Annotations specifies the annotations to attach to
-                        pods the operator creates
                       type: object
                     initContainers:
-                      description: InitContainers defines init containers of the pod.
-                        A typical use case could be using an init container to download
-                        a remote jar to a local path.
                       items:
-                        description: A single application container that you want to
-                          run within a pod. The Container API from the core group is
-                          not used directly to avoid unneeded fields and reduce the
-                          size of the CRD. New fields could be added as needed.
                         properties:
                           args:
-                            description: Arguments to the entrypoint.
                             items:
                               type: string
                             type: array
                           command:
-                            description: Entrypoint array. Not executed within a shell.
                             items:
                               type: string
                             type: array
                           env:
-                            description: List of environment variables to set in the
-                              container.
                             items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
                               properties:
                                 name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
-                                  description: 'Variable references $(VAR_NAME) are
-                                  expanded using the previous defined environment
-                                  variables in the container and any service environment
-                                  variables. If a variable cannot be resolved, the
-                                  reference in the input string will be unchanged.
-                                  The $(VAR_NAME) syntax can be escaped with a double
-                                  $$, ie: $$(VAR_NAME). Escaped references will never
-                                  be expanded, regardless of whether the variable
-                                  exists or not. Defaults to "".'
                                   type: string
                                 valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
-                                          description: The key to select.
                                           type: string
                                         name:
-                                          description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
                                           type: boolean
                                       required:
                                         - key
                                       type: object
                                     fieldRef:
-                                      description: 'Selects a field of the pod: supports
-                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                      spec.serviceAccountName, status.hostIP, status.podIP,
-                                      status.podIPs.'
                                       properties:
                                         apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
-                                          description: Path of the field to select in
-                                            the specified API version.
                                           type: string
                                       required:
                                         - fieldPath
                                       type: object
                                     resourceFieldRef:
-                                      description: 'Selects a resource of the container:
-                                      only resources limits and requests (limits.cpu,
-                                      limits.memory, limits.ephemeral-storage, requests.cpu,
-                                      requests.memory and requests.ephemeral-storage)
-                                      are currently supported.'
                                       properties:
                                         containerName:
-                                          description: 'Container name: required for
-                                          volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                             - type: integer
                                             - type: string
-                                          description: Specifies the output format of
-                                            the exposed resources, defaults to "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
-                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                         - resource
                                       type: object
                                     secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
                                       properties:
                                         key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
-                                          description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                           type: string
                                         optional:
-                                          description: Specify whether the Secret or
-                                            its key must be defined
                                           type: boolean
                                       required:
                                         - key
@@ -4695,99 +2354,52 @@ spec:
                               type: object
                             type: array
                           envFrom:
-                            description: List of sources to populate environment variables
-                              in the container.
                             items:
-                              description: EnvFromSource represents the source of a
-                                set of ConfigMaps
                               properties:
                                 configMapRef:
-                                  description: The ConfigMap to select from
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap must
-                                        be defined
                                       type: boolean
                                   type: object
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
-                                  description: The Secret to select from
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret must be
-                                        defined
                                       type: boolean
                                   type: object
                               type: object
                             type: array
                           image:
-                            description: Docker image name.
                             type: string
                           imagePullPolicy:
-                            description: Image pull policy.
                             type: string
                           livenessProbe:
-                            description: Periodic probe of container liveness.
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe
-                                  to be considered failed after having succeeded. Defaults
-                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -4795,120 +2407,66 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe
-                                  to be considered successful after having failed. Defaults
-                                  to 1. Must be 1 for liveness and startup. Minimum
-                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           name:
-                            description: Name of the container specified as a DNS_LABEL.
-                              Each container in a pod must have a unique name (DNS_LABEL).
                             type: string
                           readinessProbe:
-                            description: 'Periodic probe of container service readiness.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe
-                                  to be considered failed after having succeeded. Defaults
-                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -4916,70 +2474,43 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe
-                                  to be considered successful after having failed. Defaults
-                                  to 1. Must be 1 for liveness and startup. Minimum
-                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           resources:
-                            description: Compute Resources required by this container.
                             properties:
                               limits:
                                 additionalProperties:
@@ -4988,8 +2519,6 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -4998,61 +2527,30 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                             type: object
                           startupProbe:
-                            description: StartupProbe indicates that the Pod has successfully
-                              initialized.
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe
-                                  to be considered failed after having succeeded. Defaults
-                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -5060,103 +2558,56 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe
-                                  to be considered successful after having failed. Defaults
-                                  to 1. Must be 1 for liveness and startup. Minimum
-                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           volumeMounts:
-                            description: Pod volumes to mount into the container's filesystem.
                             items:
-                              description: VolumeMount describes a mounting of a Volume
-                                within a container.
                               properties:
                                 mountPath:
-                                  description: Path within the container at which the
-                                    volume should be mounted.  Must not contain ':'.
                                   type: string
                                 mountPropagation:
-                                  description: mountPropagation determines how mounts
-                                    are propagated from the host to container and the
-                                    other way around. When not set, MountPropagationNone
-                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
-                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
-                                  description: Mounted read-only if true, read-write
-                                    otherwise (false or unspecified). Defaults to false.
                                   type: boolean
                                 subPath:
-                                  description: Path within the volume from which the
-                                    container's volume should be mounted. Defaults to
-                                    "" (volume's root).
                                   type: string
                                 subPathExpr:
-                                  description: Expanded path within the volume from
-                                    which the container's volume should be mounted.
-                                    Behaves similarly to SubPath but environment variable
-                                    references $(VAR_NAME) are expanded using the container's
-                                    environment. Defaults to "" (volume's root). SubPathExpr
-                                    and SubPath are mutually exclusive.
                                   type: string
                               required:
                                 - mountPath
@@ -5164,14 +2615,12 @@ spec:
                               type: object
                             type: array
                           workingDir:
-                            description: Container's working directory.
                             type: string
                         required:
                           - name
                         type: object
                       type: array
                     jvmOptions:
-                      description: JVMOptions defines JVM parameters of Bookies
                       properties:
                         extraOptions:
                           items:
@@ -5193,19 +2642,12 @@ spec:
                     labels:
                       additionalProperties:
                         type: string
-                      description: Labels specifies the labels to attach to pod the
-                        operator creates for the bookkeeper cluster.
                       type: object
                     nodeSelector:
                       additionalProperties:
                         type: string
-                      description: NodeSelector specifies a map of key-value pairs.
-                        For a pod to be eligible to run on a node, the node must have
-                        each of the indicated key-value pairs as labels.
                       type: object
                     resources:
-                      description: Resources specifies the resource requirements of
-                        a pod to run in the cluster
                       properties:
                         limits:
                           additionalProperties:
@@ -5214,8 +2656,6 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
@@ -5224,127 +2664,54 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
                     securityContext:
-                      description: 'SecurityContext specifies the security context for
-                      the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
                       properties:
                         fsGroup:
-                          description: "A special supplemental group that applies to
-                          all containers in a pod. Some volume types allow the Kubelet
-                          to change the ownership of that volume to be owned by the
-                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                          bit is set (new files created in the volume will be owned
-                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                          \n If unset, the Kubelet will not modify the ownership and
-                          permissions of any volume."
                           format: int64
                           type: integer
                         fsGroupChangePolicy:
-                          description: 'fsGroupChangePolicy defines behavior of changing
-                          ownership and permission of the volume before being exposed
-                          inside Pod. This field will only apply to volume types which
-                          support fsGroup based ownership(and permissions). It will
-                          have no effect on ephemeral volume types such as: secret,
-                          configmaps and emptydir. Valid values are "OnRootMismatch"
-                          and "Always". If not specified defaults to "Always".'
                           type: string
                         runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence for that container.
                           format: int64
                           type: integer
                         runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in SecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
                           type: boolean
                         runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in SecurityContext.  If set
-                            in both SecurityContext and PodSecurityContext, the value
-                            specified in SecurityContext takes precedence for that container.
                           format: int64
                           type: integer
                         seLinuxOptions:
-                          description: The SELinux context to be applied to all containers.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence
-                            for that container.
                           properties:
                             level:
-                              description: Level is SELinux level label that applies
-                                to the container.
                               type: string
                             role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
                               type: string
                             type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
                               type: string
                             user:
-                              description: User is a SELinux user label that applies
-                                to the container.
                               type: string
                           type: object
                         seccompProfile:
-                          description: The seccomp options to use by the containers
-                            in this pod.
                           properties:
                             localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
                               type: string
                             type:
-                              description: "type indicates which kind of seccomp profile
-                              will be applied. Valid options are: \n Localhost - a
-                              profile defined in a file on the node should be used.
-                              RuntimeDefault - the container runtime default profile
-                              should be used. Unconfined - no profile should be applied."
                               type: string
                           required:
                             - type
                           type: object
                         supplementalGroups:
-                          description: A list of groups applied to the first process
-                            run in each container, in addition to the container's primary
-                            GID.  If unspecified, no groups will be added to any container.
                           items:
                             format: int64
                             type: integer
                           type: array
                         sysctls:
-                          description: Sysctls hold a list of namespaced sysctls used
-                            for the pod. Pods with unsupported sysctls (by the container
-                            runtime) might fail to launch.
                           items:
-                            description: Sysctl defines a kernel parameter to be set
                             properties:
                               name:
-                                description: Name of a property to set
                                 type: string
                               value:
-                                description: Value of a property to set
                                 type: string
                             required:
                               - name
@@ -5352,182 +2719,87 @@ spec:
                             type: object
                           type: array
                         windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options within a container's
-                            SecurityContext will be used. If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
                           properties:
                             gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
                               type: string
                             gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
                               type: string
                             runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
                               type: string
                           type: object
                       type: object
                     serviceAccountName:
-                      description: ServiceAccountName is the name of the ServiceAccount
-                        to use to run pods.
                       type: string
                     terminationGracePeriodSeconds:
-                      description: TerminationGracePeriodSeconds is the amount of time
-                        that kubernetes will give for a pod before terminating it.
                       format: int64
                       type: integer
                     tolerations:
-                      description: Tolerations specifies the tolerations of a Pod
                       items:
-                        description: The pod this Toleration is attached to tolerates
-                          any taint that matches the triple <key,value,effect> using
-                          the matching operator <operator>.
                         properties:
                           effect:
-                            description: Effect indicates the taint effect to match.
-                              Empty means match all taint effects. When specified, allowed
-                              values are NoSchedule, PreferNoSchedule and NoExecute.
                             type: string
                           key:
-                            description: Key is the taint key that the toleration applies
-                              to. Empty means match all taint keys. If the key is empty,
-                              operator must be Exists; this combination means to match
-                              all values and all keys.
                             type: string
                           operator:
-                            description: Operator represents a key's relationship to
-                              the value. Valid operators are Exists and Equal. Defaults
-                              to Equal. Exists is equivalent to wildcard for value,
-                              so that a pod can tolerate all taints of a particular
-                              category.
                             type: string
                           tolerationSeconds:
-                            description: TolerationSeconds represents the period of
-                              time the toleration (which must be of effect NoExecute,
-                              otherwise this field is ignored) tolerates the taint.
-                              By default, it is not set, which means tolerate the taint
-                              forever (do not evict). Zero and negative values will
-                              be treated as 0 (evict immediately) by the system.
                             format: int64
                             type: integer
                           value:
-                            description: Value is the taint value the toleration matches
-                              to. If the operator is Exists, the value should be empty,
-                              otherwise just a regular string.
                             type: string
                         type: object
                       type: array
                     vars:
-                      description: Vars specifies the environment variables of a Pod
                       items:
-                        description: EnvVar represents an environment variable present
-                          in a Container.
                         properties:
                           name:
-                            description: Name of the environment variable. Must be a
-                              C_IDENTIFIER.
                             type: string
                           value:
-                            description: 'Variable references $(VAR_NAME) are expanded
-                            using the previous defined environment variables in the
-                            container and any service environment variables. If a
-                            variable cannot be resolved, the reference in the input
-                            string will be unchanged. The $(VAR_NAME) syntax can be
-                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                            will never be expanded, regardless of whether the variable
-                            exists or not. Defaults to "".'
                             type: string
                           valueFrom:
-                            description: Source for the environment variable's value.
-                              Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
-                                description: Selects a key of a ConfigMap.
                                 properties:
                                   key:
-                                    description: The key to select.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or its
-                                      key must be defined
                                     type: boolean
                                 required:
                                   - key
                                 type: object
                               fieldRef:
-                                description: 'Selects a field of the pod: supports metadata.name,
-                                metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                spec.serviceAccountName, status.hostIP, status.podIP,
-                                status.podIPs.'
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
                                     type: string
                                 required:
                                   - fieldPath
                                 type: object
                               resourceFieldRef:
-                                description: 'Selects a resource of the container: only
-                                resources limits and requests (limits.cpu, limits.memory,
-                                limits.ephemeral-storage, requests.cpu, requests.memory
-                                and requests.ephemeral-storage) are currently supported.'
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes,
-                                    optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
-                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                   - resource
                                 type: object
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its key
-                                      must be defined
                                     type: boolean
                                 required:
                                   - key
@@ -5538,66 +2810,22 @@ spec:
                         type: object
                       type: array
                     volumes:
-                      description: Volumes defines extra volumes of the pod.
                       items:
-                        description: Volume represents a named volume in a pod that
-                          may be accessed by any container in the pod. The Volume API
-                          from the core group is not used directly to avoid unneeded
-                          fields defined in `VolumeSource` and reduce the size of the
-                          CRD. New fields in VolumeSource could be added as needed.
                         properties:
                           configMap:
-                            description: ConfigMap represents a configMap that should
-                              populate this volume
                             properties:
                               defaultMode:
-                                description: 'Optional: mode bits used to set permissions
-                                on created files by default. Must be an octal value
-                                between 0000 and 0777 or a decimal value between 0
-                                and 511. YAML accepts both octal and decimal values,
-                                JSON requires decimal values for mode bits. Defaults
-                                to 0644. Directories within the path are not affected
-                                by this setting. This might be in conflict with other
-                                options that affect the file mode, like fsGroup, and
-                                the result can be other mode bits set.'
                                 format: int32
                                 type: integer
                               items:
-                                description: If unspecified, each key-value pair in
-                                  the Data field of the referenced ConfigMap will be
-                                  projected into the volume as a file whose name is
-                                  the key and content is the value. If specified, the
-                                  listed keys will be projected into the specified paths,
-                                  and unlisted keys will not be present. If a key is
-                                  specified which is not present in the ConfigMap, the
-                                  volume setup will error unless it is marked optional.
-                                  Paths must be relative and may not contain the '..'
-                                  path or start with '..'.
                                 items:
-                                  description: Maps a string key to a path within a
-                                    volume.
                                   properties:
                                     key:
-                                      description: The key to project.
                                       type: string
                                     mode:
-                                      description: 'Optional: mode bits used to set
-                                      permissions on this file. Must be an octal value
-                                      between 0000 and 0777 or a decimal value between
-                                      0 and 511. YAML accepts both octal and decimal
-                                      values, JSON requires decimal values for mode
-                                      bits. If not specified, the volume defaultMode
-                                      will be used. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
                                       format: int32
                                       type: integer
                                     path:
-                                      description: The relative path of the file to
-                                        map the key to. May not be an absolute path.
-                                        May not contain the path element '..'. May not
-                                        start with the string '..'.
                                       type: string
                                   required:
                                     - key
@@ -5605,70 +2833,26 @@ spec:
                                   type: object
                                 type: array
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
-                                description: Specify whether the ConfigMap or its keys
-                                  must be defined
                                 type: boolean
                             type: object
                           name:
-                            description: 'Volume''s name. Must be a DNS_LABEL and unique
-                            within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
                           secret:
-                            description: Secret represents a secret that should populate
-                              this volume.
                             properties:
                               defaultMode:
-                                description: 'Optional: mode bits used to set permissions
-                                on created files by default. Must be an octal value
-                                between 0000 and 0777 or a decimal value between 0
-                                and 511. YAML accepts both octal and decimal values,
-                                JSON requires decimal values for mode bits. Defaults
-                                to 0644. Directories within the path are not affected
-                                by this setting. This might be in conflict with other
-                                options that affect the file mode, like fsGroup, and
-                                the result can be other mode bits set.'
                                 format: int32
                                 type: integer
                               items:
-                                description: If unspecified, each key-value pair in
-                                  the Data field of the referenced Secret will be projected
-                                  into the volume as a file whose name is the key and
-                                  content is the value. If specified, the listed keys
-                                  will be projected into the specified paths, and unlisted
-                                  keys will not be present. If a key is specified which
-                                  is not present in the Secret, the volume setup will
-                                  error unless it is marked optional. Paths must be
-                                  relative and may not contain the '..' path or start
-                                  with '..'.
                                 items:
-                                  description: Maps a string key to a path within a
-                                    volume.
                                   properties:
                                     key:
-                                      description: The key to project.
                                       type: string
                                     mode:
-                                      description: 'Optional: mode bits used to set
-                                      permissions on this file. Must be an octal value
-                                      between 0000 and 0777 or a decimal value between
-                                      0 and 511. YAML accepts both octal and decimal
-                                      values, JSON requires decimal values for mode
-                                      bits. If not specified, the volume defaultMode
-                                      will be used. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
                                       format: int32
                                       type: integer
                                     path:
-                                      description: The relative path of the file to
-                                        map the key to. May not be an absolute path.
-                                        May not contain the path element '..'. May not
-                                        start with the string '..'.
                                       type: string
                                   required:
                                     - key
@@ -5676,12 +2860,8 @@ spec:
                                   type: object
                                 type: array
                               optional:
-                                description: Specify whether the Secret or its keys
-                                  must be defined
                                 type: boolean
                               secretName:
-                                description: 'Name of the secret in the pod''s namespace
-                                to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                 type: string
                             type: object
                         required:
@@ -5690,76 +2870,38 @@ spec:
                       type: array
                   type: object
                 replicas:
-                  description: Replicas is the expected size of the bookkeeper cluster.
-                    The bookkeeper operator will eventually make the size of the running
-                    cluster equal to the expected size. Use a pointer to distinguish
-                    between a specified zero or unspecified.
                   format: int32
                   minimum: 0
                   type: integer
                 storage:
-                  description: Persistence defines the persistent volume used for the
-                    bookie pod
                   properties:
                     journal:
-                      description: Journal is the spec to define journal storage
                       properties:
                         numDirsPerVolume:
-                          description: NumDirsPerVolume defines the number of directories
-                            provisioned for this type of storage.
                           format: int32
                           type: integer
                         numVolumes:
-                          description: NumVolumes defines the number of volumes provisioned
-                            for this type of storage.
                           format: int32
                           type: integer
                         volumeClaimTemplate:
-                          description: VolumeClaimSpec is the spec to define PVC for
-                            the storage
                           properties:
                             accessModes:
-                              description: 'AccessModes contains the desired access
-                              modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                               items:
                                 type: string
                               type: array
                             dataSource:
-                              description: 'This field can be used to specify either:
-                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                              - Beta) * An existing PVC (PersistentVolumeClaim) *
-                              An existing custom resource/object that implements data
-                              population (Alpha) In order to use VolumeSnapshot object
-                              types, the appropriate feature gate must be enabled
-                              (VolumeSnapshotDataSource or AnyVolumeDataSource) If
-                              the provisioner or an external controller can support
-                              the specified data source, it will create a new volume
-                              based on the contents of the specified data source.
-                              If the specified data source is not supported, the volume
-                              will not be created and the failure will be reported
-                              as an event. In the future, we plan to support more
-                              data source types and the behavior of the provisioner
-                              may change.'
                               properties:
                                 apiGroup:
-                                  description: APIGroup is the group for the resource
-                                    being referenced. If APIGroup is not specified,
-                                    the specified Kind must be in the core API group.
-                                    For any other third-party types, APIGroup is required.
                                   type: string
                                 kind:
-                                  description: Kind is the type of resource being referenced
                                   type: string
                                 name:
-                                  description: Name is the name of resource being referenced
                                   type: string
                               required:
                                 - kind
                                 - name
                               type: object
                             resources:
-                              description: 'Resources represents the minimum resources
-                              the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                               properties:
                                 limits:
                                   additionalProperties:
@@ -5768,8 +2910,6 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount
-                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -5778,41 +2918,18 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount
-                                  of compute resources required. If Requests is omitted
-                                  for a container, it defaults to Limits if that is
-                                  explicitly specified, otherwise to an implementation-defined
-                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                   type: object
                               type: object
                             selector:
-                              description: A label query over volumes to consider for
-                                binding.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector
-                                    requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector
-                                      that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are In,
-                                          NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values.
-                                          If the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator is
-                                          Exists or DoesNotExist, the values array must
-                                          be empty. This array is replaced during a
-                                          strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -5824,89 +2941,45 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs.
-                                    A single {key,value} in the matchLabels map is equivalent
-                                    to an element of matchExpressions, whose key field
-                                    is "key", the operator is "In", and the values array
-                                    contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                             storageClassName:
-                              description: 'Name of the StorageClass required by the
-                              claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                               type: string
                             volumeMode:
-                              description: volumeMode defines what type of volume is
-                                required by the claim. Value of Filesystem is implied
-                                when not included in claim spec.
                               type: string
                             volumeName:
-                              description: VolumeName is the binding reference to the
-                                PersistentVolume backing this claim.
                               type: string
                           type: object
                       required:
                         - volumeClaimTemplate
                       type: object
                     ledger:
-                      description: Ledger is the spec to define the ledger storage
                       properties:
                         numDirsPerVolume:
-                          description: NumDirsPerVolume defines the number of directories
-                            provisioned for this type of storage.
                           format: int32
                           type: integer
                         numVolumes:
-                          description: NumVolumes defines the number of volumes provisioned
-                            for this type of storage.
                           format: int32
                           type: integer
                         volumeClaimTemplate:
-                          description: VolumeClaimSpec is the spec to define PVC for
-                            the storage
                           properties:
                             accessModes:
-                              description: 'AccessModes contains the desired access
-                              modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                               items:
                                 type: string
                               type: array
                             dataSource:
-                              description: 'This field can be used to specify either:
-                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                              - Beta) * An existing PVC (PersistentVolumeClaim) *
-                              An existing custom resource/object that implements data
-                              population (Alpha) In order to use VolumeSnapshot object
-                              types, the appropriate feature gate must be enabled
-                              (VolumeSnapshotDataSource or AnyVolumeDataSource) If
-                              the provisioner or an external controller can support
-                              the specified data source, it will create a new volume
-                              based on the contents of the specified data source.
-                              If the specified data source is not supported, the volume
-                              will not be created and the failure will be reported
-                              as an event. In the future, we plan to support more
-                              data source types and the behavior of the provisioner
-                              may change.'
                               properties:
                                 apiGroup:
-                                  description: APIGroup is the group for the resource
-                                    being referenced. If APIGroup is not specified,
-                                    the specified Kind must be in the core API group.
-                                    For any other third-party types, APIGroup is required.
                                   type: string
                                 kind:
-                                  description: Kind is the type of resource being referenced
                                   type: string
                                 name:
-                                  description: Name is the name of resource being referenced
                                   type: string
                               required:
                                 - kind
                                 - name
                               type: object
                             resources:
-                              description: 'Resources represents the minimum resources
-                              the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                               properties:
                                 limits:
                                   additionalProperties:
@@ -5915,8 +2988,6 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount
-                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -5925,41 +2996,18 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount
-                                  of compute resources required. If Requests is omitted
-                                  for a container, it defaults to Limits if that is
-                                  explicitly specified, otherwise to an implementation-defined
-                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                   type: object
                               type: object
                             selector:
-                              description: A label query over volumes to consider for
-                                binding.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector
-                                    requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector
-                                      that contains values, a key, and an operator that
-                                      relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector
-                                          applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship
-                                          to a set of values. Valid operators are In,
-                                          NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values.
-                                          If the operator is In or NotIn, the values
-                                          array must be non-empty. If the operator is
-                                          Exists or DoesNotExist, the values array must
-                                          be empty. This array is replaced during a
-                                          strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -5971,54 +3019,28 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs.
-                                    A single {key,value} in the matchLabels map is equivalent
-                                    to an element of matchExpressions, whose key field
-                                    is "key", the operator is "In", and the values array
-                                    contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                             storageClassName:
-                              description: 'Name of the StorageClass required by the
-                              claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                               type: string
                             volumeMode:
-                              description: volumeMode defines what type of volume is
-                                required by the claim. Value of Filesystem is implied
-                                when not included in claim spec.
                               type: string
                             volumeName:
-                              description: VolumeName is the binding reference to the
-                                PersistentVolume backing this claim.
                               type: string
                           type: object
                       required:
                         - volumeClaimTemplate
                       type: object
                     reclaimPolicy:
-                      description: VolumeReclaimPolicy defines how to reclaim PV.
                       type: string
                   type: object
                 zkServers:
-                  description: Zookeeper server list
                   type: string
               type: object
             status:
-              description: BookKeeperClusterStatus defines the observed state of BookKeeperCluster
               properties:
                 conditions:
-                  description: Conditions is the current conditions of the cluster
                   items:
-                    description: "Condition represents an observation of an object's
-                    state. Conditions are an extension mechanism intended to be used
-                    when the details of an observation are not a priori known or would
-                    not apply to all instances of a given Kind. \n Conditions should
-                    be added to explicitly convey properties that users and components
-                    care about rather than requiring those properties to be inferred
-                    from other observations. Once defined, the meaning of a Condition
-                    can not be changed arbitrarily - it becomes part of the API, and
-                    has the same backwards- and forwards-compatibility concerns of
-                    any other part of the API."
                     properties:
                       lastTransitionTime:
                         format: date-time
@@ -6026,20 +3048,10 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is intended to be a one-word, CamelCase
-                          representation of the category of cause of the current status.
-                          It is intended to be used in concise output, such as one-line
-                          kubectl get output, and in summarizing occurrences of causes.
                         type: string
                       status:
                         type: string
                       type:
-                        description: "ConditionType is the type of the condition and
-                        is typically a CamelCased word or short phrase. \n Condition
-                        types should indicate state in the \"abnormal-true\" polarity.
-                        For example, if the condition indicates when a policy is invalid,
-                        the \"is valid\" case is probably the norm, so the condition
-                        should be called \"Invalid\"."
                         type: string
                     required:
                       - status
@@ -6047,28 +3059,19 @@ spec:
                     type: object
                   type: array
                 currentVersion:
-                  description: CurrentVersion is the current cluster version
                   type: string
                 labelSelector:
-                  description: Label selector for scaling
                   type: string
                 observedGeneration:
-                  description: ObservedGeneration is the most recent generation observed
-                    for this cluster. It corresponds to the metadata generation, which
-                    is updated on mutation by the API Server.
                   format: int64
                   type: integer
                 readyReplicas:
-                  description: ReadyReplicas is the number of ready servers in the cluster
                   format: int32
                   type: integer
                 replicas:
-                  description: Replicas
                   format: int32
                   type: integer
                 updatedReplicas:
-                  description: UpdatedReplicas is the number of servers that has been
-                    updated to the latest configuration
                   format: int32
                   type: integer
               required:

--- a/charts/pulsar-operator/crds/pulsar.streamnative.io_pulsarbrokers.yaml
+++ b/charts/pulsar-operator/crds/pulsar.streamnative.io_pulsarbrokers.yaml
@@ -39,317 +39,202 @@ spec:
         openAPIV3Schema:
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
             spec:
-              description: PulsarBrokerSpec defines the desired state of PulsarBroker
               properties:
                 apiObjects:
-                  description: APIObjects allows precise control over how components
-                    (services, statefulset and so on) should be managed
                   properties:
                     brokerConfigMap:
-                      description: BrokerConfigMap defines the broker ConfigMap resource
-                        template.
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata used to customize
-                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels of the resource.
                               type: object
                             name:
-                              description: Name of the resource within a namespace.
-                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
-                          description: UpdatePolicy defines which field to update.
                           items:
-                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     externalService:
-                      description: ExternalService defines the Pulsar External Service
-                        resource template.
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata used to customize
-                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels of the resource.
                               type: object
                             name:
-                              description: Name of the resource within a namespace.
-                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
-                          description: UpdatePolicy defines which field to update.
                           items:
-                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     functionMeshConfigMap:
-                      description: FunctionMeshConfigMap defines the FunctionMesh ConfigMap
-                        resource template.
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata used to customize
-                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels of the resource.
                               type: object
                             name:
-                              description: Name of the resource within a namespace.
-                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
-                          description: UpdatePolicy defines which field to update.
                           items:
-                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     functionWorkerConfigMap:
-                      description: FunctionWorkerConfigMap defines the function worker
-                        ConfigMap resource template.
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata used to customize
-                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels of the resource.
                               type: object
                             name:
-                              description: Name of the resource within a namespace.
-                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
-                          description: UpdatePolicy defines which field to update.
                           items:
-                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     headlessService:
-                      description: HeadlessService defines the Pulsar Headless Service
-                        resource template.
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata used to customize
-                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels of the resource.
                               type: object
                             name:
-                              description: Name of the resource within a namespace.
-                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
-                          description: UpdatePolicy defines which field to update.
                           items:
-                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     interceptorConfigMap:
-                      description: InterceptorConfigMap defines the interceptor ConfigMap
-                        resource template.
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata used to customize
-                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels of the resource.
                               type: object
                             name:
-                              description: Name of the resource within a namespace.
-                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
-                          description: UpdatePolicy defines which field to update.
                           items:
-                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     internalService:
-                      description: InternalService defines the Pulsar Client Service
-                        resource template.
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata used to customize
-                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels of the resource.
                               type: object
                             name:
-                              description: Name of the resource within a namespace.
-                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
-                          description: UpdatePolicy defines which field to update.
                           items:
-                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     pdb:
-                      description: PDB defines the PodDisruptionBudget resource template.
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata used to customize
-                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels of the resource.
                               type: object
                             name:
-                              description: Name of the resource within a namespace.
-                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
-                          description: UpdatePolicy defines which field to update.
                           items:
-                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     statefulSet:
-                      description: StatefulSet defines the broker StatefulSet resource
-                        template.
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata used to customize
-                          the name, labels, annotations of the object. More info:
-                          https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels of the resource.
                               type: object
                             name:
-                              description: Name of the resource within a namespace.
-                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
-                          description: UpdatePolicy defines which field to update.
                           items:
-                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                         volumeClaimTemplates:
-                          description: VolumeClaimTemplates is a list of claims that
-                            pods are allowed to reference. If a non-empty list is specified,
-                            the original values in the desired STS will be replaced.
                           items:
-                            description: PersistentVolumeClaim is a user's request for
-                              and claim to a persistent volume
                             properties:
                               apiVersion:
-                                description: 'APIVersion defines the versioned schema
-                                of this representation of an object. Servers should
-                                convert recognized schemas to the latest internal
-                                value, and may reject unrecognized values. More info:
-                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                                 type: string
                               kind:
-                                description: 'Kind is a string value representing the
-                                REST resource this object represents. Servers may
-                                infer this from the endpoint the client submits requests
-                                to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                 type: string
                               metadata:
-                                description: 'Standard object''s metadata. More info:
-                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                                 properties:
                                   annotations:
                                     additionalProperties:
@@ -369,55 +254,24 @@ spec:
                                     type: string
                                 type: object
                               spec:
-                                description: 'Spec defines the desired characteristics
-                                of a volume requested by a pod author. More info:
-                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                 properties:
                                   accessModes:
-                                    description: 'AccessModes contains the desired access
-                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                     items:
                                       type: string
                                     type: array
                                   dataSource:
-                                    description: 'This field can be used to specify
-                                    either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                                    - Beta) * An existing PVC (PersistentVolumeClaim)
-                                    * An existing custom resource/object that implements
-                                    data population (Alpha) In order to use VolumeSnapshot
-                                    object types, the appropriate feature gate must
-                                    be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
-                                    If the provisioner or an external controller can
-                                    support the specified data source, it will create
-                                    a new volume based on the contents of the specified
-                                    data source. If the specified data source is not
-                                    supported, the volume will not be created and
-                                    the failure will be reported as an event. In the
-                                    future, we plan to support more data source types
-                                    and the behavior of the provisioner may change.'
                                     properties:
                                       apiGroup:
-                                        description: APIGroup is the group for the resource
-                                          being referenced. If APIGroup is not specified,
-                                          the specified Kind must be in the core API
-                                          group. For any other third-party types, APIGroup
-                                          is required.
                                         type: string
                                       kind:
-                                        description: Kind is the type of resource being
-                                          referenced
                                         type: string
                                       name:
-                                        description: Name is the name of resource being
-                                          referenced
                                         type: string
                                     required:
                                       - kind
                                       - name
                                     type: object
                                   resources:
-                                    description: 'Resources represents the minimum resources
-                                    the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -426,8 +280,6 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount
-                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -436,46 +288,18 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                        amount of compute resources required. If Requests
-                                        is omitted for a container, it defaults to
-                                        Limits if that is explicitly specified, otherwise
-                                        to an implementation-defined value. More info:
-                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   selector:
-                                    description: A label query over volumes to consider
-                                      for binding.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -487,37 +311,18 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   storageClassName:
-                                    description: 'Name of the StorageClass required
-                                    by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                     type: string
                                   volumeMode:
-                                    description: volumeMode defines what type of volume
-                                      is required by the claim. Value of Filesystem
-                                      is implied when not included in claim spec.
                                     type: string
                                   volumeName:
-                                    description: VolumeName is the binding reference
-                                      to the PersistentVolume backing this claim.
                                     type: string
                                 type: object
                               status:
-                                description: 'Status represents the current information/status
-                                of a persistent volume claim. Read-only. More info:
-                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                 properties:
                                   accessModes:
-                                    description: 'AccessModes contains the actual access
-                                    modes the volume backing the PVC has. More info:
-                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                     items:
                                       type: string
                                     type: array
@@ -528,43 +333,23 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: Represents the actual resources of
-                                      the underlying volume.
                                     type: object
                                   conditions:
-                                    description: Current Condition of persistent volume
-                                      claim. If underlying persistent volume is being
-                                      resized then the Condition will be set to 'ResizeStarted'.
                                     items:
-                                      description: PersistentVolumeClaimCondition contails
-                                        details about state of pvc
                                       properties:
                                         lastProbeTime:
-                                          description: Last time we probed the condition.
                                           format: date-time
                                           type: string
                                         lastTransitionTime:
-                                          description: Last time the condition transitioned
-                                            from one status to another.
                                           format: date-time
                                           type: string
                                         message:
-                                          description: Human-readable message indicating
-                                            details about last transition.
                                           type: string
                                         reason:
-                                          description: Unique, this should be a short,
-                                            machine understandable string that gives
-                                            the reason for condition's last transition.
-                                            If it reports "ResizeStarted" that means
-                                            the underlying persistent volume is being
-                                            resized.
                                           type: string
                                         status:
                                           type: string
                                         type:
-                                          description: PersistentVolumeClaimConditionType
-                                            is a valid value of PersistentVolumeClaimCondition.Type
                                           type: string
                                       required:
                                         - status
@@ -572,50 +357,24 @@ spec:
                                       type: object
                                     type: array
                                   phase:
-                                    description: Phase represents the current phase
-                                      of PersistentVolumeClaim.
                                     type: string
                                 type: object
                             type: object
                           type: array
                         volumeMounts:
-                          description: VolumeMounts is a list of volumes to mount into
-                            the container's filesystem. If a non-empty list is specified,
-                            the original values of the main container in the desired
-                            STS will be replaced.
                           items:
-                            description: VolumeMount describes a mounting of a Volume
-                              within a container.
                             properties:
                               mountPath:
-                                description: Path within the container at which the
-                                  volume should be mounted.  Must not contain ':'.
                                 type: string
                               mountPropagation:
-                                description: mountPropagation determines how mounts
-                                  are propagated from the host to container and the
-                                  other way around. When not set, MountPropagationNone
-                                  is used. This field is beta in 1.10.
                                 type: string
                               name:
-                                description: This must match the Name of a Volume.
                                 type: string
                               readOnly:
-                                description: Mounted read-only if true, read-write otherwise
-                                  (false or unspecified). Defaults to false.
                                 type: boolean
                               subPath:
-                                description: Path within the volume from which the container's
-                                  volume should be mounted. Defaults to "" (volume's
-                                  root).
                                 type: string
                               subPathExpr:
-                                description: Expanded path within the volume from which
-                                  the container's volume should be mounted. Behaves
-                                  similarly to SubPath but environment variable references
-                                  $(VAR_NAME) are expanded using the container's environment.
-                                  Defaults to "" (volume's root). SubPathExpr and SubPath
-                                  are mutually exclusive.
                                 type: string
                             required:
                               - mountPath
@@ -625,46 +384,20 @@ spec:
                       type: object
                   type: object
                 autoScalingPolicy:
-                  description: AutoScalingPolicy defines how BookKeeperCluster will
-                    be scaled up/down with given metrics and threshold
                   properties:
                     behavior:
-                      description: Behavior configures the scaling behavior of the target
-                        in both Up and Down directions (scaleUp and scaleDown fields
-                        respectively). If not set, the default HPAScalingRules for scale
-                        up and scale down are used.
                       properties:
                         scaleDown:
-                          description: scaleDown is scaling policy for scaling Down.
-                            If not set, the default value is to allow to scale down
-                            to minReplicas pods, with a 300 second stabilization window
-                            (i.e., the highest recommendation for the last 300sec is
-                            used).
                           properties:
                             policies:
-                              description: policies is a list of potential scaling polices
-                                which can be used during scaling. At least one policy
-                                must be specified, otherwise the HPAScalingRules will
-                                be discarded as invalid
                               items:
-                                description: HPAScalingPolicy is a single policy which
-                                  must hold true for a specified past interval.
                                 properties:
                                   periodSeconds:
-                                    description: PeriodSeconds specifies the window
-                                      of time for which the policy should hold true.
-                                      PeriodSeconds must be greater than zero and less
-                                      than or equal to 1800 (30 min).
                                     format: int32
                                     type: integer
                                   type:
-                                    description: Type is used to specify the scaling
-                                      policy.
                                     type: string
                                   value:
-                                    description: Value contains the amount of change
-                                      which is permitted by the policy. It must be greater
-                                      than zero
                                     format: int32
                                     type: integer
                                 required:
@@ -674,52 +407,22 @@ spec:
                                 type: object
                               type: array
                             selectPolicy:
-                              description: selectPolicy is used to specify which policy
-                                should be used. If not set, the default value MaxPolicySelect
-                                is used.
                               type: string
                             stabilizationWindowSeconds:
-                              description: 'StabilizationWindowSeconds is the number
-                              of seconds for which past recommendations should be
-                              considered while scaling up or scaling down. StabilizationWindowSeconds
-                              must be greater than or equal to zero and less than
-                              or equal to 3600 (one hour). If not set, use the default
-                              values: - For scale up: 0 (i.e. no stabilization is
-                              done). - For scale down: 300 (i.e. the stabilization
-                              window is 300 seconds long).'
                               format: int32
                               type: integer
                           type: object
                         scaleUp:
-                          description: 'scaleUp is scaling policy for scaling Up. If
-                          not set, the default value is the higher of:   * increase
-                          no more than 4 pods per 60 seconds   * double the number
-                          of pods per 60 seconds No stabilization is used.'
                           properties:
                             policies:
-                              description: policies is a list of potential scaling polices
-                                which can be used during scaling. At least one policy
-                                must be specified, otherwise the HPAScalingRules will
-                                be discarded as invalid
                               items:
-                                description: HPAScalingPolicy is a single policy which
-                                  must hold true for a specified past interval.
                                 properties:
                                   periodSeconds:
-                                    description: PeriodSeconds specifies the window
-                                      of time for which the policy should hold true.
-                                      PeriodSeconds must be greater than zero and less
-                                      than or equal to 1800 (30 min).
                                     format: int32
                                     type: integer
                                   type:
-                                    description: Type is used to specify the scaling
-                                      policy.
                                     type: string
                                   value:
-                                    description: Value contains the amount of change
-                                      which is permitted by the policy. It must be greater
-                                      than zero
                                     format: int32
                                     type: integer
                                 required:
@@ -729,19 +432,8 @@ spec:
                                 type: object
                               type: array
                             selectPolicy:
-                              description: selectPolicy is used to specify which policy
-                                should be used. If not set, the default value MaxPolicySelect
-                                is used.
                               type: string
                             stabilizationWindowSeconds:
-                              description: 'StabilizationWindowSeconds is the number
-                              of seconds for which past recommendations should be
-                              considered while scaling up or scaling down. StabilizationWindowSeconds
-                              must be greater than or equal to zero and less than
-                              or equal to 3600 (one hour). If not set, use the default
-                              values: - For scale up: 0 (i.e. no stabilization is
-                              done). - For scale down: 300 (i.e. the stabilization
-                              window is 300 seconds long).'
                               format: int32
                               type: integer
                           type: object
@@ -750,64 +442,24 @@ spec:
                       format: int32
                       type: integer
                     metrics:
-                      description: 'Metrics contains the specifications for which to
-                      use to calculate the desired replica count (the maximum replica
-                      count across all metrics will be used). More info: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling'
                       items:
-                        description: MetricSpec specifies how to scale based on a single
-                          metric (only `type` and one other matching field should be
-                          set at once).
                         properties:
                           external:
-                            description: external refers to a global metric that is
-                              not associated with any Kubernetes object. It allows autoscaling
-                              based on information coming from components running outside
-                              of cluster (for example length of queue in cloud messaging
-                              service, or QPS from loadbalancer running outside of cluster).
                             properties:
                               metric:
-                                description: metric identifies the target metric by
-                                  name and selector
                                 properties:
                                   name:
-                                    description: name is the name of the given metric
                                     type: string
                                   selector:
-                                    description: selector is the string-encoded form
-                                      of a standard kubernetes label selector for the
-                                      given metric When set, it is passed as an additional
-                                      parameter to the metrics server for more specific
-                                      metrics scoping. When unset, just the metricName
-                                      will be used to gather metrics.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -819,49 +471,28 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                 required:
                                   - name
                                 type: object
                               target:
-                                description: target specifies the target value for the
-                                  given metric
                                 properties:
                                   averageUtilization:
-                                    description: averageUtilization is the target value
-                                      of the average of the resource metric across all
-                                      relevant pods, represented as a percentage of
-                                      the requested value of the resource for the pods.
-                                      Currently only valid for Resource metric source
-                                      type
                                     format: int32
                                     type: integer
                                   averageValue:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: averageValue is the target value of
-                                      the average of the metric across all relevant
-                                      pods (as a quantity)
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type:
-                                    description: type represents whether the metric
-                                      type is Utilization, Value, or AverageValue
                                     type: string
                                   value:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: value is the target value of the metric
-                                      (as a quantity).
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 required:
@@ -872,70 +503,33 @@ spec:
                               - target
                             type: object
                           object:
-                            description: object refers to a metric describing a single
-                              kubernetes object (for example, hits-per-second on an
-                              Ingress object).
                             properties:
                               describedObject:
-                                description: CrossVersionObjectReference contains enough
-                                  information to let you identify the referred resource.
                                 properties:
                                   apiVersion:
-                                    description: API version of the referent
                                     type: string
                                   kind:
-                                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
                                     type: string
                                   name:
-                                    description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                                     type: string
                                 required:
                                   - kind
                                   - name
                                 type: object
                               metric:
-                                description: metric identifies the target metric by
-                                  name and selector
                                 properties:
                                   name:
-                                    description: name is the name of the given metric
                                     type: string
                                   selector:
-                                    description: selector is the string-encoded form
-                                      of a standard kubernetes label selector for the
-                                      given metric When set, it is passed as an additional
-                                      parameter to the metrics server for more specific
-                                      metrics scoping. When unset, just the metricName
-                                      will be used to gather metrics.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -947,49 +541,28 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                 required:
                                   - name
                                 type: object
                               target:
-                                description: target specifies the target value for the
-                                  given metric
                                 properties:
                                   averageUtilization:
-                                    description: averageUtilization is the target value
-                                      of the average of the resource metric across all
-                                      relevant pods, represented as a percentage of
-                                      the requested value of the resource for the pods.
-                                      Currently only valid for Resource metric source
-                                      type
                                     format: int32
                                     type: integer
                                   averageValue:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: averageValue is the target value of
-                                      the average of the metric across all relevant
-                                      pods (as a quantity)
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type:
-                                    description: type represents whether the metric
-                                      type is Utilization, Value, or AverageValue
                                     type: string
                                   value:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: value is the target value of the metric
-                                      (as a quantity).
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 required:
@@ -1001,54 +574,21 @@ spec:
                               - target
                             type: object
                           pods:
-                            description: pods refers to a metric describing each pod
-                              in the current scale target (for example, transactions-processed-per-second).  The
-                              values will be averaged together before being compared
-                              to the target value.
                             properties:
                               metric:
-                                description: metric identifies the target metric by
-                                  name and selector
                                 properties:
                                   name:
-                                    description: name is the name of the given metric
                                     type: string
                                   selector:
-                                    description: selector is the string-encoded form
-                                      of a standard kubernetes label selector for the
-                                      given metric When set, it is passed as an additional
-                                      parameter to the metrics server for more specific
-                                      metrics scoping. When unset, just the metricName
-                                      will be used to gather metrics.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -1060,49 +600,28 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                 required:
                                   - name
                                 type: object
                               target:
-                                description: target specifies the target value for the
-                                  given metric
                                 properties:
                                   averageUtilization:
-                                    description: averageUtilization is the target value
-                                      of the average of the resource metric across all
-                                      relevant pods, represented as a percentage of
-                                      the requested value of the resource for the pods.
-                                      Currently only valid for Resource metric source
-                                      type
                                     format: int32
                                     type: integer
                                   averageValue:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: averageValue is the target value of
-                                      the average of the metric across all relevant
-                                      pods (as a quantity)
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type:
-                                    description: type represents whether the metric
-                                      type is Utilization, Value, or AverageValue
                                     type: string
                                   value:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: value is the target value of the metric
-                                      (as a quantity).
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 required:
@@ -1113,48 +632,26 @@ spec:
                               - target
                             type: object
                           resource:
-                            description: resource refers to a resource metric (such
-                              as those specified in requests and limits) known to Kubernetes
-                              describing each pod in the current scale target (e.g.
-                              CPU or memory). Such metrics are built in to Kubernetes,
-                              and have special scaling options on top of those available
-                              to normal per-pod metrics using the "pods" source.
                             properties:
                               name:
-                                description: name is the name of the resource in question.
                                 type: string
                               target:
-                                description: target specifies the target value for the
-                                  given metric
                                 properties:
                                   averageUtilization:
-                                    description: averageUtilization is the target value
-                                      of the average of the resource metric across all
-                                      relevant pods, represented as a percentage of
-                                      the requested value of the resource for the pods.
-                                      Currently only valid for Resource metric source
-                                      type
                                     format: int32
                                     type: integer
                                   averageValue:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: averageValue is the target value of
-                                      the average of the metric across all relevant
-                                      pods (as a quantity)
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type:
-                                    description: type represents whether the metric
-                                      type is Utilization, Value, or AverageValue
                                     type: string
                                   value:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: value is the target value of the metric
-                                      (as a quantity).
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 required:
@@ -1165,9 +662,6 @@ spec:
                               - target
                             type: object
                           type:
-                            description: type is the type of metric source.  It should
-                              be one of "Object", "Pods" or "Resource", each mapping
-                              to a matching field in the object.
                             type: string
                         required:
                           - type
@@ -1180,92 +674,57 @@ spec:
                     - maxReplicas
                   type: object
                 bkMetadataServiceUri:
-                  description: BkMetadataServiceURI defines the metadata service uri
-                    that bookkeeper is used for loading corresponding metadata driver
-                    and resolving its metadata service location.
                   type: string
                 cleanUpPolicy:
-                  description: CleanUpPolicy defines the behavior when the object is
-                    being deleted
                   type: string
                 config:
-                  description: Config defines configurations for brokers
                   properties:
                     advertisedDomain:
-                      description: AdvertisedDomain defines a root domain of the services
-                        to advertise to the outside world.
+                      type: string
+                    clusterName:
                       type: string
                     custom:
                       additionalProperties:
                         type: string
-                      description: Custom allows to customize broker configurations
-                        directly.
                       type: object
                     function:
-                      description: FunctionConfig defines function worker configurations
                       properties:
                         custom:
                           additionalProperties:
                             type: string
-                          description: Custom allows to custom functions worker's configuration
-                            and will be written to the ConfigMap for `changeConfig`
                           type: object
                         enabled:
-                          description: Enabled defines whether to enable function in
-                            the cluster
                           type: boolean
                         functionRunnerImages:
-                          description: Function runner images
                           properties:
                             go:
-                              description: Image of Go function runner.
                               type: string
                             java:
-                              description: Image of Java function runner.
                               type: string
                             python:
-                              description: Image of Python function runner.
                               type: string
                           type: object
                         labels:
                           additionalProperties:
                             type: string
-                          description: Labels defines custom labels for function pods
                           type: object
                         mesh:
-                          description: Mesh defines configurations used in function
-                            mesh
                           properties:
                             builtinConnectorsRef:
-                              description: BuiltinConnectorsRef defines the reference
-                                to the ConfigMap that contains a list of builtin-connector
-                                definitions
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
                                   type: string
                               type: object
                             functionEnabled:
-                              description: FunctionEnabled defines whether to enable
-                                function APIs
                               type: boolean
                             sinkEnabled:
-                              description: SinkEnabled defines whether to enable sink
-                                APIs
                               type: boolean
                             sourceEnabled:
-                              description: SourceEnabled defines whether to enable source
-                                APIs
                               type: boolean
                             uploadEnabled:
-                              description: UploadEnabled defines whether to enable user
-                                code upload in APIs
                               type: boolean
                           type: object
                         resourceRequirements:
-                          description: ResourceRequirements describes the resource requirements
                           properties:
                             max:
                               additionalProperties:
@@ -1274,8 +733,6 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: Max describes maximum compute resource could
-                                request for each replica
                               type: object
                             min:
                               additionalProperties:
@@ -1284,169 +741,80 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: Min describes minimal compute resource should
-                                request for each replica
                               type: object
                           type: object
                         serviceAccountName:
-                          description: The name of the service account to run functions
-                            and connectors.
                           type: string
                         type:
-                          description: Type defines the type of function worker service
-                            to run functions/sources/sinks Function-mesh worker service
-                            is used if the value of type is FunctionMesh, otherwise
-                            the builtin worker service is used
                           type: string
                       type: object
                     protocolHandlers:
-                      description: ProtocolHandlers defines the configuration of protocol
-                        handlers
                       properties:
                         aop:
-                          description: AoP configurations
                           properties:
                             enabled:
-                              description: Enabled defines whether to enable AoP
                               type: boolean
                             proxyEnabled:
-                              description: Whether to start AMQP proxy.
                               type: boolean
                           type: object
                         kop:
-                          description: KoP defines KoP configurations
                           properties:
                             enabled:
-                              description: Enabled defines whether to enable KoP
                               type: boolean
                             tls:
-                              description: TLS defines the TLS configuration on the
-                                broker.
                               properties:
                                 certSecretName:
-                                  description: CertSecretName defines the name of the
-                                    secret that contains the certificate to use the
-                                    value should be name of the secret that contains
-                                    a valid certificate to use in the proxy
                                   type: string
                                 enabled:
-                                  description: Enabled determines whether to enable
-                                    TLS in proxies TODO move other TLS related fields
-                                    here
                                   type: boolean
                                 passwordSecretRef:
-                                  description: PasswordSecretRef is a reference to a
-                                    key in a Secret resource containing the password
-                                    used to encrypt the keystore.
                                   properties:
                                     key:
-                                      description: The key of the entry in the Secret
-                                        resource's `data` field to be used. Some instances
-                                        of this field may be defaulted, in others it
-                                        may be required.
                                       type: string
                                     name:
-                                      description: 'Name of the resource being referred
-                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                       type: string
                                   required:
                                     - name
                                   type: object
                                 trustCertsEnabled:
-                                  description: TrustCertsEnabled defines whether to
-                                    enable trust store
                                   type: boolean
                               type: object
                           type: object
                       type: object
                     transactionEnabled:
-                      description: TransactionEnabled defines whether transaction support
-                        is enabled in the brokers
                       type: boolean
                   type: object
                 configs:
                   additionalProperties:
                     type: string
-                  description: 'Configs defines custom configurations for brokers Deprecated:
-                  use Config instead'
                   type: object
                 dnsNames:
-                  description: A list of service urls this pulsar broker advertise
                   items:
                     type: string
                   type: array
                 image:
-                  description: Image is the container image used to run pulsar broker
-                    pods. default is apachepulsar/pulsar:latest
                   type: string
                 imagePullPolicy:
-                  description: Image pull policy, one of Always, Never, IfNotPresent,
-                    default to Always.
                   type: string
                 initJobPod:
-                  description: InitJobPod defines the policy for creating a pod for
-                    init job
                   properties:
                     affinity:
-                      description: Affinity specifies the scheduling constraints of
-                        a pod
                       properties:
                         nodeAffinity:
-                          description: Describes node affinity scheduling rules for
-                            the pod.
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node matches the corresponding matchExpressions;
-                                the node(s) with the highest sum are the most preferred.
                               items:
-                                description: An empty preferred scheduling term matches
-                                  all objects with implicit weight 0 (i.e. it's a no-op).
-                                  A null preferred scheduling term matches no objects
-                                  (i.e. is also a no-op).
                                 properties:
                                   preference:
-                                    description: A node selector term, associated with
-                                      the corresponding weight.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
                                         items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: The label key that the selector
-                                                applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -1456,35 +824,13 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
                                         items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: The label key that the selector
-                                                applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -1495,8 +841,6 @@ spec:
                                         type: array
                                     type: object
                                   weight:
-                                    description: Weight associated with matching the
-                                      corresponding nodeSelectorTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -1505,53 +849,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to an update), the system
-                                may or may not try to eventually evict the pod from
-                                its node.
                               properties:
                                 nodeSelectorTerms:
-                                  description: Required. A list of node selector terms.
-                                    The terms are ORed.
                                   items:
-                                    description: A null or empty node selector term
-                                      matches no objects. The requirements of them are
-                                      ANDed. The TopologySelectorTerm type implements
-                                      a subset of the NodeSelectorTerm.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
                                         items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: The label key that the selector
-                                                applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -1561,35 +870,13 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
                                         items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: The label key that the selector
-                                                applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -1605,65 +892,22 @@ spec:
                               type: object
                           type: object
                         podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g.
-                            co-locate this pod in the same node, zone, etc. as some
-                            other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1675,37 +919,18 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -1714,56 +939,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to a pod label update),
-                                the system may or may not try to eventually evict the
-                                pod from its node. When there are multiple elements,
-                                the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
                               items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -1775,29 +962,13 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -1805,65 +976,22 @@ spec:
                               type: array
                           type: object
                         podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules
-                            (e.g. avoid putting this pod in the same node, zone, etc.
-                            as some other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the anti-affinity expressions
-                                specified by this field, but it may choose a node that
-                                violates one or more of the expressions. The node that
-                                is most preferred is the one with the greatest sum of
-                                weights, i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                anti-affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1875,37 +1003,18 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -1914,56 +1023,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified
-                                by this field are not met at scheduling time, the pod
-                                will not be scheduled onto the node. If the anti-affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a pod
-                                label update), the system may or may not try to eventually
-                                evict the pod from its node. When there are multiple
-                                elements, the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
                               items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -1975,29 +1046,13 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -2008,137 +1063,71 @@ spec:
                     annotations:
                       additionalProperties:
                         type: string
-                      description: Annotations specifies the annotations to attach to
-                        pods the operator creates
                       type: object
                     debug:
-                      description: Debug defines a switch enable debug
                       type: boolean
                     initContainers:
-                      description: InitContainers defines init containers of the pod.
-                        A typical use case could be using an init container to download
-                        a remote jar to a local path.
                       items:
-                        description: A single application container that you want to
-                          run within a pod. The Container API from the core group is
-                          not used directly to avoid unneeded fields and reduce the
-                          size of the CRD. New fields could be added as needed.
                         properties:
                           args:
-                            description: Arguments to the entrypoint.
                             items:
                               type: string
                             type: array
                           command:
-                            description: Entrypoint array. Not executed within a shell.
                             items:
                               type: string
                             type: array
                           env:
-                            description: List of environment variables to set in the
-                              container.
                             items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
                               properties:
                                 name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
-                                  description: 'Variable references $(VAR_NAME) are
-                                  expanded using the previous defined environment
-                                  variables in the container and any service environment
-                                  variables. If a variable cannot be resolved, the
-                                  reference in the input string will be unchanged.
-                                  The $(VAR_NAME) syntax can be escaped with a double
-                                  $$, ie: $$(VAR_NAME). Escaped references will never
-                                  be expanded, regardless of whether the variable
-                                  exists or not. Defaults to "".'
                                   type: string
                                 valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
-                                          description: The key to select.
                                           type: string
                                         name:
-                                          description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
                                           type: boolean
                                       required:
                                         - key
                                       type: object
                                     fieldRef:
-                                      description: 'Selects a field of the pod: supports
-                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                      spec.serviceAccountName, status.hostIP, status.podIP,
-                                      status.podIPs.'
                                       properties:
                                         apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
-                                          description: Path of the field to select in
-                                            the specified API version.
                                           type: string
                                       required:
                                         - fieldPath
                                       type: object
                                     resourceFieldRef:
-                                      description: 'Selects a resource of the container:
-                                      only resources limits and requests (limits.cpu,
-                                      limits.memory, limits.ephemeral-storage, requests.cpu,
-                                      requests.memory and requests.ephemeral-storage)
-                                      are currently supported.'
                                       properties:
                                         containerName:
-                                          description: 'Container name: required for
-                                          volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                             - type: integer
                                             - type: string
-                                          description: Specifies the output format of
-                                            the exposed resources, defaults to "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
-                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                         - resource
                                       type: object
                                     secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
                                       properties:
                                         key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
-                                          description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                           type: string
                                         optional:
-                                          description: Specify whether the Secret or
-                                            its key must be defined
                                           type: boolean
                                       required:
                                         - key
@@ -2149,99 +1138,52 @@ spec:
                               type: object
                             type: array
                           envFrom:
-                            description: List of sources to populate environment variables
-                              in the container.
                             items:
-                              description: EnvFromSource represents the source of a
-                                set of ConfigMaps
                               properties:
                                 configMapRef:
-                                  description: The ConfigMap to select from
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap must
-                                        be defined
                                       type: boolean
                                   type: object
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
-                                  description: The Secret to select from
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret must be
-                                        defined
                                       type: boolean
                                   type: object
                               type: object
                             type: array
                           image:
-                            description: Docker image name.
                             type: string
                           imagePullPolicy:
-                            description: Image pull policy.
                             type: string
                           livenessProbe:
-                            description: Periodic probe of container liveness.
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe
-                                  to be considered failed after having succeeded. Defaults
-                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -2249,120 +1191,66 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe
-                                  to be considered successful after having failed. Defaults
-                                  to 1. Must be 1 for liveness and startup. Minimum
-                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           name:
-                            description: Name of the container specified as a DNS_LABEL.
-                              Each container in a pod must have a unique name (DNS_LABEL).
                             type: string
                           readinessProbe:
-                            description: 'Periodic probe of container service readiness.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe
-                                  to be considered failed after having succeeded. Defaults
-                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -2370,70 +1258,43 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe
-                                  to be considered successful after having failed. Defaults
-                                  to 1. Must be 1 for liveness and startup. Minimum
-                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           resources:
-                            description: Compute Resources required by this container.
                             properties:
                               limits:
                                 additionalProperties:
@@ -2442,8 +1303,6 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -2452,61 +1311,30 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                             type: object
                           startupProbe:
-                            description: StartupProbe indicates that the Pod has successfully
-                              initialized.
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe
-                                  to be considered failed after having succeeded. Defaults
-                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -2514,103 +1342,56 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe
-                                  to be considered successful after having failed. Defaults
-                                  to 1. Must be 1 for liveness and startup. Minimum
-                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           volumeMounts:
-                            description: Pod volumes to mount into the container's filesystem.
                             items:
-                              description: VolumeMount describes a mounting of a Volume
-                                within a container.
                               properties:
                                 mountPath:
-                                  description: Path within the container at which the
-                                    volume should be mounted.  Must not contain ':'.
                                   type: string
                                 mountPropagation:
-                                  description: mountPropagation determines how mounts
-                                    are propagated from the host to container and the
-                                    other way around. When not set, MountPropagationNone
-                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
-                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
-                                  description: Mounted read-only if true, read-write
-                                    otherwise (false or unspecified). Defaults to false.
                                   type: boolean
                                 subPath:
-                                  description: Path within the volume from which the
-                                    container's volume should be mounted. Defaults to
-                                    "" (volume's root).
                                   type: string
                                 subPathExpr:
-                                  description: Expanded path within the volume from
-                                    which the container's volume should be mounted.
-                                    Behaves similarly to SubPath but environment variable
-                                    references $(VAR_NAME) are expanded using the container's
-                                    environment. Defaults to "" (volume's root). SubPathExpr
-                                    and SubPath are mutually exclusive.
                                   type: string
                               required:
                                 - mountPath
@@ -2618,15 +1399,12 @@ spec:
                               type: object
                             type: array
                           workingDir:
-                            description: Container's working directory.
                             type: string
                         required:
                           - name
                         type: object
                       type: array
                     jvmOptions:
-                      description: JvmOptions defines the Jvm options passed to the
-                        proxy
                       properties:
                         extraOptions:
                           items:
@@ -2653,19 +1431,12 @@ spec:
                     labels:
                       additionalProperties:
                         type: string
-                      description: Labels specifies the labels to attach to pod the
-                        operator creates for the cluster.
                       type: object
                     nodeSelector:
                       additionalProperties:
                         type: string
-                      description: NodeSelector specifies a map of key-value pairs.
-                        For a pod to be eligible to run on a node, the node must have
-                        each of the indicated key-value pairs as labels.
                       type: object
                     resources:
-                      description: Resources specifies the resource requirements of
-                        a pod to run in the cluster
                       properties:
                         limits:
                           additionalProperties:
@@ -2674,8 +1445,6 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
@@ -2684,15 +1453,9 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
                     secretRefs:
-                      description: SecretRefs defines how to mount required secrets
-                        into containers
                       items:
                         properties:
                           mountPath:
@@ -2705,120 +1468,51 @@ spec:
                         type: object
                       type: array
                     securityContext:
-                      description: 'SecurityContext specifies the security context for
-                      the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
                       properties:
                         fsGroup:
-                          description: "A special supplemental group that applies to
-                          all containers in a pod. Some volume types allow the Kubelet
-                          to change the ownership of that volume to be owned by the
-                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                          bit is set (new files created in the volume will be owned
-                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                          \n If unset, the Kubelet will not modify the ownership and
-                          permissions of any volume."
                           format: int64
                           type: integer
                         fsGroupChangePolicy:
-                          description: 'fsGroupChangePolicy defines behavior of changing
-                          ownership and permission of the volume before being exposed
-                          inside Pod. This field will only apply to volume types which
-                          support fsGroup based ownership(and permissions). It will
-                          have no effect on ephemeral volume types such as: secret,
-                          configmaps and emptydir. Valid values are "OnRootMismatch"
-                          and "Always". If not specified defaults to "Always".'
                           type: string
                         runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence for that container.
                           format: int64
                           type: integer
                         runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in SecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
                           type: boolean
                         runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in SecurityContext.  If set
-                            in both SecurityContext and PodSecurityContext, the value
-                            specified in SecurityContext takes precedence for that container.
                           format: int64
                           type: integer
                         seLinuxOptions:
-                          description: The SELinux context to be applied to all containers.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence
-                            for that container.
                           properties:
                             level:
-                              description: Level is SELinux level label that applies
-                                to the container.
                               type: string
                             role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
                               type: string
                             type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
                               type: string
                             user:
-                              description: User is a SELinux user label that applies
-                                to the container.
                               type: string
                           type: object
                         seccompProfile:
-                          description: The seccomp options to use by the containers
-                            in this pod.
                           properties:
                             localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
                               type: string
                             type:
-                              description: "type indicates which kind of seccomp profile
-                              will be applied. Valid options are: \n Localhost - a
-                              profile defined in a file on the node should be used.
-                              RuntimeDefault - the container runtime default profile
-                              should be used. Unconfined - no profile should be applied."
                               type: string
                           required:
                             - type
                           type: object
                         supplementalGroups:
-                          description: A list of groups applied to the first process
-                            run in each container, in addition to the container's primary
-                            GID.  If unspecified, no groups will be added to any container.
                           items:
                             format: int64
                             type: integer
                           type: array
                         sysctls:
-                          description: Sysctls hold a list of namespaced sysctls used
-                            for the pod. Pods with unsupported sysctls (by the container
-                            runtime) might fail to launch.
                           items:
-                            description: Sysctl defines a kernel parameter to be set
                             properties:
                               name:
-                                description: Name of a property to set
                                 type: string
                               value:
-                                description: Value of a property to set
                                 type: string
                             required:
                               - name
@@ -2826,160 +1520,79 @@ spec:
                             type: object
                           type: array
                         windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options within a container's
-                            SecurityContext will be used. If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
                           properties:
                             gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
                               type: string
                             gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
                               type: string
                             runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
                               type: string
                           type: object
                       type: object
                     serviceAccountName:
-                      description: ServiceAccountName is the name of the ServiceAccount
-                        to use to run pods.
                       type: string
                     sidecars:
-                      description: Sidecars defines sidecar containers running alongside
-                        with the main function container in the pod.
                       items:
-                        description: A single application container that you want to
-                          run within a pod. The Container API from the core group is
-                          not used directly to avoid unneeded fields and reduce the
-                          size of the CRD. New fields could be added as needed.
                         properties:
                           args:
-                            description: Arguments to the entrypoint.
                             items:
                               type: string
                             type: array
                           command:
-                            description: Entrypoint array. Not executed within a shell.
                             items:
                               type: string
                             type: array
                           env:
-                            description: List of environment variables to set in the
-                              container.
                             items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
                               properties:
                                 name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
-                                  description: 'Variable references $(VAR_NAME) are
-                                  expanded using the previous defined environment
-                                  variables in the container and any service environment
-                                  variables. If a variable cannot be resolved, the
-                                  reference in the input string will be unchanged.
-                                  The $(VAR_NAME) syntax can be escaped with a double
-                                  $$, ie: $$(VAR_NAME). Escaped references will never
-                                  be expanded, regardless of whether the variable
-                                  exists or not. Defaults to "".'
                                   type: string
                                 valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
-                                          description: The key to select.
                                           type: string
                                         name:
-                                          description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
                                           type: boolean
                                       required:
                                         - key
                                       type: object
                                     fieldRef:
-                                      description: 'Selects a field of the pod: supports
-                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                      spec.serviceAccountName, status.hostIP, status.podIP,
-                                      status.podIPs.'
                                       properties:
                                         apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
-                                          description: Path of the field to select in
-                                            the specified API version.
                                           type: string
                                       required:
                                         - fieldPath
                                       type: object
                                     resourceFieldRef:
-                                      description: 'Selects a resource of the container:
-                                      only resources limits and requests (limits.cpu,
-                                      limits.memory, limits.ephemeral-storage, requests.cpu,
-                                      requests.memory and requests.ephemeral-storage)
-                                      are currently supported.'
                                       properties:
                                         containerName:
-                                          description: 'Container name: required for
-                                          volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                             - type: integer
                                             - type: string
-                                          description: Specifies the output format of
-                                            the exposed resources, defaults to "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
-                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                         - resource
                                       type: object
                                     secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
                                       properties:
                                         key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
-                                          description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                           type: string
                                         optional:
-                                          description: Specify whether the Secret or
-                                            its key must be defined
                                           type: boolean
                                       required:
                                         - key
@@ -2990,99 +1603,52 @@ spec:
                               type: object
                             type: array
                           envFrom:
-                            description: List of sources to populate environment variables
-                              in the container.
                             items:
-                              description: EnvFromSource represents the source of a
-                                set of ConfigMaps
                               properties:
                                 configMapRef:
-                                  description: The ConfigMap to select from
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap must
-                                        be defined
                                       type: boolean
                                   type: object
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
-                                  description: The Secret to select from
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret must be
-                                        defined
                                       type: boolean
                                   type: object
                               type: object
                             type: array
                           image:
-                            description: Docker image name.
                             type: string
                           imagePullPolicy:
-                            description: Image pull policy.
                             type: string
                           livenessProbe:
-                            description: Periodic probe of container liveness.
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe
-                                  to be considered failed after having succeeded. Defaults
-                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -3090,120 +1656,66 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe
-                                  to be considered successful after having failed. Defaults
-                                  to 1. Must be 1 for liveness and startup. Minimum
-                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           name:
-                            description: Name of the container specified as a DNS_LABEL.
-                              Each container in a pod must have a unique name (DNS_LABEL).
                             type: string
                           readinessProbe:
-                            description: 'Periodic probe of container service readiness.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe
-                                  to be considered failed after having succeeded. Defaults
-                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -3211,70 +1723,43 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe
-                                  to be considered successful after having failed. Defaults
-                                  to 1. Must be 1 for liveness and startup. Minimum
-                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           resources:
-                            description: Compute Resources required by this container.
                             properties:
                               limits:
                                 additionalProperties:
@@ -3283,8 +1768,6 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -3293,61 +1776,30 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                             type: object
                           startupProbe:
-                            description: StartupProbe indicates that the Pod has successfully
-                              initialized.
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe
-                                  to be considered failed after having succeeded. Defaults
-                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -3355,103 +1807,56 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe
-                                  to be considered successful after having failed. Defaults
-                                  to 1. Must be 1 for liveness and startup. Minimum
-                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           volumeMounts:
-                            description: Pod volumes to mount into the container's filesystem.
                             items:
-                              description: VolumeMount describes a mounting of a Volume
-                                within a container.
                               properties:
                                 mountPath:
-                                  description: Path within the container at which the
-                                    volume should be mounted.  Must not contain ':'.
                                   type: string
                                 mountPropagation:
-                                  description: mountPropagation determines how mounts
-                                    are propagated from the host to container and the
-                                    other way around. When not set, MountPropagationNone
-                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
-                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
-                                  description: Mounted read-only if true, read-write
-                                    otherwise (false or unspecified). Defaults to false.
                                   type: boolean
                                 subPath:
-                                  description: Path within the volume from which the
-                                    container's volume should be mounted. Defaults to
-                                    "" (volume's root).
                                   type: string
                                 subPathExpr:
-                                  description: Expanded path within the volume from
-                                    which the container's volume should be mounted.
-                                    Behaves similarly to SubPath but environment variable
-                                    references $(VAR_NAME) are expanded using the container's
-                                    environment. Defaults to "" (volume's root). SubPathExpr
-                                    and SubPath are mutually exclusive.
                                   type: string
                               required:
                                 - mountPath
@@ -3459,158 +1864,81 @@ spec:
                               type: object
                             type: array
                           workingDir:
-                            description: Container's working directory.
                             type: string
                         required:
                           - name
                         type: object
                       type: array
                     terminationGracePeriodSeconds:
-                      description: TerminationGracePeriodSeconds is the amount of time
-                        that kubernetes will give for a pod before terminating it.
                       format: int64
                       type: integer
                     tolerations:
-                      description: Tolerations specifies the tolerations of a Pod
                       items:
-                        description: The pod this Toleration is attached to tolerates
-                          any taint that matches the triple <key,value,effect> using
-                          the matching operator <operator>.
                         properties:
                           effect:
-                            description: Effect indicates the taint effect to match.
-                              Empty means match all taint effects. When specified, allowed
-                              values are NoSchedule, PreferNoSchedule and NoExecute.
                             type: string
                           key:
-                            description: Key is the taint key that the toleration applies
-                              to. Empty means match all taint keys. If the key is empty,
-                              operator must be Exists; this combination means to match
-                              all values and all keys.
                             type: string
                           operator:
-                            description: Operator represents a key's relationship to
-                              the value. Valid operators are Exists and Equal. Defaults
-                              to Equal. Exists is equivalent to wildcard for value,
-                              so that a pod can tolerate all taints of a particular
-                              category.
                             type: string
                           tolerationSeconds:
-                            description: TolerationSeconds represents the period of
-                              time the toleration (which must be of effect NoExecute,
-                              otherwise this field is ignored) tolerates the taint.
-                              By default, it is not set, which means tolerate the taint
-                              forever (do not evict). Zero and negative values will
-                              be treated as 0 (evict immediately) by the system.
                             format: int64
                             type: integer
                           value:
-                            description: Value is the taint value the toleration matches
-                              to. If the operator is Exists, the value should be empty,
-                              otherwise just a regular string.
                             type: string
                         type: object
                       type: array
                     vars:
-                      description: Vars specifies the environment variables of a Pod
                       items:
-                        description: EnvVar represents an environment variable present
-                          in a Container.
                         properties:
                           name:
-                            description: Name of the environment variable. Must be a
-                              C_IDENTIFIER.
                             type: string
                           value:
-                            description: 'Variable references $(VAR_NAME) are expanded
-                            using the previous defined environment variables in the
-                            container and any service environment variables. If a
-                            variable cannot be resolved, the reference in the input
-                            string will be unchanged. The $(VAR_NAME) syntax can be
-                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                            will never be expanded, regardless of whether the variable
-                            exists or not. Defaults to "".'
                             type: string
                           valueFrom:
-                            description: Source for the environment variable's value.
-                              Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
-                                description: Selects a key of a ConfigMap.
                                 properties:
                                   key:
-                                    description: The key to select.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or its
-                                      key must be defined
                                     type: boolean
                                 required:
                                   - key
                                 type: object
                               fieldRef:
-                                description: 'Selects a field of the pod: supports metadata.name,
-                                metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                spec.serviceAccountName, status.hostIP, status.podIP,
-                                status.podIPs.'
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
                                     type: string
                                 required:
                                   - fieldPath
                                 type: object
                               resourceFieldRef:
-                                description: 'Selects a resource of the container: only
-                                resources limits and requests (limits.cpu, limits.memory,
-                                limits.ephemeral-storage, requests.cpu, requests.memory
-                                and requests.ephemeral-storage) are currently supported.'
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes,
-                                    optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
-                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                   - resource
                                 type: object
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its key
-                                      must be defined
                                     type: boolean
                                 required:
                                   - key
@@ -3621,66 +1949,22 @@ spec:
                         type: object
                       type: array
                     volumes:
-                      description: Volumes defines extra volumes of the pod.
                       items:
-                        description: Volume represents a named volume in a pod that
-                          may be accessed by any container in the pod. The Volume API
-                          from the core group is not used directly to avoid unneeded
-                          fields defined in `VolumeSource` and reduce the size of the
-                          CRD. New fields in VolumeSource could be added as needed.
                         properties:
                           configMap:
-                            description: ConfigMap represents a configMap that should
-                              populate this volume
                             properties:
                               defaultMode:
-                                description: 'Optional: mode bits used to set permissions
-                                on created files by default. Must be an octal value
-                                between 0000 and 0777 or a decimal value between 0
-                                and 511. YAML accepts both octal and decimal values,
-                                JSON requires decimal values for mode bits. Defaults
-                                to 0644. Directories within the path are not affected
-                                by this setting. This might be in conflict with other
-                                options that affect the file mode, like fsGroup, and
-                                the result can be other mode bits set.'
                                 format: int32
                                 type: integer
                               items:
-                                description: If unspecified, each key-value pair in
-                                  the Data field of the referenced ConfigMap will be
-                                  projected into the volume as a file whose name is
-                                  the key and content is the value. If specified, the
-                                  listed keys will be projected into the specified paths,
-                                  and unlisted keys will not be present. If a key is
-                                  specified which is not present in the ConfigMap, the
-                                  volume setup will error unless it is marked optional.
-                                  Paths must be relative and may not contain the '..'
-                                  path or start with '..'.
                                 items:
-                                  description: Maps a string key to a path within a
-                                    volume.
                                   properties:
                                     key:
-                                      description: The key to project.
                                       type: string
                                     mode:
-                                      description: 'Optional: mode bits used to set
-                                      permissions on this file. Must be an octal value
-                                      between 0000 and 0777 or a decimal value between
-                                      0 and 511. YAML accepts both octal and decimal
-                                      values, JSON requires decimal values for mode
-                                      bits. If not specified, the volume defaultMode
-                                      will be used. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
                                       format: int32
                                       type: integer
                                     path:
-                                      description: The relative path of the file to
-                                        map the key to. May not be an absolute path.
-                                        May not contain the path element '..'. May not
-                                        start with the string '..'.
                                       type: string
                                   required:
                                     - key
@@ -3688,70 +1972,26 @@ spec:
                                   type: object
                                 type: array
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
-                                description: Specify whether the ConfigMap or its keys
-                                  must be defined
                                 type: boolean
                             type: object
                           name:
-                            description: 'Volume''s name. Must be a DNS_LABEL and unique
-                            within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
                           secret:
-                            description: Secret represents a secret that should populate
-                              this volume.
                             properties:
                               defaultMode:
-                                description: 'Optional: mode bits used to set permissions
-                                on created files by default. Must be an octal value
-                                between 0000 and 0777 or a decimal value between 0
-                                and 511. YAML accepts both octal and decimal values,
-                                JSON requires decimal values for mode bits. Defaults
-                                to 0644. Directories within the path are not affected
-                                by this setting. This might be in conflict with other
-                                options that affect the file mode, like fsGroup, and
-                                the result can be other mode bits set.'
                                 format: int32
                                 type: integer
                               items:
-                                description: If unspecified, each key-value pair in
-                                  the Data field of the referenced Secret will be projected
-                                  into the volume as a file whose name is the key and
-                                  content is the value. If specified, the listed keys
-                                  will be projected into the specified paths, and unlisted
-                                  keys will not be present. If a key is specified which
-                                  is not present in the Secret, the volume setup will
-                                  error unless it is marked optional. Paths must be
-                                  relative and may not contain the '..' path or start
-                                  with '..'.
                                 items:
-                                  description: Maps a string key to a path within a
-                                    volume.
                                   properties:
                                     key:
-                                      description: The key to project.
                                       type: string
                                     mode:
-                                      description: 'Optional: mode bits used to set
-                                      permissions on this file. Must be an octal value
-                                      between 0000 and 0777 or a decimal value between
-                                      0 and 511. YAML accepts both octal and decimal
-                                      values, JSON requires decimal values for mode
-                                      bits. If not specified, the volume defaultMode
-                                      will be used. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
                                       format: int32
                                       type: integer
                                     path:
-                                      description: The relative path of the file to
-                                        map the key to. May not be an absolute path.
-                                        May not contain the path element '..'. May not
-                                        start with the string '..'.
                                       type: string
                                   required:
                                     - key
@@ -3759,12 +1999,8 @@ spec:
                                   type: object
                                 type: array
                               optional:
-                                description: Specify whether the Secret or its keys
-                                  must be defined
                                 type: boolean
                               secretName:
-                                description: 'Name of the secret in the pod''s namespace
-                                to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                 type: string
                             type: object
                         required:
@@ -3772,31 +2008,23 @@ spec:
                         type: object
                       type: array
                   type: object
+                initialized:
+                  type: boolean
                 interceptors:
-                  description: Interceptors defines a list of interceptors to enable
                   items:
                     properties:
                       configs:
                         additionalProperties:
                           type: string
-                        description: Configs defines configs for the interceptor
                         type: object
                       mountedConfigs:
-                        description: MountedConfigs defines configs whose value should
-                          be put in a dedicated file
                         items:
-                          description: The operator generates config files based on
-                            the spec automatically
                           properties:
                             configName:
-                              description: ConfigName defines the name of the config
                               type: string
                             fileName:
-                              description: FileName defines the name of the file used
-                                to store the value. Defaults to the ConfigName.
                               type: string
                             value:
-                              description: Value defines the value of the config
                               type: string
                           required:
                             - configName
@@ -3804,49 +2032,32 @@ spec:
                           type: object
                         type: array
                       name:
-                        description: Name defines the name of the interceptor
                         type: string
                     required:
                       - name
                     type: object
                   type: array
                 istio:
-                  description: Istio defines the configurations for istio
                   properties:
                     enabled:
-                      description: Enabled defines whether to enable Istio
                       type: boolean
                     gateway:
-                      description: Gateway defines the gateway configuration The operator
-                        could either create a gateway automatically or use an existing
-                        one
                       properties:
                         create:
-                          description: Create defines whether to create a gateway
                           type: boolean
                         gateways:
-                          description: Gateways defines a list of existing gateways
                           items:
                             type: string
                           type: array
                         selector:
                           additionalProperties:
                             type: string
-                          description: Selector defines the selector for the gateway
-                            to create
                           type: object
                         tls:
                           properties:
                             certSecretName:
-                              description: CertSecretName defines the name of the secret
-                                that contains the certificate to use. The value should
-                                be name of the secret in the gateway workload namespace.
-                                Required in SIMPLE mode; not used in PASSTHROUGH mode.
                               type: string
                             mode:
-                              description: 'Optional: Indicates whether connections
-                              to this port should be secured using TLS. The value
-                              of this field determines how TLS is enforced.'
                               type: string
                           type: object
                       type: object
@@ -3854,72 +2065,26 @@ spec:
                 labels:
                   additionalProperties:
                     type: string
-                  description: Labels specifies the labels to attach to the stateful
-                    set created by operator for pulsar broker
                   type: object
                 pod:
-                  description: Pod defines the policy for creating a broker pod
                   properties:
                     affinity:
-                      description: Affinity specifies the scheduling constraints of
-                        a pod
                       properties:
                         nodeAffinity:
-                          description: Describes node affinity scheduling rules for
-                            the pod.
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node matches the corresponding matchExpressions;
-                                the node(s) with the highest sum are the most preferred.
                               items:
-                                description: An empty preferred scheduling term matches
-                                  all objects with implicit weight 0 (i.e. it's a no-op).
-                                  A null preferred scheduling term matches no objects
-                                  (i.e. is also a no-op).
                                 properties:
                                   preference:
-                                    description: A node selector term, associated with
-                                      the corresponding weight.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
                                         items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: The label key that the selector
-                                                applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -3929,35 +2094,13 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
                                         items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: The label key that the selector
-                                                applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -3968,8 +2111,6 @@ spec:
                                         type: array
                                     type: object
                                   weight:
-                                    description: Weight associated with matching the
-                                      corresponding nodeSelectorTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -3978,53 +2119,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to an update), the system
-                                may or may not try to eventually evict the pod from
-                                its node.
                               properties:
                                 nodeSelectorTerms:
-                                  description: Required. A list of node selector terms.
-                                    The terms are ORed.
                                   items:
-                                    description: A null or empty node selector term
-                                      matches no objects. The requirements of them are
-                                      ANDed. The TopologySelectorTerm type implements
-                                      a subset of the NodeSelectorTerm.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
                                         items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: The label key that the selector
-                                                applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -4034,35 +2140,13 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
                                         items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: The label key that the selector
-                                                applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -4078,65 +2162,22 @@ spec:
                               type: object
                           type: object
                         podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g.
-                            co-locate this pod in the same node, zone, etc. as some
-                            other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -4148,37 +2189,18 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -4187,56 +2209,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to a pod label update),
-                                the system may or may not try to eventually evict the
-                                pod from its node. When there are multiple elements,
-                                the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
                               items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -4248,29 +2232,13 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -4278,65 +2246,22 @@ spec:
                               type: array
                           type: object
                         podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules
-                            (e.g. avoid putting this pod in the same node, zone, etc.
-                            as some other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the anti-affinity expressions
-                                specified by this field, but it may choose a node that
-                                violates one or more of the expressions. The node that
-                                is most preferred is the one with the greatest sum of
-                                weights, i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                anti-affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -4348,37 +2273,18 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -4387,56 +2293,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified
-                                by this field are not met at scheduling time, the pod
-                                will not be scheduled onto the node. If the anti-affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a pod
-                                label update), the system may or may not try to eventually
-                                evict the pod from its node. When there are multiple
-                                elements, the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
                               items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -4448,29 +2316,13 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -4481,137 +2333,71 @@ spec:
                     annotations:
                       additionalProperties:
                         type: string
-                      description: Annotations specifies the annotations to attach to
-                        pods the operator creates
                       type: object
                     debug:
-                      description: Debug defines a switch enable debug
                       type: boolean
                     initContainers:
-                      description: InitContainers defines init containers of the pod.
-                        A typical use case could be using an init container to download
-                        a remote jar to a local path.
                       items:
-                        description: A single application container that you want to
-                          run within a pod. The Container API from the core group is
-                          not used directly to avoid unneeded fields and reduce the
-                          size of the CRD. New fields could be added as needed.
                         properties:
                           args:
-                            description: Arguments to the entrypoint.
                             items:
                               type: string
                             type: array
                           command:
-                            description: Entrypoint array. Not executed within a shell.
                             items:
                               type: string
                             type: array
                           env:
-                            description: List of environment variables to set in the
-                              container.
                             items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
                               properties:
                                 name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
-                                  description: 'Variable references $(VAR_NAME) are
-                                  expanded using the previous defined environment
-                                  variables in the container and any service environment
-                                  variables. If a variable cannot be resolved, the
-                                  reference in the input string will be unchanged.
-                                  The $(VAR_NAME) syntax can be escaped with a double
-                                  $$, ie: $$(VAR_NAME). Escaped references will never
-                                  be expanded, regardless of whether the variable
-                                  exists or not. Defaults to "".'
                                   type: string
                                 valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
-                                          description: The key to select.
                                           type: string
                                         name:
-                                          description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
                                           type: boolean
                                       required:
                                         - key
                                       type: object
                                     fieldRef:
-                                      description: 'Selects a field of the pod: supports
-                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                      spec.serviceAccountName, status.hostIP, status.podIP,
-                                      status.podIPs.'
                                       properties:
                                         apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
-                                          description: Path of the field to select in
-                                            the specified API version.
                                           type: string
                                       required:
                                         - fieldPath
                                       type: object
                                     resourceFieldRef:
-                                      description: 'Selects a resource of the container:
-                                      only resources limits and requests (limits.cpu,
-                                      limits.memory, limits.ephemeral-storage, requests.cpu,
-                                      requests.memory and requests.ephemeral-storage)
-                                      are currently supported.'
                                       properties:
                                         containerName:
-                                          description: 'Container name: required for
-                                          volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                             - type: integer
                                             - type: string
-                                          description: Specifies the output format of
-                                            the exposed resources, defaults to "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
-                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                         - resource
                                       type: object
                                     secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
                                       properties:
                                         key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
-                                          description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                           type: string
                                         optional:
-                                          description: Specify whether the Secret or
-                                            its key must be defined
                                           type: boolean
                                       required:
                                         - key
@@ -4622,99 +2408,52 @@ spec:
                               type: object
                             type: array
                           envFrom:
-                            description: List of sources to populate environment variables
-                              in the container.
                             items:
-                              description: EnvFromSource represents the source of a
-                                set of ConfigMaps
                               properties:
                                 configMapRef:
-                                  description: The ConfigMap to select from
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap must
-                                        be defined
                                       type: boolean
                                   type: object
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
-                                  description: The Secret to select from
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret must be
-                                        defined
                                       type: boolean
                                   type: object
                               type: object
                             type: array
                           image:
-                            description: Docker image name.
                             type: string
                           imagePullPolicy:
-                            description: Image pull policy.
                             type: string
                           livenessProbe:
-                            description: Periodic probe of container liveness.
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe
-                                  to be considered failed after having succeeded. Defaults
-                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -4722,120 +2461,66 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe
-                                  to be considered successful after having failed. Defaults
-                                  to 1. Must be 1 for liveness and startup. Minimum
-                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           name:
-                            description: Name of the container specified as a DNS_LABEL.
-                              Each container in a pod must have a unique name (DNS_LABEL).
                             type: string
                           readinessProbe:
-                            description: 'Periodic probe of container service readiness.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe
-                                  to be considered failed after having succeeded. Defaults
-                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -4843,70 +2528,43 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe
-                                  to be considered successful after having failed. Defaults
-                                  to 1. Must be 1 for liveness and startup. Minimum
-                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           resources:
-                            description: Compute Resources required by this container.
                             properties:
                               limits:
                                 additionalProperties:
@@ -4915,8 +2573,6 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -4925,61 +2581,30 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                             type: object
                           startupProbe:
-                            description: StartupProbe indicates that the Pod has successfully
-                              initialized.
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe
-                                  to be considered failed after having succeeded. Defaults
-                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -4987,103 +2612,56 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe
-                                  to be considered successful after having failed. Defaults
-                                  to 1. Must be 1 for liveness and startup. Minimum
-                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           volumeMounts:
-                            description: Pod volumes to mount into the container's filesystem.
                             items:
-                              description: VolumeMount describes a mounting of a Volume
-                                within a container.
                               properties:
                                 mountPath:
-                                  description: Path within the container at which the
-                                    volume should be mounted.  Must not contain ':'.
                                   type: string
                                 mountPropagation:
-                                  description: mountPropagation determines how mounts
-                                    are propagated from the host to container and the
-                                    other way around. When not set, MountPropagationNone
-                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
-                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
-                                  description: Mounted read-only if true, read-write
-                                    otherwise (false or unspecified). Defaults to false.
                                   type: boolean
                                 subPath:
-                                  description: Path within the volume from which the
-                                    container's volume should be mounted. Defaults to
-                                    "" (volume's root).
                                   type: string
                                 subPathExpr:
-                                  description: Expanded path within the volume from
-                                    which the container's volume should be mounted.
-                                    Behaves similarly to SubPath but environment variable
-                                    references $(VAR_NAME) are expanded using the container's
-                                    environment. Defaults to "" (volume's root). SubPathExpr
-                                    and SubPath are mutually exclusive.
                                   type: string
                               required:
                                 - mountPath
@@ -5091,15 +2669,12 @@ spec:
                               type: object
                             type: array
                           workingDir:
-                            description: Container's working directory.
                             type: string
                         required:
                           - name
                         type: object
                       type: array
                     jvmOptions:
-                      description: JvmOptions defines the Jvm options passed to the
-                        proxy
                       properties:
                         extraOptions:
                           items:
@@ -5126,19 +2701,12 @@ spec:
                     labels:
                       additionalProperties:
                         type: string
-                      description: Labels specifies the labels to attach to pod the
-                        operator creates for the cluster.
                       type: object
                     nodeSelector:
                       additionalProperties:
                         type: string
-                      description: NodeSelector specifies a map of key-value pairs.
-                        For a pod to be eligible to run on a node, the node must have
-                        each of the indicated key-value pairs as labels.
                       type: object
                     resources:
-                      description: Resources specifies the resource requirements of
-                        a pod to run in the cluster
                       properties:
                         limits:
                           additionalProperties:
@@ -5147,8 +2715,6 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
@@ -5157,15 +2723,9 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
                     secretRefs:
-                      description: SecretRefs defines how to mount required secrets
-                        into containers
                       items:
                         properties:
                           mountPath:
@@ -5178,120 +2738,51 @@ spec:
                         type: object
                       type: array
                     securityContext:
-                      description: 'SecurityContext specifies the security context for
-                      the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
                       properties:
                         fsGroup:
-                          description: "A special supplemental group that applies to
-                          all containers in a pod. Some volume types allow the Kubelet
-                          to change the ownership of that volume to be owned by the
-                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                          bit is set (new files created in the volume will be owned
-                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                          \n If unset, the Kubelet will not modify the ownership and
-                          permissions of any volume."
                           format: int64
                           type: integer
                         fsGroupChangePolicy:
-                          description: 'fsGroupChangePolicy defines behavior of changing
-                          ownership and permission of the volume before being exposed
-                          inside Pod. This field will only apply to volume types which
-                          support fsGroup based ownership(and permissions). It will
-                          have no effect on ephemeral volume types such as: secret,
-                          configmaps and emptydir. Valid values are "OnRootMismatch"
-                          and "Always". If not specified defaults to "Always".'
                           type: string
                         runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence for that container.
                           format: int64
                           type: integer
                         runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in SecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
                           type: boolean
                         runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in SecurityContext.  If set
-                            in both SecurityContext and PodSecurityContext, the value
-                            specified in SecurityContext takes precedence for that container.
                           format: int64
                           type: integer
                         seLinuxOptions:
-                          description: The SELinux context to be applied to all containers.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence
-                            for that container.
                           properties:
                             level:
-                              description: Level is SELinux level label that applies
-                                to the container.
                               type: string
                             role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
                               type: string
                             type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
                               type: string
                             user:
-                              description: User is a SELinux user label that applies
-                                to the container.
                               type: string
                           type: object
                         seccompProfile:
-                          description: The seccomp options to use by the containers
-                            in this pod.
                           properties:
                             localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
                               type: string
                             type:
-                              description: "type indicates which kind of seccomp profile
-                              will be applied. Valid options are: \n Localhost - a
-                              profile defined in a file on the node should be used.
-                              RuntimeDefault - the container runtime default profile
-                              should be used. Unconfined - no profile should be applied."
                               type: string
                           required:
                             - type
                           type: object
                         supplementalGroups:
-                          description: A list of groups applied to the first process
-                            run in each container, in addition to the container's primary
-                            GID.  If unspecified, no groups will be added to any container.
                           items:
                             format: int64
                             type: integer
                           type: array
                         sysctls:
-                          description: Sysctls hold a list of namespaced sysctls used
-                            for the pod. Pods with unsupported sysctls (by the container
-                            runtime) might fail to launch.
                           items:
-                            description: Sysctl defines a kernel parameter to be set
                             properties:
                               name:
-                                description: Name of a property to set
                                 type: string
                               value:
-                                description: Value of a property to set
                                 type: string
                             required:
                               - name
@@ -5299,160 +2790,79 @@ spec:
                             type: object
                           type: array
                         windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options within a container's
-                            SecurityContext will be used. If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
                           properties:
                             gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
                               type: string
                             gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
                               type: string
                             runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
                               type: string
                           type: object
                       type: object
                     serviceAccountName:
-                      description: ServiceAccountName is the name of the ServiceAccount
-                        to use to run pods.
                       type: string
                     sidecars:
-                      description: Sidecars defines sidecar containers running alongside
-                        with the main function container in the pod.
                       items:
-                        description: A single application container that you want to
-                          run within a pod. The Container API from the core group is
-                          not used directly to avoid unneeded fields and reduce the
-                          size of the CRD. New fields could be added as needed.
                         properties:
                           args:
-                            description: Arguments to the entrypoint.
                             items:
                               type: string
                             type: array
                           command:
-                            description: Entrypoint array. Not executed within a shell.
                             items:
                               type: string
                             type: array
                           env:
-                            description: List of environment variables to set in the
-                              container.
                             items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
                               properties:
                                 name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
-                                  description: 'Variable references $(VAR_NAME) are
-                                  expanded using the previous defined environment
-                                  variables in the container and any service environment
-                                  variables. If a variable cannot be resolved, the
-                                  reference in the input string will be unchanged.
-                                  The $(VAR_NAME) syntax can be escaped with a double
-                                  $$, ie: $$(VAR_NAME). Escaped references will never
-                                  be expanded, regardless of whether the variable
-                                  exists or not. Defaults to "".'
                                   type: string
                                 valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
-                                          description: The key to select.
                                           type: string
                                         name:
-                                          description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
                                           type: boolean
                                       required:
                                         - key
                                       type: object
                                     fieldRef:
-                                      description: 'Selects a field of the pod: supports
-                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                      spec.serviceAccountName, status.hostIP, status.podIP,
-                                      status.podIPs.'
                                       properties:
                                         apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
-                                          description: Path of the field to select in
-                                            the specified API version.
                                           type: string
                                       required:
                                         - fieldPath
                                       type: object
                                     resourceFieldRef:
-                                      description: 'Selects a resource of the container:
-                                      only resources limits and requests (limits.cpu,
-                                      limits.memory, limits.ephemeral-storage, requests.cpu,
-                                      requests.memory and requests.ephemeral-storage)
-                                      are currently supported.'
                                       properties:
                                         containerName:
-                                          description: 'Container name: required for
-                                          volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                             - type: integer
                                             - type: string
-                                          description: Specifies the output format of
-                                            the exposed resources, defaults to "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
-                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                         - resource
                                       type: object
                                     secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
                                       properties:
                                         key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
-                                          description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                           type: string
                                         optional:
-                                          description: Specify whether the Secret or
-                                            its key must be defined
                                           type: boolean
                                       required:
                                         - key
@@ -5463,99 +2873,52 @@ spec:
                               type: object
                             type: array
                           envFrom:
-                            description: List of sources to populate environment variables
-                              in the container.
                             items:
-                              description: EnvFromSource represents the source of a
-                                set of ConfigMaps
                               properties:
                                 configMapRef:
-                                  description: The ConfigMap to select from
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap must
-                                        be defined
                                       type: boolean
                                   type: object
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
-                                  description: The Secret to select from
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret must be
-                                        defined
                                       type: boolean
                                   type: object
                               type: object
                             type: array
                           image:
-                            description: Docker image name.
                             type: string
                           imagePullPolicy:
-                            description: Image pull policy.
                             type: string
                           livenessProbe:
-                            description: Periodic probe of container liveness.
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe
-                                  to be considered failed after having succeeded. Defaults
-                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -5563,120 +2926,66 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe
-                                  to be considered successful after having failed. Defaults
-                                  to 1. Must be 1 for liveness and startup. Minimum
-                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           name:
-                            description: Name of the container specified as a DNS_LABEL.
-                              Each container in a pod must have a unique name (DNS_LABEL).
                             type: string
                           readinessProbe:
-                            description: 'Periodic probe of container service readiness.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe
-                                  to be considered failed after having succeeded. Defaults
-                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -5684,70 +2993,43 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe
-                                  to be considered successful after having failed. Defaults
-                                  to 1. Must be 1 for liveness and startup. Minimum
-                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           resources:
-                            description: Compute Resources required by this container.
                             properties:
                               limits:
                                 additionalProperties:
@@ -5756,8 +3038,6 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -5766,61 +3046,30 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                             type: object
                           startupProbe:
-                            description: StartupProbe indicates that the Pod has successfully
-                              initialized.
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe
-                                  to be considered failed after having succeeded. Defaults
-                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -5828,103 +3077,56 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe
-                                  to be considered successful after having failed. Defaults
-                                  to 1. Must be 1 for liveness and startup. Minimum
-                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           volumeMounts:
-                            description: Pod volumes to mount into the container's filesystem.
                             items:
-                              description: VolumeMount describes a mounting of a Volume
-                                within a container.
                               properties:
                                 mountPath:
-                                  description: Path within the container at which the
-                                    volume should be mounted.  Must not contain ':'.
                                   type: string
                                 mountPropagation:
-                                  description: mountPropagation determines how mounts
-                                    are propagated from the host to container and the
-                                    other way around. When not set, MountPropagationNone
-                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
-                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
-                                  description: Mounted read-only if true, read-write
-                                    otherwise (false or unspecified). Defaults to false.
                                   type: boolean
                                 subPath:
-                                  description: Path within the volume from which the
-                                    container's volume should be mounted. Defaults to
-                                    "" (volume's root).
                                   type: string
                                 subPathExpr:
-                                  description: Expanded path within the volume from
-                                    which the container's volume should be mounted.
-                                    Behaves similarly to SubPath but environment variable
-                                    references $(VAR_NAME) are expanded using the container's
-                                    environment. Defaults to "" (volume's root). SubPathExpr
-                                    and SubPath are mutually exclusive.
                                   type: string
                               required:
                                 - mountPath
@@ -5932,158 +3134,81 @@ spec:
                               type: object
                             type: array
                           workingDir:
-                            description: Container's working directory.
                             type: string
                         required:
                           - name
                         type: object
                       type: array
                     terminationGracePeriodSeconds:
-                      description: TerminationGracePeriodSeconds is the amount of time
-                        that kubernetes will give for a pod before terminating it.
                       format: int64
                       type: integer
                     tolerations:
-                      description: Tolerations specifies the tolerations of a Pod
                       items:
-                        description: The pod this Toleration is attached to tolerates
-                          any taint that matches the triple <key,value,effect> using
-                          the matching operator <operator>.
                         properties:
                           effect:
-                            description: Effect indicates the taint effect to match.
-                              Empty means match all taint effects. When specified, allowed
-                              values are NoSchedule, PreferNoSchedule and NoExecute.
                             type: string
                           key:
-                            description: Key is the taint key that the toleration applies
-                              to. Empty means match all taint keys. If the key is empty,
-                              operator must be Exists; this combination means to match
-                              all values and all keys.
                             type: string
                           operator:
-                            description: Operator represents a key's relationship to
-                              the value. Valid operators are Exists and Equal. Defaults
-                              to Equal. Exists is equivalent to wildcard for value,
-                              so that a pod can tolerate all taints of a particular
-                              category.
                             type: string
                           tolerationSeconds:
-                            description: TolerationSeconds represents the period of
-                              time the toleration (which must be of effect NoExecute,
-                              otherwise this field is ignored) tolerates the taint.
-                              By default, it is not set, which means tolerate the taint
-                              forever (do not evict). Zero and negative values will
-                              be treated as 0 (evict immediately) by the system.
                             format: int64
                             type: integer
                           value:
-                            description: Value is the taint value the toleration matches
-                              to. If the operator is Exists, the value should be empty,
-                              otherwise just a regular string.
                             type: string
                         type: object
                       type: array
                     vars:
-                      description: Vars specifies the environment variables of a Pod
                       items:
-                        description: EnvVar represents an environment variable present
-                          in a Container.
                         properties:
                           name:
-                            description: Name of the environment variable. Must be a
-                              C_IDENTIFIER.
                             type: string
                           value:
-                            description: 'Variable references $(VAR_NAME) are expanded
-                            using the previous defined environment variables in the
-                            container and any service environment variables. If a
-                            variable cannot be resolved, the reference in the input
-                            string will be unchanged. The $(VAR_NAME) syntax can be
-                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                            will never be expanded, regardless of whether the variable
-                            exists or not. Defaults to "".'
                             type: string
                           valueFrom:
-                            description: Source for the environment variable's value.
-                              Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
-                                description: Selects a key of a ConfigMap.
                                 properties:
                                   key:
-                                    description: The key to select.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or its
-                                      key must be defined
                                     type: boolean
                                 required:
                                   - key
                                 type: object
                               fieldRef:
-                                description: 'Selects a field of the pod: supports metadata.name,
-                                metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                spec.serviceAccountName, status.hostIP, status.podIP,
-                                status.podIPs.'
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
                                     type: string
                                 required:
                                   - fieldPath
                                 type: object
                               resourceFieldRef:
-                                description: 'Selects a resource of the container: only
-                                resources limits and requests (limits.cpu, limits.memory,
-                                limits.ephemeral-storage, requests.cpu, requests.memory
-                                and requests.ephemeral-storage) are currently supported.'
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes,
-                                    optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
-                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                   - resource
                                 type: object
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its key
-                                      must be defined
                                     type: boolean
                                 required:
                                   - key
@@ -6094,66 +3219,22 @@ spec:
                         type: object
                       type: array
                     volumes:
-                      description: Volumes defines extra volumes of the pod.
                       items:
-                        description: Volume represents a named volume in a pod that
-                          may be accessed by any container in the pod. The Volume API
-                          from the core group is not used directly to avoid unneeded
-                          fields defined in `VolumeSource` and reduce the size of the
-                          CRD. New fields in VolumeSource could be added as needed.
                         properties:
                           configMap:
-                            description: ConfigMap represents a configMap that should
-                              populate this volume
                             properties:
                               defaultMode:
-                                description: 'Optional: mode bits used to set permissions
-                                on created files by default. Must be an octal value
-                                between 0000 and 0777 or a decimal value between 0
-                                and 511. YAML accepts both octal and decimal values,
-                                JSON requires decimal values for mode bits. Defaults
-                                to 0644. Directories within the path are not affected
-                                by this setting. This might be in conflict with other
-                                options that affect the file mode, like fsGroup, and
-                                the result can be other mode bits set.'
                                 format: int32
                                 type: integer
                               items:
-                                description: If unspecified, each key-value pair in
-                                  the Data field of the referenced ConfigMap will be
-                                  projected into the volume as a file whose name is
-                                  the key and content is the value. If specified, the
-                                  listed keys will be projected into the specified paths,
-                                  and unlisted keys will not be present. If a key is
-                                  specified which is not present in the ConfigMap, the
-                                  volume setup will error unless it is marked optional.
-                                  Paths must be relative and may not contain the '..'
-                                  path or start with '..'.
                                 items:
-                                  description: Maps a string key to a path within a
-                                    volume.
                                   properties:
                                     key:
-                                      description: The key to project.
                                       type: string
                                     mode:
-                                      description: 'Optional: mode bits used to set
-                                      permissions on this file. Must be an octal value
-                                      between 0000 and 0777 or a decimal value between
-                                      0 and 511. YAML accepts both octal and decimal
-                                      values, JSON requires decimal values for mode
-                                      bits. If not specified, the volume defaultMode
-                                      will be used. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
                                       format: int32
                                       type: integer
                                     path:
-                                      description: The relative path of the file to
-                                        map the key to. May not be an absolute path.
-                                        May not contain the path element '..'. May not
-                                        start with the string '..'.
                                       type: string
                                   required:
                                     - key
@@ -6161,70 +3242,26 @@ spec:
                                   type: object
                                 type: array
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
-                                description: Specify whether the ConfigMap or its keys
-                                  must be defined
                                 type: boolean
                             type: object
                           name:
-                            description: 'Volume''s name. Must be a DNS_LABEL and unique
-                            within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
                           secret:
-                            description: Secret represents a secret that should populate
-                              this volume.
                             properties:
                               defaultMode:
-                                description: 'Optional: mode bits used to set permissions
-                                on created files by default. Must be an octal value
-                                between 0000 and 0777 or a decimal value between 0
-                                and 511. YAML accepts both octal and decimal values,
-                                JSON requires decimal values for mode bits. Defaults
-                                to 0644. Directories within the path are not affected
-                                by this setting. This might be in conflict with other
-                                options that affect the file mode, like fsGroup, and
-                                the result can be other mode bits set.'
                                 format: int32
                                 type: integer
                               items:
-                                description: If unspecified, each key-value pair in
-                                  the Data field of the referenced Secret will be projected
-                                  into the volume as a file whose name is the key and
-                                  content is the value. If specified, the listed keys
-                                  will be projected into the specified paths, and unlisted
-                                  keys will not be present. If a key is specified which
-                                  is not present in the Secret, the volume setup will
-                                  error unless it is marked optional. Paths must be
-                                  relative and may not contain the '..' path or start
-                                  with '..'.
                                 items:
-                                  description: Maps a string key to a path within a
-                                    volume.
                                   properties:
                                     key:
-                                      description: The key to project.
                                       type: string
                                     mode:
-                                      description: 'Optional: mode bits used to set
-                                      permissions on this file. Must be an octal value
-                                      between 0000 and 0777 or a decimal value between
-                                      0 and 511. YAML accepts both octal and decimal
-                                      values, JSON requires decimal values for mode
-                                      bits. If not specified, the volume defaultMode
-                                      will be used. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
                                       format: int32
                                       type: integer
                                     path:
-                                      description: The relative path of the file to
-                                        map the key to. May not be an absolute path.
-                                        May not contain the path element '..'. May not
-                                        start with the string '..'.
                                       type: string
                                   required:
                                     - key
@@ -6232,12 +3269,8 @@ spec:
                                   type: object
                                 type: array
                               optional:
-                                description: Specify whether the Secret or its keys
-                                  must be defined
                                 type: boolean
                               secretName:
-                                description: 'Name of the secret in the pod''s namespace
-                                to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                 type: string
                             type: object
                         required:
@@ -6246,26 +3279,19 @@ spec:
                       type: array
                   type: object
                 replicas:
-                  description: Replicas is the expected size of the pulsar broker
                   format: int32
                   type: integer
                 zkServers:
-                  description: Zookeeper server list
                   type: string
               required:
                 - zkServers
               type: object
             status:
-              description: PulsarBrokerStatus defines the observed state of PulsarBroker
               properties:
                 conditions:
                   additionalProperties:
-                    description: The `Status` of a given `Condition` and the `Action`
-                      needed to reach the `Status`
                     properties:
                       action:
-                        description: The action needed to advance components to ready
-                          status
                         type: string
                       condition:
                         type: string
@@ -6276,25 +3302,16 @@ spec:
                       - condition
                       - status
                     type: object
-                  description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                  of Broker Important: Run "make" to regenerate code after modifying
-                  this file'
                   type: object
                 labelSelector:
-                  description: Label selector for scaling
                   type: string
                 observedGeneration:
-                  description: ObservedGeneration is the most recent generation observed
-                    for this cluster. It corresponds to the metadata generation, which
-                    is updated on mutation by the API Server.
                   format: int64
                   type: integer
                 readyReplicas:
-                  description: ReadyReplicas is the number of ready servers in the cluster
                   format: int32
                   type: integer
                 replicas:
-                  description: Replicas is the number of servers in the cluster
                   format: int32
                   type: integer
                 serviceEndpoints:
@@ -6315,8 +3332,6 @@ spec:
                       type: object
                   type: object
                 updatedReplicas:
-                  description: UpdatedReplicas is the number of servers that has been
-                    updated to the latest configuration
                   format: int32
                   type: integer
               required:

--- a/charts/pulsar-operator/crds/pulsar.streamnative.io_pulsarproxies.yaml
+++ b/charts/pulsar-operator/crds/pulsar.streamnative.io_pulsarproxies.yaml
@@ -11,3655 +11,1932 @@ spec:
   group: pulsar.streamnative.io
   names:
     categories:
-    - pulsar
+      - pulsar
     kind: PulsarProxy
     listKind: PulsarProxyList
     plural: pulsarproxies
     shortNames:
-    - pp
-    - proxy
+      - pp
+      - proxy
     singular: pulsarproxy
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.replicas
-      name: Replicas
-      type: integer
-    - jsonPath: .status.replicas
-      name: Ready Replicas
-      type: integer
-    - jsonPath: .spec.image
-      name: Desired Image
-      type: string
-    - jsonPath: .spec.dnsNames[0]
-      name: Endpoint
-      type: integer
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: PulsarProxy is the Schema for the pulsarproxies API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: PulsarProxySpec defines the desired state of PulsarProxy
-            properties:
-              apiObjects:
-                description: APIObjects allows precise control over how components
-                  (services, statefulset and so on) should be managed
-                properties:
-                  externalService:
-                    description: ExternalService defines the Pulsar Proxy external
-                      service resource template.
-                    properties:
-                      exposeSSLPort:
-                        description: ExposeSSLPort will be used to export SSL service
-                          port even when proxy tls is disabled, it's useful when we
-                          want to terminate tls at external load balancer and forward
-                          plain text request to proxy If it is true, the service port
-                          will be 443, 6651 otherwise, the service port will be 8080,
-                          6650
-                        type: boolean
-                      metadata:
-                        description: 'Standard object''s metadata used to customize
-                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                        properties:
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            description: Annotations of the resource.
-                            type: object
-                          labels:
-                            additionalProperties:
-                              type: string
-                            description: Labels of the resource.
-                            type: object
-                          name:
-                            description: Name of the resource within a namespace.
-                              It must be unique.
-                            type: string
-                        type: object
-                      ports:
-                        description: Ports will be used to replace existing port or
-                          create new port The default non tls service port is 6650,
-                          8080 when the type is NodePort, if you want to to expose
-                          proxy port 6650 and 8080 to a specific node port
-                        items:
-                          description: ServicePort contains information on service's
-                            port.
+    - additionalPrinterColumns:
+        - jsonPath: .spec.replicas
+          name: Replicas
+          type: integer
+        - jsonPath: .status.replicas
+          name: Ready Replicas
+          type: integer
+        - jsonPath: .spec.image
+          name: Desired Image
+          type: string
+        - jsonPath: .spec.dnsNames[0]
+          name: Endpoint
+          type: integer
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+            kind:
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                apiObjects:
+                  properties:
+                    externalService:
+                      properties:
+                        exposeSSLPort:
+                          type: boolean
+                        metadata:
                           properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
                             name:
-                              description: The name of this port within the service.
                               type: string
-                            nodePort:
-                              description: The port on each node on which this service
-                                is exposed when type is NodePort
-                              format: int32
-                              type: integer
-                            port:
-                              description: The port that will be exposed by this service.
-                              format: int32
-                              type: integer
-                            targetPort:
-                              description: Number or name of the port to access on
-                                the pods targeted by the service. When add new service
-                                port, it shouldn't be empty
+                          type: object
+                        ports:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              nodePort:
+                                format: int32
+                                type: integer
+                              port:
+                                format: int32
+                                type: integer
+                              targetPort:
+                                format: int32
+                                type: integer
+                            type: object
+                          type: array
+                        type:
+                          type: string
+                        updatePolicy:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    headlessService:
+                      properties:
+                        metadata:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            name:
+                              type: string
+                          type: object
+                        updatePolicy:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    proxyConfigMap:
+                      properties:
+                        metadata:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            name:
+                              type: string
+                          type: object
+                        updatePolicy:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    statefulSet:
+                      properties:
+                        metadata:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            name:
+                              type: string
+                          type: object
+                        updatePolicy:
+                          items:
+                            type: string
+                          type: array
+                        volumeClaimTemplates:
+                          items:
+                            properties:
+                              apiVersion:
+                                type: string
+                              kind:
+                                type: string
+                              metadata:
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  finalizers:
+                                    items:
+                                      type: string
+                                    type: array
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    type: object
+                                  name:
+                                    type: string
+                                  namespace:
+                                    type: string
+                                type: object
+                              spec:
+                                properties:
+                                  accessModes:
+                                    items:
+                                      type: string
+                                    type: array
+                                  dataSource:
+                                    properties:
+                                      apiGroup:
+                                        type: string
+                                      kind:
+                                        type: string
+                                      name:
+                                        type: string
+                                    required:
+                                      - kind
+                                      - name
+                                    type: object
+                                  resources:
+                                    properties:
+                                      limits:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        type: object
+                                    type: object
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  storageClassName:
+                                    type: string
+                                  volumeMode:
+                                    type: string
+                                  volumeName:
+                                    type: string
+                                type: object
+                              status:
+                                properties:
+                                  accessModes:
+                                    items:
+                                      type: string
+                                    type: array
+                                  capacity:
+                                    additionalProperties:
+                                      anyOf:
+                                        - type: integer
+                                        - type: string
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type: object
+                                  conditions:
+                                    items:
+                                      properties:
+                                        lastProbeTime:
+                                          format: date-time
+                                          type: string
+                                        lastTransitionTime:
+                                          format: date-time
+                                          type: string
+                                        message:
+                                          type: string
+                                        reason:
+                                          type: string
+                                        status:
+                                          type: string
+                                        type:
+                                          type: string
+                                      required:
+                                        - status
+                                        - type
+                                      type: object
+                                    type: array
+                                  phase:
+                                    type: string
+                                type: object
+                            type: object
+                          type: array
+                        volumeMounts:
+                          items:
+                            properties:
+                              mountPath:
+                                type: string
+                              mountPropagation:
+                                type: string
+                              name:
+                                type: string
+                              readOnly:
+                                type: boolean
+                              subPath:
+                                type: string
+                              subPathExpr:
+                                type: string
+                            required:
+                              - mountPath
+                              - name
+                            type: object
+                          type: array
+                      type: object
+                    websocketConfigMap:
+                      properties:
+                        metadata:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            labels:
+                              additionalProperties:
+                                type: string
+                              type: object
+                            name:
+                              type: string
+                          type: object
+                        updatePolicy:
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                  type: object
+                autoScalingPolicy:
+                  properties:
+                    behavior:
+                      properties:
+                        scaleDown:
+                          properties:
+                            policies:
+                              items:
+                                properties:
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  type:
+                                    type: string
+                                  value:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                type: object
+                              type: array
+                            selectPolicy:
+                              type: string
+                            stabilizationWindowSeconds:
                               format: int32
                               type: integer
                           type: object
-                        type: array
-                      type:
-                        description: Type indicates the external service type, LoadBalancer,
-                          NodePort, ClusterIP default is LoadBalancer for backward
-                          compatibility
-                        type: string
-                      updatePolicy:
-                        description: UpdatePolicy defines which field to update.
-                        items:
-                          description: UpdateMode defines how to update resource.
-                          type: string
-                        type: array
-                    type: object
-                  headlessService:
-                    description: HeadlessService defines the Pulsar Proxy headless
-                      service resource template.
-                    properties:
-                      metadata:
-                        description: 'Standard object''s metadata used to customize
-                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                        properties:
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            description: Annotations of the resource.
-                            type: object
-                          labels:
-                            additionalProperties:
-                              type: string
-                            description: Labels of the resource.
-                            type: object
-                          name:
-                            description: Name of the resource within a namespace.
-                              It must be unique.
-                            type: string
-                        type: object
-                      updatePolicy:
-                        description: UpdatePolicy defines which field to update.
-                        items:
-                          description: UpdateMode defines how to update resource.
-                          type: string
-                        type: array
-                    type: object
-                  proxyConfigMap:
-                    description: ProxyConfigMap defines the Pulsar proxy ConfigMap
-                      resource template.
-                    properties:
-                      metadata:
-                        description: 'Standard object''s metadata used to customize
-                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                        properties:
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            description: Annotations of the resource.
-                            type: object
-                          labels:
-                            additionalProperties:
-                              type: string
-                            description: Labels of the resource.
-                            type: object
-                          name:
-                            description: Name of the resource within a namespace.
-                              It must be unique.
-                            type: string
-                        type: object
-                      updatePolicy:
-                        description: UpdatePolicy defines which field to update.
-                        items:
-                          description: UpdateMode defines how to update resource.
-                          type: string
-                        type: array
-                    type: object
-                  statefulSet:
-                    description: StatefulSet defines the StatefulSet resource template
-                      for broker.
-                    properties:
-                      metadata:
-                        description: 'Standard object''s metadata used to customize
-                          the name, labels, annotations of the object. More info:
-                          https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                        properties:
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            description: Annotations of the resource.
-                            type: object
-                          labels:
-                            additionalProperties:
-                              type: string
-                            description: Labels of the resource.
-                            type: object
-                          name:
-                            description: Name of the resource within a namespace.
-                              It must be unique.
-                            type: string
-                        type: object
-                      updatePolicy:
-                        description: UpdatePolicy defines which field to update.
-                        items:
-                          description: UpdateMode defines how to update resource.
-                          type: string
-                        type: array
-                      volumeClaimTemplates:
-                        description: VolumeClaimTemplates is a list of claims that
-                          pods are allowed to reference. If a non-empty list is specified,
-                          the original values in the desired STS will be replaced.
-                        items:
-                          description: PersistentVolumeClaim is a user's request for
-                            and claim to a persistent volume
+                        scaleUp:
                           properties:
-                            apiVersion:
-                              description: 'APIVersion defines the versioned schema
-                                of this representation of an object. Servers should
-                                convert recognized schemas to the latest internal
-                                value, and may reject unrecognized values. More info:
-                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                            policies:
+                              items:
+                                properties:
+                                  periodSeconds:
+                                    format: int32
+                                    type: integer
+                                  type:
+                                    type: string
+                                  value:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                type: object
+                              type: array
+                            selectPolicy:
                               type: string
-                            kind:
-                              description: 'Kind is a string value representing the
-                                REST resource this object represents. Servers may
-                                infer this from the endpoint the client submits requests
-                                to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                              type: string
-                            metadata:
-                              description: 'Standard object''s metadata. More info:
-                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                              properties:
-                                annotations:
-                                  additionalProperties:
+                            stabilizationWindowSeconds:
+                              format: int32
+                              type: integer
+                          type: object
+                      type: object
+                    maxReplicas:
+                      format: int32
+                      type: integer
+                    metrics:
+                      items:
+                        properties:
+                          external:
+                            properties:
+                              metric:
+                                properties:
+                                  name:
                                     type: string
-                                  type: object
-                                finalizers:
-                                  items:
-                                    type: string
-                                  type: array
-                                labels:
-                                  additionalProperties:
-                                    type: string
-                                  type: object
-                                name:
-                                  type: string
-                                namespace:
-                                  type: string
-                              type: object
-                            spec:
-                              description: 'Spec defines the desired characteristics
-                                of a volume requested by a pod author. More info:
-                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                              properties:
-                                accessModes:
-                                  description: 'AccessModes contains the desired access
-                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                  items:
-                                    type: string
-                                  type: array
-                                dataSource:
-                                  description: 'This field can be used to specify
-                                    either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                                    - Beta) * An existing PVC (PersistentVolumeClaim)
-                                    * An existing custom resource/object that implements
-                                    data population (Alpha) In order to use VolumeSnapshot
-                                    object types, the appropriate feature gate must
-                                    be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
-                                    If the provisioner or an external controller can
-                                    support the specified data source, it will create
-                                    a new volume based on the contents of the specified
-                                    data source. If the specified data source is not
-                                    supported, the volume will not be created and
-                                    the failure will be reported as an event. In the
-                                    future, we plan to support more data source types
-                                    and the behavior of the provisioner may change.'
-                                  properties:
-                                    apiGroup:
-                                      description: APIGroup is the group for the resource
-                                        being referenced. If APIGroup is not specified,
-                                        the specified Kind must be in the core API
-                                        group. For any other third-party types, APIGroup
-                                        is required.
-                                      type: string
-                                    kind:
-                                      description: Kind is the type of resource being
-                                        referenced
-                                      type: string
-                                    name:
-                                      description: Name is the name of resource being
-                                        referenced
-                                      type: string
-                                  required:
-                                  - kind
-                                  - name
-                                  type: object
-                                resources:
-                                  description: 'Resources represents the minimum resources
-                                    the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                                  properties:
-                                    limits:
-                                      additionalProperties:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      description: 'Limits describes the maximum amount
-                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                      type: object
-                                    requests:
-                                      additionalProperties:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      description: 'Requests describes the minimum
-                                        amount of compute resources required. If Requests
-                                        is omitted for a container, it defaults to
-                                        Limits if that is explicitly specified, otherwise
-                                        to an implementation-defined value. More info:
-                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                                      type: object
-                                  type: object
-                                selector:
-                                  description: A label query over volumes to consider
-                                    for binding.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
                                               type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
                                         type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                storageClassName:
-                                  description: 'Name of the StorageClass required
-                                    by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                                  type: string
-                                volumeMode:
-                                  description: volumeMode defines what type of volume
-                                    is required by the claim. Value of Filesystem
-                                    is implied when not included in claim spec.
-                                  type: string
-                                volumeName:
-                                  description: VolumeName is the binding reference
-                                    to the PersistentVolume backing this claim.
-                                  type: string
-                              type: object
-                            status:
-                              description: 'Status represents the current information/status
-                                of a persistent volume claim. Read-only. More info:
-                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                              properties:
-                                accessModes:
-                                  description: 'AccessModes contains the actual access
-                                    modes the volume backing the PVC has. More info:
-                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                  items:
-                                    type: string
-                                  type: array
-                                capacity:
-                                  additionalProperties:
+                                    type: object
+                                required:
+                                  - name
+                                type: object
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
                                     anyOf:
-                                    - type: integer
-                                    - type: string
+                                      - type: integer
+                                      - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: Represents the actual resources of
-                                    the underlying volume.
-                                  type: object
-                                conditions:
-                                  description: Current Condition of persistent volume
-                                    claim. If underlying persistent volume is being
-                                    resized then the Condition will be set to 'ResizeStarted'.
-                                  items:
-                                    description: PersistentVolumeClaimCondition contails
-                                      details about state of pvc
-                                    properties:
-                                      lastProbeTime:
-                                        description: Last time we probed the condition.
-                                        format: date-time
-                                        type: string
-                                      lastTransitionTime:
-                                        description: Last time the condition transitioned
-                                          from one status to another.
-                                        format: date-time
-                                        type: string
-                                      message:
-                                        description: Human-readable message indicating
-                                          details about last transition.
-                                        type: string
-                                      reason:
-                                        description: Unique, this should be a short,
-                                          machine understandable string that gives
-                                          the reason for condition's last transition.
-                                          If it reports "ResizeStarted" that means
-                                          the underlying persistent volume is being
-                                          resized.
-                                        type: string
-                                      status:
-                                        type: string
-                                      type:
-                                        description: PersistentVolumeClaimConditionType
-                                          is a valid value of PersistentVolumeClaimCondition.Type
-                                        type: string
-                                    required:
-                                    - status
-                                    - type
-                                    type: object
-                                  type: array
-                                phase:
-                                  description: Phase represents the current phase
-                                    of PersistentVolumeClaim.
-                                  type: string
-                              type: object
-                          type: object
-                        type: array
-                      volumeMounts:
-                        description: VolumeMounts is a list of volumes to mount into
-                          the container's filesystem. If a non-empty list is specified,
-                          the original values of the main container in the desired
-                          STS will be replaced.
-                        items:
-                          description: VolumeMount describes a mounting of a Volume
-                            within a container.
-                          properties:
-                            mountPath:
-                              description: Path within the container at which the
-                                volume should be mounted.  Must not contain ':'.
-                              type: string
-                            mountPropagation:
-                              description: mountPropagation determines how mounts
-                                are propagated from the host to container and the
-                                other way around. When not set, MountPropagationNone
-                                is used. This field is beta in 1.10.
-                              type: string
-                            name:
-                              description: This must match the Name of a Volume.
-                              type: string
-                            readOnly:
-                              description: Mounted read-only if true, read-write otherwise
-                                (false or unspecified). Defaults to false.
-                              type: boolean
-                            subPath:
-                              description: Path within the volume from which the container's
-                                volume should be mounted. Defaults to "" (volume's
-                                root).
-                              type: string
-                            subPathExpr:
-                              description: Expanded path within the volume from which
-                                the container's volume should be mounted. Behaves
-                                similarly to SubPath but environment variable references
-                                $(VAR_NAME) are expanded using the container's environment.
-                                Defaults to "" (volume's root). SubPathExpr and SubPath
-                                are mutually exclusive.
-                              type: string
-                          required:
-                          - mountPath
-                          - name
-                          type: object
-                        type: array
-                    type: object
-                  websocketConfigMap:
-                    description: WebSocketConfigMap defines the Pulsar WebSocket ConfigMap
-                      resource template.
-                    properties:
-                      metadata:
-                        description: 'Standard object''s metadata used to customize
-                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
-                        properties:
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            description: Annotations of the resource.
-                            type: object
-                          labels:
-                            additionalProperties:
-                              type: string
-                            description: Labels of the resource.
-                            type: object
-                          name:
-                            description: Name of the resource within a namespace.
-                              It must be unique.
-                            type: string
-                        type: object
-                      updatePolicy:
-                        description: UpdatePolicy defines which field to update.
-                        items:
-                          description: UpdateMode defines how to update resource.
-                          type: string
-                        type: array
-                    type: object
-                type: object
-              autoScalingPolicy:
-                description: AutoScalingPolicy defines how BookKeeperCluster will
-                  be scaled up/down with given metrics and threshold
-                properties:
-                  behavior:
-                    description: Behavior configures the scaling behavior of the target
-                      in both Up and Down directions (scaleUp and scaleDown fields
-                      respectively). If not set, the default HPAScalingRules for scale
-                      up and scale down are used.
-                    properties:
-                      scaleDown:
-                        description: scaleDown is scaling policy for scaling Down.
-                          If not set, the default value is to allow to scale down
-                          to minReplicas pods, with a 300 second stabilization window
-                          (i.e., the highest recommendation for the last 300sec is
-                          used).
-                        properties:
-                          policies:
-                            description: policies is a list of potential scaling polices
-                              which can be used during scaling. At least one policy
-                              must be specified, otherwise the HPAScalingRules will
-                              be discarded as invalid
-                            items:
-                              description: HPAScalingPolicy is a single policy which
-                                must hold true for a specified past interval.
-                              properties:
-                                periodSeconds:
-                                  description: PeriodSeconds specifies the window
-                                    of time for which the policy should hold true.
-                                    PeriodSeconds must be greater than zero and less
-                                    than or equal to 1800 (30 min).
-                                  format: int32
-                                  type: integer
-                                type:
-                                  description: Type is used to specify the scaling
-                                    policy.
-                                  type: string
-                                value:
-                                  description: Value contains the amount of change
-                                    which is permitted by the policy. It must be greater
-                                    than zero
-                                  format: int32
-                                  type: integer
-                              required:
-                              - periodSeconds
-                              - type
-                              - value
-                              type: object
-                            type: array
-                          selectPolicy:
-                            description: selectPolicy is used to specify which policy
-                              should be used. If not set, the default value MaxPolicySelect
-                              is used.
-                            type: string
-                          stabilizationWindowSeconds:
-                            description: 'StabilizationWindowSeconds is the number
-                              of seconds for which past recommendations should be
-                              considered while scaling up or scaling down. StabilizationWindowSeconds
-                              must be greater than or equal to zero and less than
-                              or equal to 3600 (one hour). If not set, use the default
-                              values: - For scale up: 0 (i.e. no stabilization is
-                              done). - For scale down: 300 (i.e. the stabilization
-                              window is 300 seconds long).'
-                            format: int32
-                            type: integer
-                        type: object
-                      scaleUp:
-                        description: 'scaleUp is scaling policy for scaling Up. If
-                          not set, the default value is the higher of:   * increase
-                          no more than 4 pods per 60 seconds   * double the number
-                          of pods per 60 seconds No stabilization is used.'
-                        properties:
-                          policies:
-                            description: policies is a list of potential scaling polices
-                              which can be used during scaling. At least one policy
-                              must be specified, otherwise the HPAScalingRules will
-                              be discarded as invalid
-                            items:
-                              description: HPAScalingPolicy is a single policy which
-                                must hold true for a specified past interval.
-                              properties:
-                                periodSeconds:
-                                  description: PeriodSeconds specifies the window
-                                    of time for which the policy should hold true.
-                                    PeriodSeconds must be greater than zero and less
-                                    than or equal to 1800 (30 min).
-                                  format: int32
-                                  type: integer
-                                type:
-                                  description: Type is used to specify the scaling
-                                    policy.
-                                  type: string
-                                value:
-                                  description: Value contains the amount of change
-                                    which is permitted by the policy. It must be greater
-                                    than zero
-                                  format: int32
-                                  type: integer
-                              required:
-                              - periodSeconds
-                              - type
-                              - value
-                              type: object
-                            type: array
-                          selectPolicy:
-                            description: selectPolicy is used to specify which policy
-                              should be used. If not set, the default value MaxPolicySelect
-                              is used.
-                            type: string
-                          stabilizationWindowSeconds:
-                            description: 'StabilizationWindowSeconds is the number
-                              of seconds for which past recommendations should be
-                              considered while scaling up or scaling down. StabilizationWindowSeconds
-                              must be greater than or equal to zero and less than
-                              or equal to 3600 (one hour). If not set, use the default
-                              values: - For scale up: 0 (i.e. no stabilization is
-                              done). - For scale down: 300 (i.e. the stabilization
-                              window is 300 seconds long).'
-                            format: int32
-                            type: integer
-                        type: object
-                    type: object
-                  maxReplicas:
-                    format: int32
-                    type: integer
-                  metrics:
-                    description: 'Metrics contains the specifications for which to
-                      use to calculate the desired replica count (the maximum replica
-                      count across all metrics will be used). More info: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling'
-                    items:
-                      description: MetricSpec specifies how to scale based on a single
-                        metric (only `type` and one other matching field should be
-                        set at once).
-                      properties:
-                        external:
-                          description: external refers to a global metric that is
-                            not associated with any Kubernetes object. It allows autoscaling
-                            based on information coming from components running outside
-                            of cluster (for example length of queue in cloud messaging
-                            service, or QPS from loadbalancer running outside of cluster).
-                          properties:
-                            metric:
-                              description: metric identifies the target metric by
-                                name and selector
-                              properties:
-                                name:
-                                  description: name is the name of the given metric
-                                  type: string
-                                selector:
-                                  description: selector is the string-encoded form
-                                    of a standard kubernetes label selector for the
-                                    given metric When set, it is passed as an additional
-                                    parameter to the metrics server for more specific
-                                    metrics scoping. When unset, just the metricName
-                                    will be used to gather metrics.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            target:
-                              description: target specifies the target value for the
-                                given metric
-                              properties:
-                                averageUtilization:
-                                  description: averageUtilization is the target value
-                                    of the average of the resource metric across all
-                                    relevant pods, represented as a percentage of
-                                    the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source
-                                    type
-                                  format: int32
-                                  type: integer
-                                averageValue:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: averageValue is the target value of
-                                    the average of the metric across all relevant
-                                    pods (as a quantity)
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                type:
-                                  description: type represents whether the metric
-                                    type is Utilization, Value, or AverageValue
-                                  type: string
-                                value:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: value is the target value of the metric
-                                    (as a quantity).
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                              required:
-                              - type
-                              type: object
-                          required:
-                          - metric
-                          - target
-                          type: object
-                        object:
-                          description: object refers to a metric describing a single
-                            kubernetes object (for example, hits-per-second on an
-                            Ingress object).
-                          properties:
-                            describedObject:
-                              description: CrossVersionObjectReference contains enough
-                                information to let you identify the referred resource.
-                              properties:
-                                apiVersion:
-                                  description: API version of the referent
-                                  type: string
-                                kind:
-                                  description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
-                                  type: string
-                                name:
-                                  description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                                  type: string
-                              required:
-                              - kind
-                              - name
-                              type: object
-                            metric:
-                              description: metric identifies the target metric by
-                                name and selector
-                              properties:
-                                name:
-                                  description: name is the name of the given metric
-                                  type: string
-                                selector:
-                                  description: selector is the string-encoded form
-                                    of a standard kubernetes label selector for the
-                                    given metric When set, it is passed as an additional
-                                    parameter to the metrics server for more specific
-                                    metrics scoping. When unset, just the metricName
-                                    will be used to gather metrics.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            target:
-                              description: target specifies the target value for the
-                                given metric
-                              properties:
-                                averageUtilization:
-                                  description: averageUtilization is the target value
-                                    of the average of the resource metric across all
-                                    relevant pods, represented as a percentage of
-                                    the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source
-                                    type
-                                  format: int32
-                                  type: integer
-                                averageValue:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: averageValue is the target value of
-                                    the average of the metric across all relevant
-                                    pods (as a quantity)
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                type:
-                                  description: type represents whether the metric
-                                    type is Utilization, Value, or AverageValue
-                                  type: string
-                                value:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: value is the target value of the metric
-                                    (as a quantity).
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                              required:
-                              - type
-                              type: object
-                          required:
-                          - describedObject
-                          - metric
-                          - target
-                          type: object
-                        pods:
-                          description: pods refers to a metric describing each pod
-                            in the current scale target (for example, transactions-processed-per-second).  The
-                            values will be averaged together before being compared
-                            to the target value.
-                          properties:
-                            metric:
-                              description: metric identifies the target metric by
-                                name and selector
-                              properties:
-                                name:
-                                  description: name is the name of the given metric
-                                  type: string
-                                selector:
-                                  description: selector is the string-encoded form
-                                    of a standard kubernetes label selector for the
-                                    given metric When set, it is passed as an additional
-                                    parameter to the metrics server for more specific
-                                    metrics scoping. When unset, just the metricName
-                                    will be used to gather metrics.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                              required:
-                              - name
-                              type: object
-                            target:
-                              description: target specifies the target value for the
-                                given metric
-                              properties:
-                                averageUtilization:
-                                  description: averageUtilization is the target value
-                                    of the average of the resource metric across all
-                                    relevant pods, represented as a percentage of
-                                    the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source
-                                    type
-                                  format: int32
-                                  type: integer
-                                averageValue:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: averageValue is the target value of
-                                    the average of the metric across all relevant
-                                    pods (as a quantity)
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                type:
-                                  description: type represents whether the metric
-                                    type is Utilization, Value, or AverageValue
-                                  type: string
-                                value:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: value is the target value of the metric
-                                    (as a quantity).
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                              required:
-                              - type
-                              type: object
-                          required:
-                          - metric
-                          - target
-                          type: object
-                        resource:
-                          description: resource refers to a resource metric (such
-                            as those specified in requests and limits) known to Kubernetes
-                            describing each pod in the current scale target (e.g.
-                            CPU or memory). Such metrics are built in to Kubernetes,
-                            and have special scaling options on top of those available
-                            to normal per-pod metrics using the "pods" source.
-                          properties:
-                            name:
-                              description: name is the name of the resource in question.
-                              type: string
-                            target:
-                              description: target specifies the target value for the
-                                given metric
-                              properties:
-                                averageUtilization:
-                                  description: averageUtilization is the target value
-                                    of the average of the resource metric across all
-                                    relevant pods, represented as a percentage of
-                                    the requested value of the resource for the pods.
-                                    Currently only valid for Resource metric source
-                                    type
-                                  format: int32
-                                  type: integer
-                                averageValue:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: averageValue is the target value of
-                                    the average of the metric across all relevant
-                                    pods (as a quantity)
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                type:
-                                  description: type represents whether the metric
-                                    type is Utilization, Value, or AverageValue
-                                  type: string
-                                value:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: value is the target value of the metric
-                                    (as a quantity).
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                              required:
-                              - type
-                              type: object
-                          required:
-                          - name
-                          - target
-                          type: object
-                        type:
-                          description: type is the type of metric source.  It should
-                            be one of "Object", "Pods" or "Resource", each mapping
-                            to a matching field in the object.
-                          type: string
-                      required:
-                      - type
-                      type: object
-                    type: array
-                  minReplicas:
-                    format: int32
-                    type: integer
-                required:
-                - maxReplicas
-                type: object
-              brokerAddress:
-                description: The address of the broker
-                type: string
-              certSecretName:
-                description: CertSecretName defines the name of the secret that contains
-                  the certificate to use in the proxy if the value is not set, then
-                  the operator create an certificate automatically if the value is
-                  set to be an empty string, then the proxy will not use a certificate
-                  otherwise the value should be name of the secret that contains a
-                  valid certificate to use in the proxy
-                type: string
-              config:
-                description: Config defines configurations for proxies
-                properties:
-                  custom:
-                    additionalProperties:
-                      type: string
-                    description: Custom allows to customize broker configurations
-                      directly.
-                    type: object
-                  prometheusPlugin:
-                    description: PrometheusPlugin defines the configuration of the
-                      Prometheus servlet plugin which could be used to query the Prometheus
-                      cluster deployed alongside the proxy cluster.
-                    properties:
-                      host:
-                        description: Host defines the host of the Prometheus service
-                        type: string
-                    type: object
-                  tls:
-                    description: TLS defines the configuration of TLS in proxies
-                    properties:
-                      certSecretName:
-                        description: CertSecretName defines the name of the secret
-                          that contains the certificate to use the value should be
-                          name of the secret that contains a valid certificate to
-                          use in the proxy
-                        type: string
-                      enabled:
-                        description: Enabled determines whether to enable TLS in proxies
-                          TODO move other TLS related fields here
-                        type: boolean
-                      trustCertsEnabled:
-                        description: TrustCertsEnabled defines whether to enable trust
-                          store
-                        type: boolean
-                    type: object
-                type: object
-              configs:
-                additionalProperties:
-                  type: string
-                description: Configs defines custom configurations for proxies
-                type: object
-              configurationStoreServers:
-                description: ConfigurationStoreServers defines the configuration store
-                  servers address
-                type: string
-              dnsNames:
-                description: A list of service urls this pulsar proxy advertise
-                items:
-                  type: string
-                type: array
-              image:
-                description: Image is the container image used to run pulsar proxy
-                  pods. default is apachepulsar/pulsar:latest
-                type: string
-              imagePullPolicy:
-                description: Image pull policy, one of Always, Never, IfNotPresent,
-                  default to Always.
-                type: string
-              issuerRef:
-                description: IssuerRef is a reference to the issuer for the TLS endpoint.  If
-                  the 'kind' field is not set, or set to 'Issuer', an Issuer resource
-                  with the given name in the same namespace as the PulsarProxy will
-                  be used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
-                  with the provided name will be used. The 'name' field in this stanza
-                  is required at all times. The group field refers to the API group
-                  of the issuer which defaults to 'cert-manager.io' if empty.
-                properties:
-                  group:
-                    type: string
-                  kind:
-                    type: string
-                  name:
-                    type: string
-                required:
-                - name
-                type: object
-              labels:
-                additionalProperties:
-                  type: string
-                description: Labels specifies the labels to attach to the stateful
-                  set created by operator for pulsar proxy
-                type: object
-              pod:
-                description: Pod defines the policy for creating a proxy pod
-                properties:
-                  affinity:
-                    description: Affinity specifies the scheduling constraints of
-                      a pod
-                    properties:
-                      nodeAffinity:
-                        description: Describes node affinity scheduling rules for
-                          the pod.
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods
-                              to nodes that satisfy the affinity expressions specified
-                              by this field, but it may choose a node that violates
-                              one or more of the expressions. The node that is most
-                              preferred is the one with the greatest sum of weights,
-                              i.e. for each node that meets all of the scheduling
-                              requirements (resource request, requiredDuringScheduling
-                              affinity expressions, etc.), compute a sum by iterating
-                              through the elements of this field and adding "weight"
-                              to the sum if the node matches the corresponding matchExpressions;
-                              the node(s) with the highest sum are the most preferred.
-                            items:
-                              description: An empty preferred scheduling term matches
-                                all objects with implicit weight 0 (i.e. it's a no-op).
-                                A null preferred scheduling term matches no objects
-                                (i.e. is also a no-op).
-                              properties:
-                                preference:
-                                  description: A node selector term, associated with
-                                    the corresponding weight.
-                                  properties:
-                                    matchExpressions:
-                                      description: A list of node selector requirements
-                                        by node's labels.
-                                      items:
-                                        description: A node selector requirement is
-                                          a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: The label key that the selector
-                                              applies to.
-                                            type: string
-                                          operator:
-                                            description: Represents a key's relationship
-                                              to a set of values. Valid operators
-                                              are In, NotIn, Exists, DoesNotExist.
-                                              Gt, and Lt.
-                                            type: string
-                                          values:
-                                            description: An array of string values.
-                                              If the operator is In or NotIn, the
-                                              values array must be non-empty. If the
-                                              operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the
-                                              operator is Gt or Lt, the values array
-                                              must have a single element, which will
-                                              be interpreted as an integer. This array
-                                              is replaced during a strategic merge
-                                              patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchFields:
-                                      description: A list of node selector requirements
-                                        by node's fields.
-                                      items:
-                                        description: A node selector requirement is
-                                          a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: The label key that the selector
-                                              applies to.
-                                            type: string
-                                          operator:
-                                            description: Represents a key's relationship
-                                              to a set of values. Valid operators
-                                              are In, NotIn, Exists, DoesNotExist.
-                                              Gt, and Lt.
-                                            type: string
-                                          values:
-                                            description: An array of string values.
-                                              If the operator is In or NotIn, the
-                                              values array must be non-empty. If the
-                                              operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the
-                                              operator is Gt or Lt, the values array
-                                              must have a single element, which will
-                                              be interpreted as an integer. This array
-                                              is replaced during a strategic merge
-                                              patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                  type: object
-                                weight:
-                                  description: Weight associated with matching the
-                                    corresponding nodeSelectorTerm, in the range 1-100.
-                                  format: int32
-                                  type: integer
-                              required:
-                              - preference
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the affinity requirements specified by
-                              this field are not met at scheduling time, the pod will
-                              not be scheduled onto the node. If the affinity requirements
-                              specified by this field cease to be met at some point
-                              during pod execution (e.g. due to an update), the system
-                              may or may not try to eventually evict the pod from
-                              its node.
-                            properties:
-                              nodeSelectorTerms:
-                                description: Required. A list of node selector terms.
-                                  The terms are ORed.
-                                items:
-                                  description: A null or empty node selector term
-                                    matches no objects. The requirements of them are
-                                    ANDed. The TopologySelectorTerm type implements
-                                    a subset of the NodeSelectorTerm.
-                                  properties:
-                                    matchExpressions:
-                                      description: A list of node selector requirements
-                                        by node's labels.
-                                      items:
-                                        description: A node selector requirement is
-                                          a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: The label key that the selector
-                                              applies to.
-                                            type: string
-                                          operator:
-                                            description: Represents a key's relationship
-                                              to a set of values. Valid operators
-                                              are In, NotIn, Exists, DoesNotExist.
-                                              Gt, and Lt.
-                                            type: string
-                                          values:
-                                            description: An array of string values.
-                                              If the operator is In or NotIn, the
-                                              values array must be non-empty. If the
-                                              operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the
-                                              operator is Gt or Lt, the values array
-                                              must have a single element, which will
-                                              be interpreted as an integer. This array
-                                              is replaced during a strategic merge
-                                              patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchFields:
-                                      description: A list of node selector requirements
-                                        by node's fields.
-                                      items:
-                                        description: A node selector requirement is
-                                          a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: The label key that the selector
-                                              applies to.
-                                            type: string
-                                          operator:
-                                            description: Represents a key's relationship
-                                              to a set of values. Valid operators
-                                              are In, NotIn, Exists, DoesNotExist.
-                                              Gt, and Lt.
-                                            type: string
-                                          values:
-                                            description: An array of string values.
-                                              If the operator is In or NotIn, the
-                                              values array must be non-empty. If the
-                                              operator is Exists or DoesNotExist,
-                                              the values array must be empty. If the
-                                              operator is Gt or Lt, the values array
-                                              must have a single element, which will
-                                              be interpreted as an integer. This array
-                                              is replaced during a strategic merge
-                                              patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                  type: object
-                                type: array
-                            required:
-                            - nodeSelectorTerms
-                            type: object
-                        type: object
-                      podAffinity:
-                        description: Describes pod affinity scheduling rules (e.g.
-                          co-locate this pod in the same node, zone, etc. as some
-                          other pod(s)).
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods
-                              to nodes that satisfy the affinity expressions specified
-                              by this field, but it may choose a node that violates
-                              one or more of the expressions. The node that is most
-                              preferred is the one with the greatest sum of weights,
-                              i.e. for each node that meets all of the scheduling
-                              requirements (resource request, requiredDuringScheduling
-                              affinity expressions, etc.), compute a sum by iterating
-                              through the elements of this field and adding "weight"
-                              to the sum if the node has pods which matches the corresponding
-                              podAffinityTerm; the node(s) with the highest sum are
-                              the most preferred.
-                            items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm
-                                fields are added per-node to find the most preferred
-                                node(s)
-                              properties:
-                                podAffinityTerm:
-                                  description: Required. A pod affinity term, associated
-                                    with the corresponding weight.
-                                  properties:
-                                    labelSelector:
-                                      description: A label query over a set of resources,
-                                        in this case pods.
-                                      properties:
-                                        matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
-                                          items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
-                                            properties:
-                                              key:
-                                                description: key is the label key
-                                                  that the selector applies to.
-                                                type: string
-                                              operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
-                                                type: string
-                                              values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      description: namespaces specifies which namespaces
-                                        the labelSelector applies to (matches against);
-                                        null or empty list means "this pod's namespace"
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      description: This pod should be co-located (affinity)
-                                        or not co-located (anti-affinity) with the
-                                        pods matching the labelSelector in the specified
-                                        namespaces, where co-located is defined as
-                                        running on a node whose value of the label
-                                        with key topologyKey matches that of any node
-                                        on which any of the selected pods is running.
-                                        Empty topologyKey is not allowed.
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                weight:
-                                  description: weight associated with matching the
-                                    corresponding podAffinityTerm, in the range 1-100.
-                                  format: int32
-                                  type: integer
-                              required:
-                              - podAffinityTerm
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the affinity requirements specified by
-                              this field are not met at scheduling time, the pod will
-                              not be scheduled onto the node. If the affinity requirements
-                              specified by this field cease to be met at some point
-                              during pod execution (e.g. due to a pod label update),
-                              the system may or may not try to eventually evict the
-                              pod from its node. When there are multiple elements,
-                              the lists of nodes corresponding to each podAffinityTerm
-                              are intersected, i.e. all terms must be satisfied.
-                            items:
-                              description: Defines a set of pods (namely those matching
-                                the labelSelector relative to the given namespace(s))
-                                that this pod should be co-located (affinity) or not
-                                co-located (anti-affinity) with, where co-located
-                                is defined as running on a node whose value of the
-                                label with key <topologyKey> matches that of any node
-                                on which a pod of the set of pods is running
-                              properties:
-                                labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
-                                  items:
+                                  type:
                                     type: string
-                                  type: array
-                                topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            type: array
-                        type: object
-                      podAntiAffinity:
-                        description: Describes pod anti-affinity scheduling rules
-                          (e.g. avoid putting this pod in the same node, zone, etc.
-                          as some other pod(s)).
-                        properties:
-                          preferredDuringSchedulingIgnoredDuringExecution:
-                            description: The scheduler will prefer to schedule pods
-                              to nodes that satisfy the anti-affinity expressions
-                              specified by this field, but it may choose a node that
-                              violates one or more of the expressions. The node that
-                              is most preferred is the one with the greatest sum of
-                              weights, i.e. for each node that meets all of the scheduling
-                              requirements (resource request, requiredDuringScheduling
-                              anti-affinity expressions, etc.), compute a sum by iterating
-                              through the elements of this field and adding "weight"
-                              to the sum if the node has pods which matches the corresponding
-                              podAffinityTerm; the node(s) with the highest sum are
-                              the most preferred.
-                            items:
-                              description: The weights of all of the matched WeightedPodAffinityTerm
-                                fields are added per-node to find the most preferred
-                                node(s)
-                              properties:
-                                podAffinityTerm:
-                                  description: Required. A pod affinity term, associated
-                                    with the corresponding weight.
-                                  properties:
-                                    labelSelector:
-                                      description: A label query over a set of resources,
-                                        in this case pods.
-                                      properties:
-                                        matchExpressions:
-                                          description: matchExpressions is a list
-                                            of label selector requirements. The requirements
-                                            are ANDed.
-                                          items:
-                                            description: A label selector requirement
-                                              is a selector that contains values,
-                                              a key, and an operator that relates
-                                              the key and values.
-                                            properties:
-                                              key:
-                                                description: key is the label key
-                                                  that the selector applies to.
-                                                type: string
-                                              operator:
-                                                description: operator represents a
-                                                  key's relationship to a set of values.
-                                                  Valid operators are In, NotIn, Exists
-                                                  and DoesNotExist.
-                                                type: string
-                                              values:
-                                                description: values is an array of
-                                                  string values. If the operator is
-                                                  In or NotIn, the values array must
-                                                  be non-empty. If the operator is
-                                                  Exists or DoesNotExist, the values
-                                                  array must be empty. This array
-                                                  is replaced during a strategic merge
-                                                  patch.
-                                                items:
-                                                  type: string
-                                                type: array
-                                            required:
-                                            - key
-                                            - operator
-                                            type: object
-                                          type: array
-                                        matchLabels:
-                                          additionalProperties:
-                                            type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator
-                                            is "In", and the values array contains
-                                            only "value". The requirements are ANDed.
-                                          type: object
-                                      type: object
-                                    namespaces:
-                                      description: namespaces specifies which namespaces
-                                        the labelSelector applies to (matches against);
-                                        null or empty list means "this pod's namespace"
-                                      items:
-                                        type: string
-                                      type: array
-                                    topologyKey:
-                                      description: This pod should be co-located (affinity)
-                                        or not co-located (anti-affinity) with the
-                                        pods matching the labelSelector in the specified
-                                        namespaces, where co-located is defined as
-                                        running on a node whose value of the label
-                                        with key topologyKey matches that of any node
-                                        on which any of the selected pods is running.
-                                        Empty topologyKey is not allowed.
-                                      type: string
-                                  required:
-                                  - topologyKey
-                                  type: object
-                                weight:
-                                  description: weight associated with matching the
-                                    corresponding podAffinityTerm, in the range 1-100.
-                                  format: int32
-                                  type: integer
-                              required:
-                              - podAffinityTerm
-                              - weight
-                              type: object
-                            type: array
-                          requiredDuringSchedulingIgnoredDuringExecution:
-                            description: If the anti-affinity requirements specified
-                              by this field are not met at scheduling time, the pod
-                              will not be scheduled onto the node. If the anti-affinity
-                              requirements specified by this field cease to be met
-                              at some point during pod execution (e.g. due to a pod
-                              label update), the system may or may not try to eventually
-                              evict the pod from its node. When there are multiple
-                              elements, the lists of nodes corresponding to each podAffinityTerm
-                              are intersected, i.e. all terms must be satisfied.
-                            items:
-                              description: Defines a set of pods (namely those matching
-                                the labelSelector relative to the given namespace(s))
-                                that this pod should be co-located (affinity) or not
-                                co-located (anti-affinity) with, where co-located
-                                is defined as running on a node whose value of the
-                                label with key <topologyKey> matches that of any node
-                                on which a pod of the set of pods is running
-                              properties:
-                                labelSelector:
-                                  description: A label query over a set of resources,
-                                    in this case pods.
-                                  properties:
-                                    matchExpressions:
-                                      description: matchExpressions is a list of label
-                                        selector requirements. The requirements are
-                                        ANDed.
-                                      items:
-                                        description: A label selector requirement
-                                          is a selector that contains values, a key,
-                                          and an operator that relates the key and
-                                          values.
-                                        properties:
-                                          key:
-                                            description: key is the label key that
-                                              the selector applies to.
-                                            type: string
-                                          operator:
-                                            description: operator represents a key's
-                                              relationship to a set of values. Valid
-                                              operators are In, NotIn, Exists and
-                                              DoesNotExist.
-                                            type: string
-                                          values:
-                                            description: values is an array of string
-                                              values. If the operator is In or NotIn,
-                                              the values array must be non-empty.
-                                              If the operator is Exists or DoesNotExist,
-                                              the values array must be empty. This
-                                              array is replaced during a strategic
-                                              merge patch.
-                                            items:
-                                              type: string
-                                            type: array
-                                        required:
-                                        - key
-                                        - operator
-                                        type: object
-                                      type: array
-                                    matchLabels:
-                                      additionalProperties:
-                                        type: string
-                                      description: matchLabels is a map of {key,value}
-                                        pairs. A single {key,value} in the matchLabels
-                                        map is equivalent to an element of matchExpressions,
-                                        whose key field is "key", the operator is
-                                        "In", and the values array contains only "value".
-                                        The requirements are ANDed.
-                                      type: object
-                                  type: object
-                                namespaces:
-                                  description: namespaces specifies which namespaces
-                                    the labelSelector applies to (matches against);
-                                    null or empty list means "this pod's namespace"
-                                  items:
-                                    type: string
-                                  type: array
-                                topologyKey:
-                                  description: This pod should be co-located (affinity)
-                                    or not co-located (anti-affinity) with the pods
-                                    matching the labelSelector in the specified namespaces,
-                                    where co-located is defined as running on a node
-                                    whose value of the label with key topologyKey
-                                    matches that of any node on which any of the selected
-                                    pods is running. Empty topologyKey is not allowed.
-                                  type: string
-                              required:
-                              - topologyKey
-                              type: object
-                            type: array
-                        type: object
-                    type: object
-                  annotations:
-                    additionalProperties:
-                      type: string
-                    description: Annotations specifies the annotations to attach to
-                      pods the operator creates
-                    type: object
-                  debug:
-                    description: Debug defines a switch enable debug
-                    type: boolean
-                  initContainers:
-                    description: InitContainers defines init containers of the pod.
-                      A typical use case could be using an init container to download
-                      a remote jar to a local path.
-                    items:
-                      description: A single application container that you want to
-                        run within a pod. The Container API from the core group is
-                        not used directly to avoid unneeded fields and reduce the
-                        size of the CRD. New fields could be added as needed.
-                      properties:
-                        args:
-                          description: Arguments to the entrypoint.
-                          items:
-                            type: string
-                          type: array
-                        command:
-                          description: Entrypoint array. Not executed within a shell.
-                          items:
-                            type: string
-                          type: array
-                        env:
-                          description: List of environment variables to set in the
-                            container.
-                          items:
-                            description: EnvVar represents an environment variable
-                              present in a Container.
-                            properties:
-                              name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
-                                type: string
-                              value:
-                                description: 'Variable references $(VAR_NAME) are
-                                  expanded using the previous defined environment
-                                  variables in the container and any service environment
-                                  variables. If a variable cannot be resolved, the
-                                  reference in the input string will be unchanged.
-                                  The $(VAR_NAME) syntax can be escaped with a double
-                                  $$, ie: $$(VAR_NAME). Escaped references will never
-                                  be expanded, regardless of whether the variable
-                                  exists or not. Defaults to "".'
-                                type: string
-                              valueFrom:
-                                description: Source for the environment variable's
-                                  value. Cannot be used if value is not empty.
-                                properties:
-                                  configMapKeyRef:
-                                    description: Selects a key of a ConfigMap.
-                                    properties:
-                                      key:
-                                        description: The key to select.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the ConfigMap
-                                          or its key must be defined
-                                        type: boolean
-                                    required:
-                                    - key
-                                    type: object
-                                  fieldRef:
-                                    description: 'Selects a field of the pod: supports
-                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                      spec.serviceAccountName, status.hostIP, status.podIP,
-                                      status.podIPs.'
-                                    properties:
-                                      apiVersion:
-                                        description: Version of the schema the FieldPath
-                                          is written in terms of, defaults to "v1".
-                                        type: string
-                                      fieldPath:
-                                        description: Path of the field to select in
-                                          the specified API version.
-                                        type: string
-                                    required:
-                                    - fieldPath
-                                    type: object
-                                  resourceFieldRef:
-                                    description: 'Selects a resource of the container:
-                                      only resources limits and requests (limits.cpu,
-                                      limits.memory, limits.ephemeral-storage, requests.cpu,
-                                      requests.memory and requests.ephemeral-storage)
-                                      are currently supported.'
-                                    properties:
-                                      containerName:
-                                        description: 'Container name: required for
-                                          volumes, optional for env vars'
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        description: Specifies the output format of
-                                          the exposed resources, defaults to "1"
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        description: 'Required: resource to select'
-                                        type: string
-                                    required:
-                                    - resource
-                                    type: object
-                                  secretKeyRef:
-                                    description: Selects a key of a secret in the
-                                      pod's namespace
-                                    properties:
-                                      key:
-                                        description: The key of the secret to select
-                                          from.  Must be a valid secret key.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the Secret or
-                                          its key must be defined
-                                        type: boolean
-                                    required:
-                                    - key
-                                    type: object
+                                  value:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - type
                                 type: object
                             required:
-                            - name
+                              - metric
+                              - target
                             type: object
-                          type: array
-                        envFrom:
-                          description: List of sources to populate environment variables
-                            in the container.
-                          items:
-                            description: EnvFromSource represents the source of a
-                              set of ConfigMaps
+                          object:
                             properties:
-                              configMapRef:
-                                description: The ConfigMap to select from
+                              describedObject:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  kind:
+                                    type: string
+                                  name:
+                                    type: string
+                                required:
+                                  - kind
+                                  - name
+                                type: object
+                              metric:
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                     type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap must
-                                      be defined
-                                    type: boolean
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                required:
+                                  - name
                                 type: object
-                              prefix:
-                                description: An optional identifier to prepend to
-                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
-                                type: string
-                              secretRef:
-                                description: The Secret to select from
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type:
+                                    type: string
+                                  value:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - type
+                                type: object
+                            required:
+                              - describedObject
+                              - metric
+                              - target
+                            type: object
+                          pods:
+                            properties:
+                              metric:
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                     type: string
-                                  optional:
-                                    description: Specify whether the Secret must be
-                                      defined
-                                    type: boolean
+                                  selector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                required:
+                                  - name
                                 type: object
-                            type: object
-                          type: array
-                        image:
-                          description: Docker image name.
-                          type: string
-                        imagePullPolicy:
-                          description: Image pull policy.
-                          type: string
-                        livenessProbe:
-                          description: Periodic probe of container liveness.
-                          properties:
-                            exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
-                              properties:
-                                command:
-                                  description: Command is the command line to execute
-                                    inside the container, the working directory for
-                                    the command  is root ('/') in the container's
-                                    filesystem. The command is simply exec'd, it is
-                                    not run inside a shell, so traditional shell instructions
-                                    ('|', etc) won't work. To use a shell, you need
-                                    to explicitly call out to that shell. Exit status
-                                    of 0 is treated as live/healthy and non-zero is
-                                    unhealthy.
-                                  items:
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type:
                                     type: string
-                                  type: array
-                              type: object
-                            failureThreshold:
-                              description: Minimum consecutive failures for the probe
-                                to be considered failed after having succeeded. Defaults
-                                to 3. Minimum value is 1.
-                              format: int32
-                              type: integer
-                            httpGet:
-                              description: HTTPGet specifies the http request to perform.
-                              properties:
-                                host:
-                                  description: Host name to connect to, defaults to
-                                    the pod IP. You probably want to set "Host" in
-                                    httpHeaders instead.
-                                  type: string
-                                httpHeaders:
-                                  description: Custom headers to set in the request.
-                                    HTTP allows repeated headers.
-                                  items:
-                                    description: HTTPHeader describes a custom header
-                                      to be used in HTTP probes
-                                    properties:
-                                      name:
-                                        description: The header field name
-                                        type: string
-                                      value:
-                                        description: The header field value
-                                        type: string
-                                    required:
-                                    - name
-                                    - value
-                                    type: object
-                                  type: array
-                                path:
-                                  description: Path to access on the HTTP server.
-                                  type: string
-                                port:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: Name or number of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
-                                  x-kubernetes-int-or-string: true
-                                scheme:
-                                  description: Scheme to use for connecting to the
-                                    host. Defaults to HTTP.
-                                  type: string
-                              required:
-                              - port
-                              type: object
-                            initialDelaySeconds:
-                              description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                              format: int32
-                              type: integer
-                            periodSeconds:
-                              description: How often (in seconds) to perform the probe.
-                                Default to 10 seconds. Minimum value is 1.
-                              format: int32
-                              type: integer
-                            successThreshold:
-                              description: Minimum consecutive successes for the probe
-                                to be considered successful after having failed. Defaults
-                                to 1. Must be 1 for liveness and startup. Minimum
-                                value is 1.
-                              format: int32
-                              type: integer
-                            tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
-                              properties:
-                                host:
-                                  description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
-                                  type: string
-                                port:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: Number or name of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
-                                  x-kubernetes-int-or-string: true
-                              required:
-                              - port
-                              type: object
-                            timeoutSeconds:
-                              description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                              format: int32
-                              type: integer
-                          type: object
-                        name:
-                          description: Name of the container specified as a DNS_LABEL.
-                            Each container in a pod must have a unique name (DNS_LABEL).
-                          type: string
-                        readinessProbe:
-                          description: 'Periodic probe of container service readiness.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                          properties:
-                            exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
-                              properties:
-                                command:
-                                  description: Command is the command line to execute
-                                    inside the container, the working directory for
-                                    the command  is root ('/') in the container's
-                                    filesystem. The command is simply exec'd, it is
-                                    not run inside a shell, so traditional shell instructions
-                                    ('|', etc) won't work. To use a shell, you need
-                                    to explicitly call out to that shell. Exit status
-                                    of 0 is treated as live/healthy and non-zero is
-                                    unhealthy.
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            failureThreshold:
-                              description: Minimum consecutive failures for the probe
-                                to be considered failed after having succeeded. Defaults
-                                to 3. Minimum value is 1.
-                              format: int32
-                              type: integer
-                            httpGet:
-                              description: HTTPGet specifies the http request to perform.
-                              properties:
-                                host:
-                                  description: Host name to connect to, defaults to
-                                    the pod IP. You probably want to set "Host" in
-                                    httpHeaders instead.
-                                  type: string
-                                httpHeaders:
-                                  description: Custom headers to set in the request.
-                                    HTTP allows repeated headers.
-                                  items:
-                                    description: HTTPHeader describes a custom header
-                                      to be used in HTTP probes
-                                    properties:
-                                      name:
-                                        description: The header field name
-                                        type: string
-                                      value:
-                                        description: The header field value
-                                        type: string
-                                    required:
-                                    - name
-                                    - value
-                                    type: object
-                                  type: array
-                                path:
-                                  description: Path to access on the HTTP server.
-                                  type: string
-                                port:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: Name or number of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
-                                  x-kubernetes-int-or-string: true
-                                scheme:
-                                  description: Scheme to use for connecting to the
-                                    host. Defaults to HTTP.
-                                  type: string
-                              required:
-                              - port
-                              type: object
-                            initialDelaySeconds:
-                              description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                              format: int32
-                              type: integer
-                            periodSeconds:
-                              description: How often (in seconds) to perform the probe.
-                                Default to 10 seconds. Minimum value is 1.
-                              format: int32
-                              type: integer
-                            successThreshold:
-                              description: Minimum consecutive successes for the probe
-                                to be considered successful after having failed. Defaults
-                                to 1. Must be 1 for liveness and startup. Minimum
-                                value is 1.
-                              format: int32
-                              type: integer
-                            tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
-                              properties:
-                                host:
-                                  description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
-                                  type: string
-                                port:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: Number or name of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
-                                  x-kubernetes-int-or-string: true
-                              required:
-                              - port
-                              type: object
-                            timeoutSeconds:
-                              description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                              format: int32
-                              type: integer
-                          type: object
-                        resources:
-                          description: Compute Resources required by this container.
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                          type: object
-                        startupProbe:
-                          description: StartupProbe indicates that the Pod has successfully
-                            initialized.
-                          properties:
-                            exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
-                              properties:
-                                command:
-                                  description: Command is the command line to execute
-                                    inside the container, the working directory for
-                                    the command  is root ('/') in the container's
-                                    filesystem. The command is simply exec'd, it is
-                                    not run inside a shell, so traditional shell instructions
-                                    ('|', etc) won't work. To use a shell, you need
-                                    to explicitly call out to that shell. Exit status
-                                    of 0 is treated as live/healthy and non-zero is
-                                    unhealthy.
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            failureThreshold:
-                              description: Minimum consecutive failures for the probe
-                                to be considered failed after having succeeded. Defaults
-                                to 3. Minimum value is 1.
-                              format: int32
-                              type: integer
-                            httpGet:
-                              description: HTTPGet specifies the http request to perform.
-                              properties:
-                                host:
-                                  description: Host name to connect to, defaults to
-                                    the pod IP. You probably want to set "Host" in
-                                    httpHeaders instead.
-                                  type: string
-                                httpHeaders:
-                                  description: Custom headers to set in the request.
-                                    HTTP allows repeated headers.
-                                  items:
-                                    description: HTTPHeader describes a custom header
-                                      to be used in HTTP probes
-                                    properties:
-                                      name:
-                                        description: The header field name
-                                        type: string
-                                      value:
-                                        description: The header field value
-                                        type: string
-                                    required:
-                                    - name
-                                    - value
-                                    type: object
-                                  type: array
-                                path:
-                                  description: Path to access on the HTTP server.
-                                  type: string
-                                port:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: Name or number of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
-                                  x-kubernetes-int-or-string: true
-                                scheme:
-                                  description: Scheme to use for connecting to the
-                                    host. Defaults to HTTP.
-                                  type: string
-                              required:
-                              - port
-                              type: object
-                            initialDelaySeconds:
-                              description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                              format: int32
-                              type: integer
-                            periodSeconds:
-                              description: How often (in seconds) to perform the probe.
-                                Default to 10 seconds. Minimum value is 1.
-                              format: int32
-                              type: integer
-                            successThreshold:
-                              description: Minimum consecutive successes for the probe
-                                to be considered successful after having failed. Defaults
-                                to 1. Must be 1 for liveness and startup. Minimum
-                                value is 1.
-                              format: int32
-                              type: integer
-                            tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
-                              properties:
-                                host:
-                                  description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
-                                  type: string
-                                port:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: Number or name of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
-                                  x-kubernetes-int-or-string: true
-                              required:
-                              - port
-                              type: object
-                            timeoutSeconds:
-                              description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                              format: int32
-                              type: integer
-                          type: object
-                        volumeMounts:
-                          description: Pod volumes to mount into the container's filesystem.
-                          items:
-                            description: VolumeMount describes a mounting of a Volume
-                              within a container.
-                            properties:
-                              mountPath:
-                                description: Path within the container at which the
-                                  volume should be mounted.  Must not contain ':'.
-                                type: string
-                              mountPropagation:
-                                description: mountPropagation determines how mounts
-                                  are propagated from the host to container and the
-                                  other way around. When not set, MountPropagationNone
-                                  is used. This field is beta in 1.10.
-                                type: string
-                              name:
-                                description: This must match the Name of a Volume.
-                                type: string
-                              readOnly:
-                                description: Mounted read-only if true, read-write
-                                  otherwise (false or unspecified). Defaults to false.
-                                type: boolean
-                              subPath:
-                                description: Path within the volume from which the
-                                  container's volume should be mounted. Defaults to
-                                  "" (volume's root).
-                                type: string
-                              subPathExpr:
-                                description: Expanded path within the volume from
-                                  which the container's volume should be mounted.
-                                  Behaves similarly to SubPath but environment variable
-                                  references $(VAR_NAME) are expanded using the container's
-                                  environment. Defaults to "" (volume's root). SubPathExpr
-                                  and SubPath are mutually exclusive.
-                                type: string
+                                  value:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - type
+                                type: object
                             required:
-                            - mountPath
-                            - name
+                              - metric
+                              - target
                             type: object
-                          type: array
-                        workingDir:
-                          description: Container's working directory.
-                          type: string
-                      required:
-                      - name
-                      type: object
-                    type: array
-                  jvmOptions:
-                    description: JvmOptions defines the Jvm options passed to the
-                      proxy
-                    properties:
-                      extraOptions:
-                        items:
-                          type: string
-                        type: array
-                      gcLoggingOptions:
-                        items:
-                          type: string
-                        type: array
-                      gcOptions:
-                        items:
-                          type: string
-                        type: array
-                      memoryOptions:
-                        items:
-                          type: string
-                        type: array
-                    required:
-                    - extraOptions
-                    - gcLoggingOptions
-                    - gcOptions
-                    - memoryOptions
-                    type: object
-                  labels:
-                    additionalProperties:
-                      type: string
-                    description: Labels specifies the labels to attach to pod the
-                      operator creates for the cluster.
-                    type: object
-                  nodeSelector:
-                    additionalProperties:
-                      type: string
-                    description: NodeSelector specifies a map of key-value pairs.
-                      For a pod to be eligible to run on a node, the node must have
-                      each of the indicated key-value pairs as labels.
-                    type: object
-                  resources:
-                    description: Resources specifies the resource requirements of
-                      a pod to run in the cluster
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                        type: object
-                    type: object
-                  secretRefs:
-                    description: SecretRefs defines how to mount required secrets
-                      into containers
-                    items:
-                      properties:
-                        mountPath:
-                          type: string
-                        secretName:
-                          type: string
-                      required:
-                      - mountPath
-                      - secretName
-                      type: object
-                    type: array
-                  securityContext:
-                    description: 'SecurityContext specifies the security context for
-                      the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
-                    properties:
-                      fsGroup:
-                        description: "A special supplemental group that applies to
-                          all containers in a pod. Some volume types allow the Kubelet
-                          to change the ownership of that volume to be owned by the
-                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                          bit is set (new files created in the volume will be owned
-                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                          \n If unset, the Kubelet will not modify the ownership and
-                          permissions of any volume."
-                        format: int64
-                        type: integer
-                      fsGroupChangePolicy:
-                        description: 'fsGroupChangePolicy defines behavior of changing
-                          ownership and permission of the volume before being exposed
-                          inside Pod. This field will only apply to volume types which
-                          support fsGroup based ownership(and permissions). It will
-                          have no effect on ephemeral volume types such as: secret,
-                          configmaps and emptydir. Valid values are "OnRootMismatch"
-                          and "Always". If not specified defaults to "Always".'
-                        type: string
-                      runAsGroup:
-                        description: The GID to run the entrypoint of the container
-                          process. Uses runtime default if unset. May also be set
-                          in SecurityContext.  If set in both SecurityContext and
-                          PodSecurityContext, the value specified in SecurityContext
-                          takes precedence for that container.
-                        format: int64
-                        type: integer
-                      runAsNonRoot:
-                        description: Indicates that the container must run as a non-root
-                          user. If true, the Kubelet will validate the image at runtime
-                          to ensure that it does not run as UID 0 (root) and fail
-                          to start the container if it does. If unset or false, no
-                          such validation will be performed. May also be set in SecurityContext.  If
-                          set in both SecurityContext and PodSecurityContext, the
-                          value specified in SecurityContext takes precedence.
-                        type: boolean
-                      runAsUser:
-                        description: The UID to run the entrypoint of the container
-                          process. Defaults to user specified in image metadata if
-                          unspecified. May also be set in SecurityContext.  If set
-                          in both SecurityContext and PodSecurityContext, the value
-                          specified in SecurityContext takes precedence for that container.
-                        format: int64
-                        type: integer
-                      seLinuxOptions:
-                        description: The SELinux context to be applied to all containers.
-                          If unspecified, the container runtime will allocate a random
-                          SELinux context for each container.  May also be set in
-                          SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                          the value specified in SecurityContext takes precedence
-                          for that container.
-                        properties:
-                          level:
-                            description: Level is SELinux level label that applies
-                              to the container.
-                            type: string
-                          role:
-                            description: Role is a SELinux role label that applies
-                              to the container.
-                            type: string
+                          resource:
+                            properties:
+                              name:
+                                type: string
+                              target:
+                                properties:
+                                  averageUtilization:
+                                    format: int32
+                                    type: integer
+                                  averageValue:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  type:
+                                    type: string
+                                  value:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - type
+                                type: object
+                            required:
+                              - name
+                              - target
+                            type: object
                           type:
-                            description: Type is a SELinux type label that applies
-                              to the container.
-                            type: string
-                          user:
-                            description: User is a SELinux user label that applies
-                              to the container.
-                            type: string
-                        type: object
-                      seccompProfile:
-                        description: The seccomp options to use by the containers
-                          in this pod.
-                        properties:
-                          localhostProfile:
-                            description: localhostProfile indicates a profile defined
-                              in a file on the node should be used. The profile must
-                              be preconfigured on the node to work. Must be a descending
-                              path, relative to the kubelet's configured seccomp profile
-                              location. Must only be set if type is "Localhost".
-                            type: string
-                          type:
-                            description: "type indicates which kind of seccomp profile
-                              will be applied. Valid options are: \n Localhost - a
-                              profile defined in a file on the node should be used.
-                              RuntimeDefault - the container runtime default profile
-                              should be used. Unconfined - no profile should be applied."
                             type: string
                         required:
-                        - type
+                          - type
                         type: object
-                      supplementalGroups:
-                        description: A list of groups applied to the first process
-                          run in each container, in addition to the container's primary
-                          GID.  If unspecified, no groups will be added to any container.
-                        items:
-                          format: int64
-                          type: integer
-                        type: array
-                      sysctls:
-                        description: Sysctls hold a list of namespaced sysctls used
-                          for the pod. Pods with unsupported sysctls (by the container
-                          runtime) might fail to launch.
-                        items:
-                          description: Sysctl defines a kernel parameter to be set
-                          properties:
-                            name:
-                              description: Name of a property to set
-                              type: string
-                            value:
-                              description: Value of a property to set
-                              type: string
-                          required:
-                          - name
-                          - value
-                          type: object
-                        type: array
-                      windowsOptions:
-                        description: The Windows specific settings applied to all
-                          containers. If unspecified, the options within a container's
-                          SecurityContext will be used. If set in both SecurityContext
-                          and PodSecurityContext, the value specified in SecurityContext
-                          takes precedence.
-                        properties:
-                          gmsaCredentialSpec:
-                            description: GMSACredentialSpec is where the GMSA admission
-                              webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                              inlines the contents of the GMSA credential spec named
-                              by the GMSACredentialSpecName field.
-                            type: string
-                          gmsaCredentialSpecName:
-                            description: GMSACredentialSpecName is the name of the
-                              GMSA credential spec to use.
-                            type: string
-                          runAsUserName:
-                            description: The UserName in Windows to run the entrypoint
-                              of the container process. Defaults to the user specified
-                              in image metadata if unspecified. May also be set in
-                              PodSecurityContext. If set in both SecurityContext and
-                              PodSecurityContext, the value specified in SecurityContext
-                              takes precedence.
-                            type: string
-                        type: object
-                    type: object
-                  serviceAccountName:
-                    description: ServiceAccountName is the name of the ServiceAccount
-                      to use to run pods.
-                    type: string
-                  sidecars:
-                    description: Sidecars defines sidecar containers running alongside
-                      with the main function container in the pod.
-                    items:
-                      description: A single application container that you want to
-                        run within a pod. The Container API from the core group is
-                        not used directly to avoid unneeded fields and reduce the
-                        size of the CRD. New fields could be added as needed.
-                      properties:
-                        args:
-                          description: Arguments to the entrypoint.
-                          items:
-                            type: string
-                          type: array
-                        command:
-                          description: Entrypoint array. Not executed within a shell.
-                          items:
-                            type: string
-                          type: array
-                        env:
-                          description: List of environment variables to set in the
-                            container.
-                          items:
-                            description: EnvVar represents an environment variable
-                              present in a Container.
-                            properties:
-                              name:
-                                description: Name of the environment variable. Must
-                                  be a C_IDENTIFIER.
-                                type: string
-                              value:
-                                description: 'Variable references $(VAR_NAME) are
-                                  expanded using the previous defined environment
-                                  variables in the container and any service environment
-                                  variables. If a variable cannot be resolved, the
-                                  reference in the input string will be unchanged.
-                                  The $(VAR_NAME) syntax can be escaped with a double
-                                  $$, ie: $$(VAR_NAME). Escaped references will never
-                                  be expanded, regardless of whether the variable
-                                  exists or not. Defaults to "".'
-                                type: string
-                              valueFrom:
-                                description: Source for the environment variable's
-                                  value. Cannot be used if value is not empty.
-                                properties:
-                                  configMapKeyRef:
-                                    description: Selects a key of a ConfigMap.
-                                    properties:
-                                      key:
-                                        description: The key to select.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the ConfigMap
-                                          or its key must be defined
-                                        type: boolean
-                                    required:
-                                    - key
-                                    type: object
-                                  fieldRef:
-                                    description: 'Selects a field of the pod: supports
-                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                      spec.serviceAccountName, status.hostIP, status.podIP,
-                                      status.podIPs.'
-                                    properties:
-                                      apiVersion:
-                                        description: Version of the schema the FieldPath
-                                          is written in terms of, defaults to "v1".
-                                        type: string
-                                      fieldPath:
-                                        description: Path of the field to select in
-                                          the specified API version.
-                                        type: string
-                                    required:
-                                    - fieldPath
-                                    type: object
-                                  resourceFieldRef:
-                                    description: 'Selects a resource of the container:
-                                      only resources limits and requests (limits.cpu,
-                                      limits.memory, limits.ephemeral-storage, requests.cpu,
-                                      requests.memory and requests.ephemeral-storage)
-                                      are currently supported.'
-                                    properties:
-                                      containerName:
-                                        description: 'Container name: required for
-                                          volumes, optional for env vars'
-                                        type: string
-                                      divisor:
-                                        anyOf:
-                                        - type: integer
-                                        - type: string
-                                        description: Specifies the output format of
-                                          the exposed resources, defaults to "1"
-                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                        x-kubernetes-int-or-string: true
-                                      resource:
-                                        description: 'Required: resource to select'
-                                        type: string
-                                    required:
-                                    - resource
-                                    type: object
-                                  secretKeyRef:
-                                    description: Selects a key of a secret in the
-                                      pod's namespace
-                                    properties:
-                                      key:
-                                        description: The key of the secret to select
-                                          from.  Must be a valid secret key.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the Secret or
-                                          its key must be defined
-                                        type: boolean
-                                    required:
-                                    - key
-                                    type: object
-                                type: object
-                            required:
-                            - name
-                            type: object
-                          type: array
-                        envFrom:
-                          description: List of sources to populate environment variables
-                            in the container.
-                          items:
-                            description: EnvFromSource represents the source of a
-                              set of ConfigMaps
-                            properties:
-                              configMapRef:
-                                description: The ConfigMap to select from
-                                properties:
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the ConfigMap must
-                                      be defined
-                                    type: boolean
-                                type: object
-                              prefix:
-                                description: An optional identifier to prepend to
-                                  each key in the ConfigMap. Must be a C_IDENTIFIER.
-                                type: string
-                              secretRef:
-                                description: The Secret to select from
-                                properties:
-                                  name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
-                                    type: string
-                                  optional:
-                                    description: Specify whether the Secret must be
-                                      defined
-                                    type: boolean
-                                type: object
-                            type: object
-                          type: array
-                        image:
-                          description: Docker image name.
-                          type: string
-                        imagePullPolicy:
-                          description: Image pull policy.
-                          type: string
-                        livenessProbe:
-                          description: Periodic probe of container liveness.
-                          properties:
-                            exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
-                              properties:
-                                command:
-                                  description: Command is the command line to execute
-                                    inside the container, the working directory for
-                                    the command  is root ('/') in the container's
-                                    filesystem. The command is simply exec'd, it is
-                                    not run inside a shell, so traditional shell instructions
-                                    ('|', etc) won't work. To use a shell, you need
-                                    to explicitly call out to that shell. Exit status
-                                    of 0 is treated as live/healthy and non-zero is
-                                    unhealthy.
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            failureThreshold:
-                              description: Minimum consecutive failures for the probe
-                                to be considered failed after having succeeded. Defaults
-                                to 3. Minimum value is 1.
-                              format: int32
-                              type: integer
-                            httpGet:
-                              description: HTTPGet specifies the http request to perform.
-                              properties:
-                                host:
-                                  description: Host name to connect to, defaults to
-                                    the pod IP. You probably want to set "Host" in
-                                    httpHeaders instead.
-                                  type: string
-                                httpHeaders:
-                                  description: Custom headers to set in the request.
-                                    HTTP allows repeated headers.
-                                  items:
-                                    description: HTTPHeader describes a custom header
-                                      to be used in HTTP probes
-                                    properties:
-                                      name:
-                                        description: The header field name
-                                        type: string
-                                      value:
-                                        description: The header field value
-                                        type: string
-                                    required:
-                                    - name
-                                    - value
-                                    type: object
-                                  type: array
-                                path:
-                                  description: Path to access on the HTTP server.
-                                  type: string
-                                port:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: Name or number of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
-                                  x-kubernetes-int-or-string: true
-                                scheme:
-                                  description: Scheme to use for connecting to the
-                                    host. Defaults to HTTP.
-                                  type: string
-                              required:
-                              - port
-                              type: object
-                            initialDelaySeconds:
-                              description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                              format: int32
-                              type: integer
-                            periodSeconds:
-                              description: How often (in seconds) to perform the probe.
-                                Default to 10 seconds. Minimum value is 1.
-                              format: int32
-                              type: integer
-                            successThreshold:
-                              description: Minimum consecutive successes for the probe
-                                to be considered successful after having failed. Defaults
-                                to 1. Must be 1 for liveness and startup. Minimum
-                                value is 1.
-                              format: int32
-                              type: integer
-                            tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
-                              properties:
-                                host:
-                                  description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
-                                  type: string
-                                port:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: Number or name of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
-                                  x-kubernetes-int-or-string: true
-                              required:
-                              - port
-                              type: object
-                            timeoutSeconds:
-                              description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                              format: int32
-                              type: integer
-                          type: object
-                        name:
-                          description: Name of the container specified as a DNS_LABEL.
-                            Each container in a pod must have a unique name (DNS_LABEL).
-                          type: string
-                        readinessProbe:
-                          description: 'Periodic probe of container service readiness.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                          properties:
-                            exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
-                              properties:
-                                command:
-                                  description: Command is the command line to execute
-                                    inside the container, the working directory for
-                                    the command  is root ('/') in the container's
-                                    filesystem. The command is simply exec'd, it is
-                                    not run inside a shell, so traditional shell instructions
-                                    ('|', etc) won't work. To use a shell, you need
-                                    to explicitly call out to that shell. Exit status
-                                    of 0 is treated as live/healthy and non-zero is
-                                    unhealthy.
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            failureThreshold:
-                              description: Minimum consecutive failures for the probe
-                                to be considered failed after having succeeded. Defaults
-                                to 3. Minimum value is 1.
-                              format: int32
-                              type: integer
-                            httpGet:
-                              description: HTTPGet specifies the http request to perform.
-                              properties:
-                                host:
-                                  description: Host name to connect to, defaults to
-                                    the pod IP. You probably want to set "Host" in
-                                    httpHeaders instead.
-                                  type: string
-                                httpHeaders:
-                                  description: Custom headers to set in the request.
-                                    HTTP allows repeated headers.
-                                  items:
-                                    description: HTTPHeader describes a custom header
-                                      to be used in HTTP probes
-                                    properties:
-                                      name:
-                                        description: The header field name
-                                        type: string
-                                      value:
-                                        description: The header field value
-                                        type: string
-                                    required:
-                                    - name
-                                    - value
-                                    type: object
-                                  type: array
-                                path:
-                                  description: Path to access on the HTTP server.
-                                  type: string
-                                port:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: Name or number of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
-                                  x-kubernetes-int-or-string: true
-                                scheme:
-                                  description: Scheme to use for connecting to the
-                                    host. Defaults to HTTP.
-                                  type: string
-                              required:
-                              - port
-                              type: object
-                            initialDelaySeconds:
-                              description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                              format: int32
-                              type: integer
-                            periodSeconds:
-                              description: How often (in seconds) to perform the probe.
-                                Default to 10 seconds. Minimum value is 1.
-                              format: int32
-                              type: integer
-                            successThreshold:
-                              description: Minimum consecutive successes for the probe
-                                to be considered successful after having failed. Defaults
-                                to 1. Must be 1 for liveness and startup. Minimum
-                                value is 1.
-                              format: int32
-                              type: integer
-                            tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
-                              properties:
-                                host:
-                                  description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
-                                  type: string
-                                port:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: Number or name of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
-                                  x-kubernetes-int-or-string: true
-                              required:
-                              - port
-                              type: object
-                            timeoutSeconds:
-                              description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                              format: int32
-                              type: integer
-                          type: object
-                        resources:
-                          description: Compute Resources required by this container.
-                          properties:
-                            limits:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                            requests:
-                              additionalProperties:
-                                anyOf:
-                                - type: integer
-                                - type: string
-                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                              type: object
-                          type: object
-                        startupProbe:
-                          description: StartupProbe indicates that the Pod has successfully
-                            initialized.
-                          properties:
-                            exec:
-                              description: One and only one of the following should
-                                be specified. Exec specifies the action to take.
-                              properties:
-                                command:
-                                  description: Command is the command line to execute
-                                    inside the container, the working directory for
-                                    the command  is root ('/') in the container's
-                                    filesystem. The command is simply exec'd, it is
-                                    not run inside a shell, so traditional shell instructions
-                                    ('|', etc) won't work. To use a shell, you need
-                                    to explicitly call out to that shell. Exit status
-                                    of 0 is treated as live/healthy and non-zero is
-                                    unhealthy.
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            failureThreshold:
-                              description: Minimum consecutive failures for the probe
-                                to be considered failed after having succeeded. Defaults
-                                to 3. Minimum value is 1.
-                              format: int32
-                              type: integer
-                            httpGet:
-                              description: HTTPGet specifies the http request to perform.
-                              properties:
-                                host:
-                                  description: Host name to connect to, defaults to
-                                    the pod IP. You probably want to set "Host" in
-                                    httpHeaders instead.
-                                  type: string
-                                httpHeaders:
-                                  description: Custom headers to set in the request.
-                                    HTTP allows repeated headers.
-                                  items:
-                                    description: HTTPHeader describes a custom header
-                                      to be used in HTTP probes
-                                    properties:
-                                      name:
-                                        description: The header field name
-                                        type: string
-                                      value:
-                                        description: The header field value
-                                        type: string
-                                    required:
-                                    - name
-                                    - value
-                                    type: object
-                                  type: array
-                                path:
-                                  description: Path to access on the HTTP server.
-                                  type: string
-                                port:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: Name or number of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
-                                  x-kubernetes-int-or-string: true
-                                scheme:
-                                  description: Scheme to use for connecting to the
-                                    host. Defaults to HTTP.
-                                  type: string
-                              required:
-                              - port
-                              type: object
-                            initialDelaySeconds:
-                              description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                              format: int32
-                              type: integer
-                            periodSeconds:
-                              description: How often (in seconds) to perform the probe.
-                                Default to 10 seconds. Minimum value is 1.
-                              format: int32
-                              type: integer
-                            successThreshold:
-                              description: Minimum consecutive successes for the probe
-                                to be considered successful after having failed. Defaults
-                                to 1. Must be 1 for liveness and startup. Minimum
-                                value is 1.
-                              format: int32
-                              type: integer
-                            tcpSocket:
-                              description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
-                              properties:
-                                host:
-                                  description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
-                                  type: string
-                                port:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: Number or name of the port to access
-                                    on the container. Number must be in the range
-                                    1 to 65535. Name must be an IANA_SVC_NAME.
-                                  x-kubernetes-int-or-string: true
-                              required:
-                              - port
-                              type: object
-                            timeoutSeconds:
-                              description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
-                              format: int32
-                              type: integer
-                          type: object
-                        volumeMounts:
-                          description: Pod volumes to mount into the container's filesystem.
-                          items:
-                            description: VolumeMount describes a mounting of a Volume
-                              within a container.
-                            properties:
-                              mountPath:
-                                description: Path within the container at which the
-                                  volume should be mounted.  Must not contain ':'.
-                                type: string
-                              mountPropagation:
-                                description: mountPropagation determines how mounts
-                                  are propagated from the host to container and the
-                                  other way around. When not set, MountPropagationNone
-                                  is used. This field is beta in 1.10.
-                                type: string
-                              name:
-                                description: This must match the Name of a Volume.
-                                type: string
-                              readOnly:
-                                description: Mounted read-only if true, read-write
-                                  otherwise (false or unspecified). Defaults to false.
-                                type: boolean
-                              subPath:
-                                description: Path within the volume from which the
-                                  container's volume should be mounted. Defaults to
-                                  "" (volume's root).
-                                type: string
-                              subPathExpr:
-                                description: Expanded path within the volume from
-                                  which the container's volume should be mounted.
-                                  Behaves similarly to SubPath but environment variable
-                                  references $(VAR_NAME) are expanded using the container's
-                                  environment. Defaults to "" (volume's root). SubPathExpr
-                                  and SubPath are mutually exclusive.
-                                type: string
-                            required:
-                            - mountPath
-                            - name
-                            type: object
-                          type: array
-                        workingDir:
-                          description: Container's working directory.
-                          type: string
-                      required:
-                      - name
-                      type: object
-                    type: array
-                  terminationGracePeriodSeconds:
-                    description: TerminationGracePeriodSeconds is the amount of time
-                      that kubernetes will give for a pod before terminating it.
-                    format: int64
-                    type: integer
-                  tolerations:
-                    description: Tolerations specifies the tolerations of a Pod
-                    items:
-                      description: The pod this Toleration is attached to tolerates
-                        any taint that matches the triple <key,value,effect> using
-                        the matching operator <operator>.
-                      properties:
-                        effect:
-                          description: Effect indicates the taint effect to match.
-                            Empty means match all taint effects. When specified, allowed
-                            values are NoSchedule, PreferNoSchedule and NoExecute.
-                          type: string
-                        key:
-                          description: Key is the taint key that the toleration applies
-                            to. Empty means match all taint keys. If the key is empty,
-                            operator must be Exists; this combination means to match
-                            all values and all keys.
-                          type: string
-                        operator:
-                          description: Operator represents a key's relationship to
-                            the value. Valid operators are Exists and Equal. Defaults
-                            to Equal. Exists is equivalent to wildcard for value,
-                            so that a pod can tolerate all taints of a particular
-                            category.
-                          type: string
-                        tolerationSeconds:
-                          description: TolerationSeconds represents the period of
-                            time the toleration (which must be of effect NoExecute,
-                            otherwise this field is ignored) tolerates the taint.
-                            By default, it is not set, which means tolerate the taint
-                            forever (do not evict). Zero and negative values will
-                            be treated as 0 (evict immediately) by the system.
-                          format: int64
-                          type: integer
-                        value:
-                          description: Value is the taint value the toleration matches
-                            to. If the operator is Exists, the value should be empty,
-                            otherwise just a regular string.
-                          type: string
-                      type: object
-                    type: array
-                  vars:
-                    description: Vars specifies the environment variables of a Pod
-                    items:
-                      description: EnvVar represents an environment variable present
-                        in a Container.
-                      properties:
-                        name:
-                          description: Name of the environment variable. Must be a
-                            C_IDENTIFIER.
-                          type: string
-                        value:
-                          description: 'Variable references $(VAR_NAME) are expanded
-                            using the previous defined environment variables in the
-                            container and any service environment variables. If a
-                            variable cannot be resolved, the reference in the input
-                            string will be unchanged. The $(VAR_NAME) syntax can be
-                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                            will never be expanded, regardless of whether the variable
-                            exists or not. Defaults to "".'
-                          type: string
-                        valueFrom:
-                          description: Source for the environment variable's value.
-                            Cannot be used if value is not empty.
-                          properties:
-                            configMapKeyRef:
-                              description: Selects a key of a ConfigMap.
-                              properties:
-                                key:
-                                  description: The key to select.
-                                  type: string
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the ConfigMap or its
-                                    key must be defined
-                                  type: boolean
-                              required:
-                              - key
-                              type: object
-                            fieldRef:
-                              description: 'Selects a field of the pod: supports metadata.name,
-                                metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                spec.serviceAccountName, status.hostIP, status.podIP,
-                                status.podIPs.'
-                              properties:
-                                apiVersion:
-                                  description: Version of the schema the FieldPath
-                                    is written in terms of, defaults to "v1".
-                                  type: string
-                                fieldPath:
-                                  description: Path of the field to select in the
-                                    specified API version.
-                                  type: string
-                              required:
-                              - fieldPath
-                              type: object
-                            resourceFieldRef:
-                              description: 'Selects a resource of the container: only
-                                resources limits and requests (limits.cpu, limits.memory,
-                                limits.ephemeral-storage, requests.cpu, requests.memory
-                                and requests.ephemeral-storage) are currently supported.'
-                              properties:
-                                containerName:
-                                  description: 'Container name: required for volumes,
-                                    optional for env vars'
-                                  type: string
-                                divisor:
-                                  anyOf:
-                                  - type: integer
-                                  - type: string
-                                  description: Specifies the output format of the
-                                    exposed resources, defaults to "1"
-                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                                  x-kubernetes-int-or-string: true
-                                resource:
-                                  description: 'Required: resource to select'
-                                  type: string
-                              required:
-                              - resource
-                              type: object
-                            secretKeyRef:
-                              description: Selects a key of a secret in the pod's
-                                namespace
-                              properties:
-                                key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
-                                  type: string
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
-                                  type: string
-                                optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
-                                  type: boolean
-                              required:
-                              - key
-                              type: object
-                          type: object
-                      required:
-                      - name
-                      type: object
-                    type: array
-                  volumes:
-                    description: Volumes defines extra volumes of the pod.
-                    items:
-                      description: Volume represents a named volume in a pod that
-                        may be accessed by any container in the pod. The Volume API
-                        from the core group is not used directly to avoid unneeded
-                        fields defined in `VolumeSource` and reduce the size of the
-                        CRD. New fields in VolumeSource could be added as needed.
-                      properties:
-                        configMap:
-                          description: ConfigMap represents a configMap that should
-                            populate this volume
-                          properties:
-                            defaultMode:
-                              description: 'Optional: mode bits used to set permissions
-                                on created files by default. Must be an octal value
-                                between 0000 and 0777 or a decimal value between 0
-                                and 511. YAML accepts both octal and decimal values,
-                                JSON requires decimal values for mode bits. Defaults
-                                to 0644. Directories within the path are not affected
-                                by this setting. This might be in conflict with other
-                                options that affect the file mode, like fsGroup, and
-                                the result can be other mode bits set.'
-                              format: int32
-                              type: integer
-                            items:
-                              description: If unspecified, each key-value pair in
-                                the Data field of the referenced ConfigMap will be
-                                projected into the volume as a file whose name is
-                                the key and content is the value. If specified, the
-                                listed keys will be projected into the specified paths,
-                                and unlisted keys will not be present. If a key is
-                                specified which is not present in the ConfigMap, the
-                                volume setup will error unless it is marked optional.
-                                Paths must be relative and may not contain the '..'
-                                path or start with '..'.
-                              items:
-                                description: Maps a string key to a path within a
-                                  volume.
-                                properties:
-                                  key:
-                                    description: The key to project.
-                                    type: string
-                                  mode:
-                                    description: 'Optional: mode bits used to set
-                                      permissions on this file. Must be an octal value
-                                      between 0000 and 0777 or a decimal value between
-                                      0 and 511. YAML accepts both octal and decimal
-                                      values, JSON requires decimal values for mode
-                                      bits. If not specified, the volume defaultMode
-                                      will be used. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    description: The relative path of the file to
-                                      map the key to. May not be an absolute path.
-                                      May not contain the path element '..'. May not
-                                      start with the string '..'.
-                                    type: string
-                                required:
-                                - key
-                                - path
-                                type: object
-                              type: array
-                            name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
-                              type: string
-                            optional:
-                              description: Specify whether the ConfigMap or its keys
-                                must be defined
-                              type: boolean
-                          type: object
-                        name:
-                          description: 'Volume''s name. Must be a DNS_LABEL and unique
-                            within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                          type: string
-                        secret:
-                          description: Secret represents a secret that should populate
-                            this volume.
-                          properties:
-                            defaultMode:
-                              description: 'Optional: mode bits used to set permissions
-                                on created files by default. Must be an octal value
-                                between 0000 and 0777 or a decimal value between 0
-                                and 511. YAML accepts both octal and decimal values,
-                                JSON requires decimal values for mode bits. Defaults
-                                to 0644. Directories within the path are not affected
-                                by this setting. This might be in conflict with other
-                                options that affect the file mode, like fsGroup, and
-                                the result can be other mode bits set.'
-                              format: int32
-                              type: integer
-                            items:
-                              description: If unspecified, each key-value pair in
-                                the Data field of the referenced Secret will be projected
-                                into the volume as a file whose name is the key and
-                                content is the value. If specified, the listed keys
-                                will be projected into the specified paths, and unlisted
-                                keys will not be present. If a key is specified which
-                                is not present in the Secret, the volume setup will
-                                error unless it is marked optional. Paths must be
-                                relative and may not contain the '..' path or start
-                                with '..'.
-                              items:
-                                description: Maps a string key to a path within a
-                                  volume.
-                                properties:
-                                  key:
-                                    description: The key to project.
-                                    type: string
-                                  mode:
-                                    description: 'Optional: mode bits used to set
-                                      permissions on this file. Must be an octal value
-                                      between 0000 and 0777 or a decimal value between
-                                      0 and 511. YAML accepts both octal and decimal
-                                      values, JSON requires decimal values for mode
-                                      bits. If not specified, the volume defaultMode
-                                      will be used. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
-                                    format: int32
-                                    type: integer
-                                  path:
-                                    description: The relative path of the file to
-                                      map the key to. May not be an absolute path.
-                                      May not contain the path element '..'. May not
-                                      start with the string '..'.
-                                    type: string
-                                required:
-                                - key
-                                - path
-                                type: object
-                              type: array
-                            optional:
-                              description: Specify whether the Secret or its keys
-                                must be defined
-                              type: boolean
-                            secretName:
-                              description: 'Name of the secret in the pod''s namespace
-                                to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                              type: string
-                          type: object
-                      required:
-                      - name
-                      type: object
-                    type: array
-                type: object
-              replicas:
-                description: Replicas is the expected size of the pulsar proxy
-                format: int32
-                type: integer
-              webSocketServiceEnabled:
-                description: WebSocketServiceEnabled defines whether WebSocket will
-                  be enabled
-                type: boolean
-            required:
-            - brokerAddress
-            - dnsNames
-            - issuerRef
-            type: object
-          status:
-            description: PulsarProxyStatus defines the observed state of PulsarProxy
-            properties:
-              conditions:
-                additionalProperties:
-                  description: The `Status` of a given `Condition` and the `Action`
-                    needed to reach the `Status`
+                      type: array
+                    minReplicas:
+                      format: int32
+                      type: integer
+                  required:
+                    - maxReplicas
+                  type: object
+                brokerAddress:
+                  type: string
+                certSecretName:
+                  type: string
+                config:
                   properties:
-                    action:
-                      description: The action needed to advance components to ready
-                        status
+                    clusterName:
                       type: string
-                    condition:
+                    custom:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    prometheusPlugin:
+                      properties:
+                        host:
+                          type: string
+                      type: object
+                    tls:
+                      properties:
+                        certSecretName:
+                          type: string
+                        enabled:
+                          type: boolean
+                        trustCertsEnabled:
+                          type: boolean
+                      type: object
+                  type: object
+                configs:
+                  additionalProperties:
+                    type: string
+                  type: object
+                configurationStoreServers:
+                  type: string
+                dnsNames:
+                  items:
+                    type: string
+                  type: array
+                image:
+                  type: string
+                imagePullPolicy:
+                  type: string
+                issuerRef:
+                  properties:
+                    group:
                       type: string
-                    status:
+                    kind:
+                      type: string
+                    name:
                       type: string
                   required:
-                  - action
-                  - condition
-                  - status
+                    - name
                   type: object
-                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                  of cluster Important: Run "make" to regenerate code after modifying
-                  this file'
-                type: object
-              labelSelector:
-                description: Label selector for scaling
-                type: string
-              observedGeneration:
-                description: ObservedGeneration is the most recent generation observed
-                  for this cluster. It corresponds to the metadata generation, which
-                  is updated on mutation by the API Server.
-                format: int64
-                type: integer
-              readyReplicas:
-                description: ReadyReplicas is the number of ready servers in the cluster
-                format: int32
-                type: integer
-              replicas:
-                description: Replicas is the number of servers in the cluster
-                format: int32
-                type: integer
-              updatedReplicas:
-                description: UpdatedReplicas is the number of servers that has been
-                  updated to the latest configuration
-                format: int32
-                type: integer
-            required:
-            - conditions
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      scale:
-        labelSelectorPath: .status.labelSelector
-        specReplicasPath: .spec.replicas
-        statusReplicasPath: .status.replicas
-      status: {}
+                labels:
+                  additionalProperties:
+                    type: string
+                  type: object
+                pod:
+                  properties:
+                    affinity:
+                      properties:
+                        nodeAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  preference:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - preference
+                                  - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              properties:
+                                nodeSelectorTerms:
+                                  items:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                  type: array
+                              required:
+                                - nodeSelectorTerms
+                              type: object
+                          type: object
+                        podAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  podAffinityTerm:
+                                    properties:
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  podAffinityTerm:
+                                    properties:
+                                      labelSelector:
+                                        properties:
+                                          matchExpressions:
+                                            items:
+                                              properties:
+                                                key:
+                                                  type: string
+                                                operator:
+                                                  type: string
+                                                values:
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            type: object
+                                        type: object
+                                      namespaces:
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              items:
+                                properties:
+                                  labelSelector:
+                                    properties:
+                                      matchExpressions:
+                                        items:
+                                          properties:
+                                            key:
+                                              type: string
+                                            operator:
+                                              type: string
+                                            values:
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        type: object
+                                    type: object
+                                  namespaces:
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    debug:
+                      type: boolean
+                    initContainers:
+                      items:
+                        properties:
+                          args:
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    configMapKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                    fieldRef:
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        fieldPath:
+                                          type: string
+                                      required:
+                                        - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      properties:
+                                        containerName:
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          type: string
+                                      required:
+                                        - resource
+                                      type: object
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                  type: object
+                              required:
+                                - name
+                              type: object
+                            type: array
+                          envFrom:
+                            items:
+                              properties:
+                                configMapRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  type: string
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            type: string
+                          imagePullPolicy:
+                            type: string
+                          livenessProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                        - name
+                                        - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    type: string
+                                required:
+                                  - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            type: string
+                          readinessProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                        - name
+                                        - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    type: string
+                                required:
+                                  - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          startupProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                        - name
+                                        - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    type: string
+                                required:
+                                  - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                          volumeMounts:
+                            items:
+                              properties:
+                                mountPath:
+                                  type: string
+                                mountPropagation:
+                                  type: string
+                                name:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                subPath:
+                                  type: string
+                                subPathExpr:
+                                  type: string
+                              required:
+                                - mountPath
+                                - name
+                              type: object
+                            type: array
+                          workingDir:
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    jvmOptions:
+                      properties:
+                        extraOptions:
+                          items:
+                            type: string
+                          type: array
+                        gcLoggingOptions:
+                          items:
+                            type: string
+                          type: array
+                        gcOptions:
+                          items:
+                            type: string
+                          type: array
+                        memoryOptions:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                        - extraOptions
+                        - gcLoggingOptions
+                        - gcOptions
+                        - memoryOptions
+                      type: object
+                    labels:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      type: object
+                    resources:
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          type: object
+                      type: object
+                    secretRefs:
+                      items:
+                        properties:
+                          mountPath:
+                            type: string
+                          secretName:
+                            type: string
+                        required:
+                          - mountPath
+                          - secretName
+                        type: object
+                      type: array
+                    securityContext:
+                      properties:
+                        fsGroup:
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          type: string
+                        runAsGroup:
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          type: boolean
+                        runAsUser:
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          properties:
+                            level:
+                              type: string
+                            role:
+                              type: string
+                            type:
+                              type: string
+                            user:
+                              type: string
+                          type: object
+                        seccompProfile:
+                          properties:
+                            localhostProfile:
+                              type: string
+                            type:
+                              type: string
+                          required:
+                            - type
+                          type: object
+                        supplementalGroups:
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                        sysctls:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                              - name
+                              - value
+                            type: object
+                          type: array
+                        windowsOptions:
+                          properties:
+                            gmsaCredentialSpec:
+                              type: string
+                            gmsaCredentialSpecName:
+                              type: string
+                            runAsUserName:
+                              type: string
+                          type: object
+                      type: object
+                    serviceAccountName:
+                      type: string
+                    sidecars:
+                      items:
+                        properties:
+                          args:
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            items:
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                                valueFrom:
+                                  properties:
+                                    configMapKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                    fieldRef:
+                                      properties:
+                                        apiVersion:
+                                          type: string
+                                        fieldPath:
+                                          type: string
+                                      required:
+                                        - fieldPath
+                                      type: object
+                                    resourceFieldRef:
+                                      properties:
+                                        containerName:
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                            - type: integer
+                                            - type: string
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          type: string
+                                      required:
+                                        - resource
+                                      type: object
+                                    secretKeyRef:
+                                      properties:
+                                        key:
+                                          type: string
+                                        name:
+                                          type: string
+                                        optional:
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                  type: object
+                              required:
+                                - name
+                              type: object
+                            type: array
+                          envFrom:
+                            items:
+                              properties:
+                                configMapRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                                prefix:
+                                  type: string
+                                secretRef:
+                                  properties:
+                                    name:
+                                      type: string
+                                    optional:
+                                      type: boolean
+                                  type: object
+                              type: object
+                            type: array
+                          image:
+                            type: string
+                          imagePullPolicy:
+                            type: string
+                          livenessProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                        - name
+                                        - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    type: string
+                                required:
+                                  - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                          name:
+                            type: string
+                          readinessProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                        - name
+                                        - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    type: string
+                                required:
+                                  - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                          resources:
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                    - type: integer
+                                    - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                type: object
+                            type: object
+                          startupProbe:
+                            properties:
+                              exec:
+                                properties:
+                                  command:
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              failureThreshold:
+                                format: int32
+                                type: integer
+                              httpGet:
+                                properties:
+                                  host:
+                                    type: string
+                                  httpHeaders:
+                                    items:
+                                      properties:
+                                        name:
+                                          type: string
+                                        value:
+                                          type: string
+                                      required:
+                                        - name
+                                        - value
+                                      type: object
+                                    type: array
+                                  path:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                  scheme:
+                                    type: string
+                                required:
+                                  - port
+                                type: object
+                              initialDelaySeconds:
+                                format: int32
+                                type: integer
+                              periodSeconds:
+                                format: int32
+                                type: integer
+                              successThreshold:
+                                format: int32
+                                type: integer
+                              tcpSocket:
+                                properties:
+                                  host:
+                                    type: string
+                                  port:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    x-kubernetes-int-or-string: true
+                                required:
+                                  - port
+                                type: object
+                              timeoutSeconds:
+                                format: int32
+                                type: integer
+                            type: object
+                          volumeMounts:
+                            items:
+                              properties:
+                                mountPath:
+                                  type: string
+                                mountPropagation:
+                                  type: string
+                                name:
+                                  type: string
+                                readOnly:
+                                  type: boolean
+                                subPath:
+                                  type: string
+                                subPathExpr:
+                                  type: string
+                              required:
+                                - mountPath
+                                - name
+                              type: object
+                            type: array
+                          workingDir:
+                            type: string
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    terminationGracePeriodSeconds:
+                      format: int64
+                      type: integer
+                    tolerations:
+                      items:
+                        properties:
+                          effect:
+                            type: string
+                          key:
+                            type: string
+                          operator:
+                            type: string
+                          tolerationSeconds:
+                            format: int64
+                            type: integer
+                          value:
+                            type: string
+                        type: object
+                      type: array
+                    vars:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                          value:
+                            type: string
+                          valueFrom:
+                            properties:
+                              configMapKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                              fieldRef:
+                                properties:
+                                  apiVersion:
+                                    type: string
+                                  fieldPath:
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                              resourceFieldRef:
+                                properties:
+                                  containerName:
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                              secretKeyRef:
+                                properties:
+                                  key:
+                                    type: string
+                                  name:
+                                    type: string
+                                  optional:
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    volumes:
+                      items:
+                        properties:
+                          configMap:
+                            properties:
+                              defaultMode:
+                                format: int32
+                                type: integer
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                              name:
+                                type: string
+                              optional:
+                                type: boolean
+                            type: object
+                          name:
+                            type: string
+                          secret:
+                            properties:
+                              defaultMode:
+                                format: int32
+                                type: integer
+                              items:
+                                items:
+                                  properties:
+                                    key:
+                                      type: string
+                                    mode:
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                              optional:
+                                type: boolean
+                              secretName:
+                                type: string
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                  type: object
+                replicas:
+                  format: int32
+                  type: integer
+                webSocketServiceEnabled:
+                  type: boolean
+              required:
+                - brokerAddress
+                - dnsNames
+                - issuerRef
+              type: object
+            status:
+              properties:
+                conditions:
+                  additionalProperties:
+                    properties:
+                      action:
+                        type: string
+                      condition:
+                        type: string
+                      status:
+                        type: string
+                    required:
+                      - action
+                      - condition
+                      - status
+                    type: object
+                  type: object
+                labelSelector:
+                  type: string
+                observedGeneration:
+                  format: int64
+                  type: integer
+                readyReplicas:
+                  format: int32
+                  type: integer
+                replicas:
+                  format: int32
+                  type: integer
+                updatedReplicas:
+                  format: int32
+                  type: integer
+              required:
+                - conditions
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        scale:
+          labelSelectorPath: .status.labelSelector
+          specReplicasPath: .spec.replicas
+          statusReplicasPath: .status.replicas
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/charts/pulsar-operator/crds/zookeeper.streamnative.io_zookeeperclusters.yaml
+++ b/charts/pulsar-operator/crds/zookeeper.streamnative.io_zookeeperclusters.yaml
@@ -36,75 +36,44 @@ spec:
       name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: ZooKeeperCluster is the Schema for the zookeeperclusters API
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
             spec:
-              description: ZooKeeperClusterSpec defines the desired state of ZooKeeperCluster
               properties:
                 advancedOptions:
-                  description: AdvancedOptions contains advancedOptions for additional
-                    customization the pod
                   properties:
                     customStartupCommand:
-                      description: CustomStartupCommand defines a custom command to
-                        use for starting up
                       type: string
                     staticServerList:
-                      description: StaticServerList defines a list of static servers
-                        to be used in the zookeeper config. this overrides the default
-                        generated list of servers
                       properties:
                         servers:
-                          description: Servers is the list of zookeeper servers used
                           items:
                             properties:
                               clientAddress:
-                                description: ClientAddress is the address to bind for
-                                  client connections, defaults to `0.0.0.0`
                                 type: string
                               id:
-                                description: ID is the id of this server
                                 type: integer
                               listeners:
-                                description: Listeners is an array of listeners, must
-                                  have at least one listener
                                 items:
                                   properties:
                                     electionPort:
-                                      description: ElectionPort is the port for connecting
-                                        to leader, defaults to 3888
                                       type: integer
                                     followerPort:
-                                      description: FollowerPort is the port for connecting
-                                        to leader, defaults to 2888
                                       type: integer
                                     hostname:
-                                      description: Hostname is the name of the listener
                                       type: string
                                     role:
-                                      description: Role is the type of node this is,
-                                        options are participant or observer, defaults
-                                        to participant
                                       type: string
                                   required:
                                     - hostname
                                   type: object
                                 type: array
                               port:
-                                description: ClientPort is the port to bind for client
-                                  connections, defaults to `2181`
                                 type: integer
                             required:
                               - id
@@ -116,181 +85,114 @@ spec:
                       type: object
                   type: object
                 apiObjects:
-                  description: APIObjects allows precise control over how components
-                    (services, statefulset and so on) should be managed
                   properties:
                     clientService:
-                      description: ClientService defines the Zookeeper Client Service
-                        resource template.
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata used to customize
-                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels of the resource.
                               type: object
                             name:
-                              description: Name of the resource within a namespace.
-                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
-                          description: UpdatePolicy defines which field to update.
                           items:
-                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     configMap:
-                      description: ConfigMap defines the configmap resource template.
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata used to customize
-                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels of the resource.
                               type: object
                             name:
-                              description: Name of the resource within a namespace.
-                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
-                          description: UpdatePolicy defines which field to update.
                           items:
-                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     headlessService:
-                      description: HeadlessService defines the Zookeeper Headless Service
-                        resource template.
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata used to customize
-                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels of the resource.
                               type: object
                             name:
-                              description: Name of the resource within a namespace.
-                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
-                          description: UpdatePolicy defines which field to update.
                           items:
-                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     pdb:
-                      description: PDB defines the podDisruptionBudget resource template.
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata used to customize
-                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels of the resource.
                               type: object
                             name:
-                              description: Name of the resource within a namespace.
-                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
-                          description: UpdatePolicy defines which field to update.
                           items:
-                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     statefulSet:
-                      description: StatefulSet defines the Zookeeper Cluster Statefulset
-                        resource template.
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata used to customize
-                          the name, labels, annotations of the object. More info:
-                          https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels of the resource.
                               type: object
                             name:
-                              description: Name of the resource within a namespace.
-                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
-                          description: UpdatePolicy defines which field to update.
                           items:
-                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                         volumeClaimTemplates:
-                          description: VolumeClaimTemplates is a list of claims that
-                            pods are allowed to reference. If a non-empty list is specified,
-                            the original values in the desired STS will be replaced.
                           items:
-                            description: PersistentVolumeClaim is a user's request for
-                              and claim to a persistent volume
                             properties:
                               apiVersion:
-                                description: 'APIVersion defines the versioned schema
-                                of this representation of an object. Servers should
-                                convert recognized schemas to the latest internal
-                                value, and may reject unrecognized values. More info:
-                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                                 type: string
                               kind:
-                                description: 'Kind is a string value representing the
-                                REST resource this object represents. Servers may
-                                infer this from the endpoint the client submits requests
-                                to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                 type: string
                               metadata:
-                                description: 'Standard object''s metadata. More info:
-                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                                 properties:
                                   annotations:
                                     additionalProperties:
@@ -310,55 +212,24 @@ spec:
                                     type: string
                                 type: object
                               spec:
-                                description: 'Spec defines the desired characteristics
-                                of a volume requested by a pod author. More info:
-                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                 properties:
                                   accessModes:
-                                    description: 'AccessModes contains the desired access
-                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                     items:
                                       type: string
                                     type: array
                                   dataSource:
-                                    description: 'This field can be used to specify
-                                    either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                                    - Beta) * An existing PVC (PersistentVolumeClaim)
-                                    * An existing custom resource/object that implements
-                                    data population (Alpha) In order to use VolumeSnapshot
-                                    object types, the appropriate feature gate must
-                                    be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
-                                    If the provisioner or an external controller can
-                                    support the specified data source, it will create
-                                    a new volume based on the contents of the specified
-                                    data source. If the specified data source is not
-                                    supported, the volume will not be created and
-                                    the failure will be reported as an event. In the
-                                    future, we plan to support more data source types
-                                    and the behavior of the provisioner may change.'
                                     properties:
                                       apiGroup:
-                                        description: APIGroup is the group for the resource
-                                          being referenced. If APIGroup is not specified,
-                                          the specified Kind must be in the core API
-                                          group. For any other third-party types, APIGroup
-                                          is required.
                                         type: string
                                       kind:
-                                        description: Kind is the type of resource being
-                                          referenced
                                         type: string
                                       name:
-                                        description: Name is the name of resource being
-                                          referenced
                                         type: string
                                     required:
                                       - kind
                                       - name
                                     type: object
                                   resources:
-                                    description: 'Resources represents the minimum resources
-                                    the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -367,8 +238,6 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount
-                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -377,46 +246,18 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                        amount of compute resources required. If Requests
-                                        is omitted for a container, it defaults to
-                                        Limits if that is explicitly specified, otherwise
-                                        to an implementation-defined value. More info:
-                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   selector:
-                                    description: A label query over volumes to consider
-                                      for binding.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -428,37 +269,18 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   storageClassName:
-                                    description: 'Name of the StorageClass required
-                                    by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                     type: string
                                   volumeMode:
-                                    description: volumeMode defines what type of volume
-                                      is required by the claim. Value of Filesystem
-                                      is implied when not included in claim spec.
                                     type: string
                                   volumeName:
-                                    description: VolumeName is the binding reference
-                                      to the PersistentVolume backing this claim.
                                     type: string
                                 type: object
                               status:
-                                description: 'Status represents the current information/status
-                                of a persistent volume claim. Read-only. More info:
-                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                 properties:
                                   accessModes:
-                                    description: 'AccessModes contains the actual access
-                                    modes the volume backing the PVC has. More info:
-                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                     items:
                                       type: string
                                     type: array
@@ -469,43 +291,23 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
-                                    description: Represents the actual resources of
-                                      the underlying volume.
                                     type: object
                                   conditions:
-                                    description: Current Condition of persistent volume
-                                      claim. If underlying persistent volume is being
-                                      resized then the Condition will be set to 'ResizeStarted'.
                                     items:
-                                      description: PersistentVolumeClaimCondition contails
-                                        details about state of pvc
                                       properties:
                                         lastProbeTime:
-                                          description: Last time we probed the condition.
                                           format: date-time
                                           type: string
                                         lastTransitionTime:
-                                          description: Last time the condition transitioned
-                                            from one status to another.
                                           format: date-time
                                           type: string
                                         message:
-                                          description: Human-readable message indicating
-                                            details about last transition.
                                           type: string
                                         reason:
-                                          description: Unique, this should be a short,
-                                            machine understandable string that gives
-                                            the reason for condition's last transition.
-                                            If it reports "ResizeStarted" that means
-                                            the underlying persistent volume is being
-                                            resized.
                                           type: string
                                         status:
                                           type: string
                                         type:
-                                          description: PersistentVolumeClaimConditionType
-                                            is a valid value of PersistentVolumeClaimCondition.Type
                                           type: string
                                       required:
                                         - status
@@ -513,50 +315,24 @@ spec:
                                       type: object
                                     type: array
                                   phase:
-                                    description: Phase represents the current phase
-                                      of PersistentVolumeClaim.
                                     type: string
                                 type: object
                             type: object
                           type: array
                         volumeMounts:
-                          description: VolumeMounts is a list of volumes to mount into
-                            the container's filesystem. If a non-empty list is specified,
-                            the original values of the main container in the desired
-                            STS will be replaced.
                           items:
-                            description: VolumeMount describes a mounting of a Volume
-                              within a container.
                             properties:
                               mountPath:
-                                description: Path within the container at which the
-                                  volume should be mounted.  Must not contain ':'.
                                 type: string
                               mountPropagation:
-                                description: mountPropagation determines how mounts
-                                  are propagated from the host to container and the
-                                  other way around. When not set, MountPropagationNone
-                                  is used. This field is beta in 1.10.
                                 type: string
                               name:
-                                description: This must match the Name of a Volume.
                                 type: string
                               readOnly:
-                                description: Mounted read-only if true, read-write otherwise
-                                  (false or unspecified). Defaults to false.
                                 type: boolean
                               subPath:
-                                description: Path within the volume from which the container's
-                                  volume should be mounted. Defaults to "" (volume's
-                                  root).
                                 type: string
                               subPathExpr:
-                                description: Expanded path within the volume from which
-                                  the container's volume should be mounted. Behaves
-                                  similarly to SubPath but environment variable references
-                                  $(VAR_NAME) are expanded using the container's environment.
-                                  Defaults to "" (volume's root). SubPathExpr and SubPath
-                                  are mutually exclusive.
                                 type: string
                             required:
                               - mountPath
@@ -566,148 +342,76 @@ spec:
                       type: object
                   type: object
                 conf:
-                  description: 'Conf defines the zookeeper configuration. It will be
-                  used for generating the configuration file used by zookeeper process.
-                  Deprecated: use `config`'
                   properties:
                     custom:
                       additionalProperties:
                         type: string
-                      description: Custom accepts other configurations
                       type: object
                     globalOutstandingLimit:
-                      description: "GlobalOutstandingLimit limits the number of queued
-                      outstanding requests \n The default value is 100000"
                       type: integer
                     initLimit:
-                      description: "InitLimit is the number of ticks that the initial
-                      synchronization phase can take. \n The default value is 10."
                       type: integer
                     maxClientCnxns:
-                      description: "MaxClientCnxns limits the maximum number of client
-                      connections. \n The default value is 1000"
                       type: integer
                     serverCnxnFactory:
-                      description: "ServerCnxnFactory is the ServerCnxnFactory implementation.
-                      \n The default value is org.apache.zookeeper.server.NettyServerCnxnFactory"
                       type: string
                     snapCount:
-                      description: "SnapCount is the number of transactions recorded
-                      in the transaction log before a snapshot can be taken. \n The
-                      default value is 1000000"
                       type: integer
                     syncLimit:
-                      description: "SyncLimit is the number of ticks that can pass between
-                      sending a request and getting an acknowledgement \n The default
-                      value is 5."
                       type: integer
                     tickTime:
-                      description: "TickTime is the number of milliseconds of each tick.
-                      A tick is the basic time unit used by ZooKeeper, as measured
-                      in milliseconds \n The default value is 2000."
                       type: integer
                   type: object
                 config:
-                  description: Config defines the zookeeper configuration
                   properties:
                     custom:
                       additionalProperties:
                         type: string
-                      description: Custom accepts other configurations
                       type: object
                     globalOutstandingLimit:
-                      description: "GlobalOutstandingLimit limits the number of queued
-                      outstanding requests \n The default value is 100000"
                       type: integer
                     initLimit:
-                      description: "InitLimit is the number of ticks that the initial
-                      synchronization phase can take. \n The default value is 10."
                       type: integer
                     maxClientCnxns:
-                      description: "MaxClientCnxns limits the maximum number of client
-                      connections. \n The default value is 1000"
                       type: integer
                     serverCnxnFactory:
-                      description: "ServerCnxnFactory is the ServerCnxnFactory implementation.
-                      \n The default value is org.apache.zookeeper.server.NettyServerCnxnFactory"
                       type: string
                     snapCount:
-                      description: "SnapCount is the number of transactions recorded
-                      in the transaction log before a snapshot can be taken. \n The
-                      default value is 1000000"
                       type: integer
                     syncLimit:
-                      description: "SyncLimit is the number of ticks that can pass between
-                      sending a request and getting an acknowledgement \n The default
-                      value is 5."
                       type: integer
                     tickTime:
-                      description: "TickTime is the number of milliseconds of each tick.
-                      A tick is the basic time unit used by ZooKeeper, as measured
-                      in milliseconds \n The default value is 2000."
                       type: integer
                   type: object
                 image:
-                  description: Image is the container image used to run zookeeper pods.
-                    default is apachepulsar/pulsar:latest
                   type: string
                 imagePullPolicy:
-                  description: Image pull policy, one of Always, Never, IfNotPresent,
-                    default to Always.
                   type: string
                 labels:
                   additionalProperties:
                     type: string
-                  description: Labels specifies the labels to attach to the stateful
-                    set the operator creates for the zookeeper cluster.
                   type: object
                 persistence:
-                  description: Persistence defines the persistent volume used for the
-                    zookeeper pod
                   properties:
                     data:
-                      description: Data is the spec to define the data PVC for the container
                       properties:
                         accessModes:
-                          description: 'AccessModes contains the desired access modes
-                          the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                           items:
                             type: string
                           type: array
                         dataSource:
-                          description: 'This field can be used to specify either: *
-                          An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                          - Beta) * An existing PVC (PersistentVolumeClaim) * An existing
-                          custom resource/object that implements data population (Alpha)
-                          In order to use VolumeSnapshot object types, the appropriate
-                          feature gate must be enabled (VolumeSnapshotDataSource or
-                          AnyVolumeDataSource) If the provisioner or an external controller
-                          can support the specified data source, it will create a
-                          new volume based on the contents of the specified data source.
-                          If the specified data source is not supported, the volume
-                          will not be created and the failure will be reported as
-                          an event. In the future, we plan to support more data source
-                          types and the behavior of the provisioner may change.'
                           properties:
                             apiGroup:
-                              description: APIGroup is the group for the resource being
-                                referenced. If APIGroup is not specified, the specified
-                                Kind must be in the core API group. For any other third-party
-                                types, APIGroup is required.
                               type: string
                             kind:
-                              description: Kind is the type of resource being referenced
                               type: string
                             name:
-                              description: Name is the name of resource being referenced
                               type: string
                           required:
                             - kind
                             - name
                           type: object
                         resources:
-                          description: 'Resources represents the minimum resources the
-                          volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                           properties:
                             limits:
                               additionalProperties:
@@ -716,8 +420,6 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                               type: object
                             requests:
                               additionalProperties:
@@ -726,40 +428,18 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                               type: object
                           type: object
                         selector:
-                          description: A label query over volumes to consider for binding.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In, NotIn,
-                                      Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists or
-                                      DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
                                     items:
                                       type: string
                                     type: array
@@ -771,71 +451,34 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field is
-                                "key", the operator is "In", and the values array contains
-                                only "value". The requirements are ANDed.
                               type: object
                           type: object
                         storageClassName:
-                          description: 'Name of the StorageClass required by the claim.
-                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                           type: string
                         volumeMode:
-                          description: volumeMode defines what type of volume is required
-                            by the claim. Value of Filesystem is implied when not included
-                            in claim spec.
                           type: string
                         volumeName:
-                          description: VolumeName is the binding reference to the PersistentVolume
-                            backing this claim.
                           type: string
                       type: object
                     dataLog:
-                      description: DataLog is the spec to define the data-log PVC for
-                        the container
                       properties:
                         accessModes:
-                          description: 'AccessModes contains the desired access modes
-                          the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                           items:
                             type: string
                           type: array
                         dataSource:
-                          description: 'This field can be used to specify either: *
-                          An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
-                          - Beta) * An existing PVC (PersistentVolumeClaim) * An existing
-                          custom resource/object that implements data population (Alpha)
-                          In order to use VolumeSnapshot object types, the appropriate
-                          feature gate must be enabled (VolumeSnapshotDataSource or
-                          AnyVolumeDataSource) If the provisioner or an external controller
-                          can support the specified data source, it will create a
-                          new volume based on the contents of the specified data source.
-                          If the specified data source is not supported, the volume
-                          will not be created and the failure will be reported as
-                          an event. In the future, we plan to support more data source
-                          types and the behavior of the provisioner may change.'
                           properties:
                             apiGroup:
-                              description: APIGroup is the group for the resource being
-                                referenced. If APIGroup is not specified, the specified
-                                Kind must be in the core API group. For any other third-party
-                                types, APIGroup is required.
                               type: string
                             kind:
-                              description: Kind is the type of resource being referenced
                               type: string
                             name:
-                              description: Name is the name of resource being referenced
                               type: string
                           required:
                             - kind
                             - name
                           type: object
                         resources:
-                          description: 'Resources represents the minimum resources the
-                          volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                           properties:
                             limits:
                               additionalProperties:
@@ -844,8 +487,6 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                               type: object
                             requests:
                               additionalProperties:
@@ -854,40 +495,18 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                               type: object
                           type: object
                         selector:
-                          description: A label query over volumes to consider for binding.
                           properties:
                             matchExpressions:
-                              description: matchExpressions is a list of label selector
-                                requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
-                                  relates the key and values.
                                 properties:
                                   key:
-                                    description: key is the label key that the selector
-                                      applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In, NotIn,
-                                      Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists or
-                                      DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
                                     items:
                                       type: string
                                     type: array
@@ -899,95 +518,37 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field is
-                                "key", the operator is "In", and the values array contains
-                                only "value". The requirements are ANDed.
                               type: object
                           type: object
                         storageClassName:
-                          description: 'Name of the StorageClass required by the claim.
-                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                           type: string
                         volumeMode:
-                          description: volumeMode defines what type of volume is required
-                            by the claim. Value of Filesystem is implied when not included
-                            in claim spec.
                           type: string
                         volumeName:
-                          description: VolumeName is the binding reference to the PersistentVolume
-                            backing this claim.
                           type: string
                       type: object
                     reclaimPolicy:
-                      description: VolumeReclaimPolicy defines how to reclaim PV.
                       type: string
                   type: object
                 pod:
-                  description: Pod defines the policy for creating a zookeeper pod for
-                    the cluster
                   properties:
                     affinity:
-                      description: Affinity specifies the scheduling constraints of
-                        a pod
                       properties:
                         nodeAffinity:
-                          description: Describes node affinity scheduling rules for
-                            the pod.
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node matches the corresponding matchExpressions;
-                                the node(s) with the highest sum are the most preferred.
                               items:
-                                description: An empty preferred scheduling term matches
-                                  all objects with implicit weight 0 (i.e. it's a no-op).
-                                  A null preferred scheduling term matches no objects
-                                  (i.e. is also a no-op).
                                 properties:
                                   preference:
-                                    description: A node selector term, associated with
-                                      the corresponding weight.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
                                         items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: The label key that the selector
-                                                applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -997,35 +558,13 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
                                         items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: The label key that the selector
-                                                applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -1036,8 +575,6 @@ spec:
                                         type: array
                                     type: object
                                   weight:
-                                    description: Weight associated with matching the
-                                      corresponding nodeSelectorTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -1046,53 +583,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to an update), the system
-                                may or may not try to eventually evict the pod from
-                                its node.
                               properties:
                                 nodeSelectorTerms:
-                                  description: Required. A list of node selector terms.
-                                    The terms are ORed.
                                   items:
-                                    description: A null or empty node selector term
-                                      matches no objects. The requirements of them are
-                                      ANDed. The TopologySelectorTerm type implements
-                                      a subset of the NodeSelectorTerm.
                                     properties:
                                       matchExpressions:
-                                        description: A list of node selector requirements
-                                          by node's labels.
                                         items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: The label key that the selector
-                                                applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -1102,35 +604,13 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
-                                        description: A list of node selector requirements
-                                          by node's fields.
                                         items:
-                                          description: A node selector requirement is
-                                            a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: The label key that the selector
-                                                applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If the
-                                                operator is Exists or DoesNotExist,
-                                                the values array must be empty. If the
-                                                operator is Gt or Lt, the values array
-                                                must have a single element, which will
-                                                be interpreted as an integer. This array
-                                                is replaced during a strategic merge
-                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -1146,65 +626,22 @@ spec:
                               type: object
                           type: object
                         podAffinity:
-                          description: Describes pod affinity scheduling rules (e.g.
-                            co-locate this pod in the same node, zone, etc. as some
-                            other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1216,37 +653,18 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -1255,56 +673,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified by
-                                this field are not met at scheduling time, the pod will
-                                not be scheduled onto the node. If the affinity requirements
-                                specified by this field cease to be met at some point
-                                during pod execution (e.g. due to a pod label update),
-                                the system may or may not try to eventually evict the
-                                pod from its node. When there are multiple elements,
-                                the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
                               items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -1316,29 +696,13 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -1346,65 +710,22 @@ spec:
                               type: array
                           type: object
                         podAntiAffinity:
-                          description: Describes pod anti-affinity scheduling rules
-                            (e.g. avoid putting this pod in the same node, zone, etc.
-                            as some other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the anti-affinity expressions
-                                specified by this field, but it may choose a node that
-                                violates one or more of the expressions. The node that
-                                is most preferred is the one with the greatest sum of
-                                weights, i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                anti-affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the corresponding
-                                podAffinityTerm; the node(s) with the highest sum are
-                                the most preferred.
                               items:
-                                description: The weights of all of the matched WeightedPodAffinityTerm
-                                  fields are added per-node to find the most preferred
-                                  node(s)
                                 properties:
                                   podAffinityTerm:
-                                    description: Required. A pod affinity term, associated
-                                      with the corresponding weight.
                                     properties:
                                       labelSelector:
-                                        description: A label query over a set of resources,
-                                          in this case pods.
                                         properties:
                                           matchExpressions:
-                                            description: matchExpressions is a list
-                                              of label selector requirements. The requirements
-                                              are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
                                               properties:
                                                 key:
-                                                  description: key is the label key
-                                                    that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents a
-                                                    key's relationship to a set of values.
-                                                    Valid operators are In, NotIn, Exists
-                                                    and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array of
-                                                    string values. If the operator is
-                                                    In or NotIn, the values array must
-                                                    be non-empty. If the operator is
-                                                    Exists or DoesNotExist, the values
-                                                    array must be empty. This array
-                                                    is replaced during a strategic merge
-                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1416,37 +737,18 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       namespaces:
-                                        description: namespaces specifies which namespaces
-                                          the labelSelector applies to (matches against);
-                                          null or empty list means "this pod's namespace"
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located (affinity)
-                                          or not co-located (anti-affinity) with the
-                                          pods matching the labelSelector in the specified
-                                          namespaces, where co-located is defined as
-                                          running on a node whose value of the label
-                                          with key topologyKey matches that of any node
-                                          on which any of the selected pods is running.
-                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -1455,56 +757,18 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified
-                                by this field are not met at scheduling time, the pod
-                                will not be scheduled onto the node. If the anti-affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a pod
-                                label update), the system may or may not try to eventually
-                                evict the pod from its node. When there are multiple
-                                elements, the lists of nodes corresponding to each podAffinityTerm
-                                are intersected, i.e. all terms must be satisfied.
                               items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or not
-                                  co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any node
-                                  on which a pod of the set of pods is running
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label
-                                          selector requirements. The requirements are
-                                          ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
                                           properties:
                                             key:
-                                              description: key is the label key that
-                                                the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
-                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -1516,29 +780,13 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
-                                    description: namespaces specifies which namespaces
-                                      the labelSelector applies to (matches against);
-                                      null or empty list means "this pod's namespace"
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -1549,134 +797,69 @@ spec:
                     annotations:
                       additionalProperties:
                         type: string
-                      description: Annotations specifies the annotations to attach to
-                        pods the operator creates
                       type: object
                     initContainers:
-                      description: InitContainers defines init containers of the pod.
-                        A typical use case could be using an init container to download
-                        a remote jar to a local path.
                       items:
-                        description: A single application container that you want to
-                          run within a pod. The Container API from the core group is
-                          not used directly to avoid unneeded fields and reduce the
-                          size of the CRD. New fields could be added as needed.
                         properties:
                           args:
-                            description: Arguments to the entrypoint.
                             items:
                               type: string
                             type: array
                           command:
-                            description: Entrypoint array. Not executed within a shell.
                             items:
                               type: string
                             type: array
                           env:
-                            description: List of environment variables to set in the
-                              container.
                             items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
                               properties:
                                 name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
-                                  description: 'Variable references $(VAR_NAME) are
-                                  expanded using the previous defined environment
-                                  variables in the container and any service environment
-                                  variables. If a variable cannot be resolved, the
-                                  reference in the input string will be unchanged.
-                                  The $(VAR_NAME) syntax can be escaped with a double
-                                  $$, ie: $$(VAR_NAME). Escaped references will never
-                                  be expanded, regardless of whether the variable
-                                  exists or not. Defaults to "".'
                                   type: string
                                 valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
-                                          description: The key to select.
                                           type: string
                                         name:
-                                          description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
                                           type: boolean
                                       required:
                                         - key
                                       type: object
                                     fieldRef:
-                                      description: 'Selects a field of the pod: supports
-                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                      spec.serviceAccountName, status.hostIP, status.podIP,
-                                      status.podIPs.'
                                       properties:
                                         apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
-                                          description: Path of the field to select in
-                                            the specified API version.
                                           type: string
                                       required:
                                         - fieldPath
                                       type: object
                                     resourceFieldRef:
-                                      description: 'Selects a resource of the container:
-                                      only resources limits and requests (limits.cpu,
-                                      limits.memory, limits.ephemeral-storage, requests.cpu,
-                                      requests.memory and requests.ephemeral-storage)
-                                      are currently supported.'
                                       properties:
                                         containerName:
-                                          description: 'Container name: required for
-                                          volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                             - type: integer
                                             - type: string
-                                          description: Specifies the output format of
-                                            the exposed resources, defaults to "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
-                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                         - resource
                                       type: object
                                     secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
                                       properties:
                                         key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
-                                          description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                           type: string
                                         optional:
-                                          description: Specify whether the Secret or
-                                            its key must be defined
                                           type: boolean
                                       required:
                                         - key
@@ -1687,99 +870,52 @@ spec:
                               type: object
                             type: array
                           envFrom:
-                            description: List of sources to populate environment variables
-                              in the container.
                             items:
-                              description: EnvFromSource represents the source of a
-                                set of ConfigMaps
                               properties:
                                 configMapRef:
-                                  description: The ConfigMap to select from
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap must
-                                        be defined
                                       type: boolean
                                   type: object
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
-                                  description: The Secret to select from
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret must be
-                                        defined
                                       type: boolean
                                   type: object
                               type: object
                             type: array
                           image:
-                            description: Docker image name.
                             type: string
                           imagePullPolicy:
-                            description: Image pull policy.
                             type: string
                           livenessProbe:
-                            description: Periodic probe of container liveness.
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe
-                                  to be considered failed after having succeeded. Defaults
-                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1787,120 +923,66 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe
-                                  to be considered successful after having failed. Defaults
-                                  to 1. Must be 1 for liveness and startup. Minimum
-                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           name:
-                            description: Name of the container specified as a DNS_LABEL.
-                              Each container in a pod must have a unique name (DNS_LABEL).
                             type: string
                           readinessProbe:
-                            description: 'Periodic probe of container service readiness.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe
-                                  to be considered failed after having succeeded. Defaults
-                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1908,70 +990,43 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe
-                                  to be considered successful after having failed. Defaults
-                                  to 1. Must be 1 for liveness and startup. Minimum
-                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           resources:
-                            description: Compute Resources required by this container.
                             properties:
                               limits:
                                 additionalProperties:
@@ -1980,8 +1035,6 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -1990,61 +1043,30 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                             type: object
                           startupProbe:
-                            description: StartupProbe indicates that the Pod has successfully
-                              initialized.
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe
-                                  to be considered failed after having succeeded. Defaults
-                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -2052,103 +1074,56 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe
-                                  to be considered successful after having failed. Defaults
-                                  to 1. Must be 1 for liveness and startup. Minimum
-                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           volumeMounts:
-                            description: Pod volumes to mount into the container's filesystem.
                             items:
-                              description: VolumeMount describes a mounting of a Volume
-                                within a container.
                               properties:
                                 mountPath:
-                                  description: Path within the container at which the
-                                    volume should be mounted.  Must not contain ':'.
                                   type: string
                                 mountPropagation:
-                                  description: mountPropagation determines how mounts
-                                    are propagated from the host to container and the
-                                    other way around. When not set, MountPropagationNone
-                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
-                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
-                                  description: Mounted read-only if true, read-write
-                                    otherwise (false or unspecified). Defaults to false.
                                   type: boolean
                                 subPath:
-                                  description: Path within the volume from which the
-                                    container's volume should be mounted. Defaults to
-                                    "" (volume's root).
                                   type: string
                                 subPathExpr:
-                                  description: Expanded path within the volume from
-                                    which the container's volume should be mounted.
-                                    Behaves similarly to SubPath but environment variable
-                                    references $(VAR_NAME) are expanded using the container's
-                                    environment. Defaults to "" (volume's root). SubPathExpr
-                                    and SubPath are mutually exclusive.
                                   type: string
                               required:
                                 - mountPath
@@ -2156,14 +1131,12 @@ spec:
                               type: object
                             type: array
                           workingDir:
-                            description: Container's working directory.
                             type: string
                         required:
                           - name
                         type: object
                       type: array
                     jvmOptions:
-                      description: JVMOptions defines JVM parameters
                       properties:
                         extraOptions:
                           items:
@@ -2185,19 +1158,12 @@ spec:
                     labels:
                       additionalProperties:
                         type: string
-                      description: Labels specifies the labels to attach to pod the
-                        operator creates for the zookeeper cluster.
                       type: object
                     nodeSelector:
                       additionalProperties:
                         type: string
-                      description: NodeSelector specifies a map of key-value pairs.
-                        For a pod to be eligible to run on a node, the node must have
-                        each of the indicated key-value pairs as labels.
                       type: object
                     resources:
-                      description: Resources specifies the resource requirements of
-                        a pod to run in the cluster
                       properties:
                         limits:
                           additionalProperties:
@@ -2206,8 +1172,6 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
@@ -2216,127 +1180,54 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
-                          description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
                     securityContext:
-                      description: 'SecurityContext specifies the security context for
-                      the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
                       properties:
                         fsGroup:
-                          description: "A special supplemental group that applies to
-                          all containers in a pod. Some volume types allow the Kubelet
-                          to change the ownership of that volume to be owned by the
-                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
-                          bit is set (new files created in the volume will be owned
-                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
-                          \n If unset, the Kubelet will not modify the ownership and
-                          permissions of any volume."
                           format: int64
                           type: integer
                         fsGroupChangePolicy:
-                          description: 'fsGroupChangePolicy defines behavior of changing
-                          ownership and permission of the volume before being exposed
-                          inside Pod. This field will only apply to volume types which
-                          support fsGroup based ownership(and permissions). It will
-                          have no effect on ephemeral volume types such as: secret,
-                          configmaps and emptydir. Valid values are "OnRootMismatch"
-                          and "Always". If not specified defaults to "Always".'
                           type: string
                         runAsGroup:
-                          description: The GID to run the entrypoint of the container
-                            process. Uses runtime default if unset. May also be set
-                            in SecurityContext.  If set in both SecurityContext and
-                            PodSecurityContext, the value specified in SecurityContext
-                            takes precedence for that container.
                           format: int64
                           type: integer
                         runAsNonRoot:
-                          description: Indicates that the container must run as a non-root
-                            user. If true, the Kubelet will validate the image at runtime
-                            to ensure that it does not run as UID 0 (root) and fail
-                            to start the container if it does. If unset or false, no
-                            such validation will be performed. May also be set in SecurityContext.  If
-                            set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
                           type: boolean
                         runAsUser:
-                          description: The UID to run the entrypoint of the container
-                            process. Defaults to user specified in image metadata if
-                            unspecified. May also be set in SecurityContext.  If set
-                            in both SecurityContext and PodSecurityContext, the value
-                            specified in SecurityContext takes precedence for that container.
                           format: int64
                           type: integer
                         seLinuxOptions:
-                          description: The SELinux context to be applied to all containers.
-                            If unspecified, the container runtime will allocate a random
-                            SELinux context for each container.  May also be set in
-                            SecurityContext.  If set in both SecurityContext and PodSecurityContext,
-                            the value specified in SecurityContext takes precedence
-                            for that container.
                           properties:
                             level:
-                              description: Level is SELinux level label that applies
-                                to the container.
                               type: string
                             role:
-                              description: Role is a SELinux role label that applies
-                                to the container.
                               type: string
                             type:
-                              description: Type is a SELinux type label that applies
-                                to the container.
                               type: string
                             user:
-                              description: User is a SELinux user label that applies
-                                to the container.
                               type: string
                           type: object
                         seccompProfile:
-                          description: The seccomp options to use by the containers
-                            in this pod.
                           properties:
                             localhostProfile:
-                              description: localhostProfile indicates a profile defined
-                                in a file on the node should be used. The profile must
-                                be preconfigured on the node to work. Must be a descending
-                                path, relative to the kubelet's configured seccomp profile
-                                location. Must only be set if type is "Localhost".
                               type: string
                             type:
-                              description: "type indicates which kind of seccomp profile
-                              will be applied. Valid options are: \n Localhost - a
-                              profile defined in a file on the node should be used.
-                              RuntimeDefault - the container runtime default profile
-                              should be used. Unconfined - no profile should be applied."
                               type: string
                           required:
                             - type
                           type: object
                         supplementalGroups:
-                          description: A list of groups applied to the first process
-                            run in each container, in addition to the container's primary
-                            GID.  If unspecified, no groups will be added to any container.
                           items:
                             format: int64
                             type: integer
                           type: array
                         sysctls:
-                          description: Sysctls hold a list of namespaced sysctls used
-                            for the pod. Pods with unsupported sysctls (by the container
-                            runtime) might fail to launch.
                           items:
-                            description: Sysctl defines a kernel parameter to be set
                             properties:
                               name:
-                                description: Name of a property to set
                                 type: string
                               value:
-                                description: Value of a property to set
                                 type: string
                             required:
                               - name
@@ -2344,160 +1235,79 @@ spec:
                             type: object
                           type: array
                         windowsOptions:
-                          description: The Windows specific settings applied to all
-                            containers. If unspecified, the options within a container's
-                            SecurityContext will be used. If set in both SecurityContext
-                            and PodSecurityContext, the value specified in SecurityContext
-                            takes precedence.
                           properties:
                             gmsaCredentialSpec:
-                              description: GMSACredentialSpec is where the GMSA admission
-                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                inlines the contents of the GMSA credential spec named
-                                by the GMSACredentialSpecName field.
                               type: string
                             gmsaCredentialSpecName:
-                              description: GMSACredentialSpecName is the name of the
-                                GMSA credential spec to use.
                               type: string
                             runAsUserName:
-                              description: The UserName in Windows to run the entrypoint
-                                of the container process. Defaults to the user specified
-                                in image metadata if unspecified. May also be set in
-                                PodSecurityContext. If set in both SecurityContext and
-                                PodSecurityContext, the value specified in SecurityContext
-                                takes precedence.
                               type: string
                           type: object
                       type: object
                     serviceAccountName:
-                      description: ServiceAccountName is the name of the ServiceAccount
-                        to use to run pods.
                       type: string
                     sidecars:
-                      description: Sidecars defines sidecar containers running alongside
-                        with the main function container in the pod.
                       items:
-                        description: A single application container that you want to
-                          run within a pod. The Container API from the core group is
-                          not used directly to avoid unneeded fields and reduce the
-                          size of the CRD. New fields could be added as needed.
                         properties:
                           args:
-                            description: Arguments to the entrypoint.
                             items:
                               type: string
                             type: array
                           command:
-                            description: Entrypoint array. Not executed within a shell.
                             items:
                               type: string
                             type: array
                           env:
-                            description: List of environment variables to set in the
-                              container.
                             items:
-                              description: EnvVar represents an environment variable
-                                present in a Container.
                               properties:
                                 name:
-                                  description: Name of the environment variable. Must
-                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
-                                  description: 'Variable references $(VAR_NAME) are
-                                  expanded using the previous defined environment
-                                  variables in the container and any service environment
-                                  variables. If a variable cannot be resolved, the
-                                  reference in the input string will be unchanged.
-                                  The $(VAR_NAME) syntax can be escaped with a double
-                                  $$, ie: $$(VAR_NAME). Escaped references will never
-                                  be expanded, regardless of whether the variable
-                                  exists or not. Defaults to "".'
                                   type: string
                                 valueFrom:
-                                  description: Source for the environment variable's
-                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
-                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
-                                          description: The key to select.
                                           type: string
                                         name:
-                                          description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                           type: string
                                         optional:
-                                          description: Specify whether the ConfigMap
-                                            or its key must be defined
                                           type: boolean
                                       required:
                                         - key
                                       type: object
                                     fieldRef:
-                                      description: 'Selects a field of the pod: supports
-                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                      spec.serviceAccountName, status.hostIP, status.podIP,
-                                      status.podIPs.'
                                       properties:
                                         apiVersion:
-                                          description: Version of the schema the FieldPath
-                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
-                                          description: Path of the field to select in
-                                            the specified API version.
                                           type: string
                                       required:
                                         - fieldPath
                                       type: object
                                     resourceFieldRef:
-                                      description: 'Selects a resource of the container:
-                                      only resources limits and requests (limits.cpu,
-                                      limits.memory, limits.ephemeral-storage, requests.cpu,
-                                      requests.memory and requests.ephemeral-storage)
-                                      are currently supported.'
                                       properties:
                                         containerName:
-                                          description: 'Container name: required for
-                                          volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                             - type: integer
                                             - type: string
-                                          description: Specifies the output format of
-                                            the exposed resources, defaults to "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
-                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                         - resource
                                       type: object
                                     secretKeyRef:
-                                      description: Selects a key of a secret in the
-                                        pod's namespace
                                       properties:
                                         key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
-                                          description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
                                           type: string
                                         optional:
-                                          description: Specify whether the Secret or
-                                            its key must be defined
                                           type: boolean
                                       required:
                                         - key
@@ -2508,99 +1318,52 @@ spec:
                               type: object
                             type: array
                           envFrom:
-                            description: List of sources to populate environment variables
-                              in the container.
                             items:
-                              description: EnvFromSource represents the source of a
-                                set of ConfigMaps
                               properties:
                                 configMapRef:
-                                  description: The ConfigMap to select from
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the ConfigMap must
-                                        be defined
                                       type: boolean
                                   type: object
                                 prefix:
-                                  description: An optional identifier to prepend to
-                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
-                                  description: The Secret to select from
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
                                       type: string
                                     optional:
-                                      description: Specify whether the Secret must be
-                                        defined
                                       type: boolean
                                   type: object
                               type: object
                             type: array
                           image:
-                            description: Docker image name.
                             type: string
                           imagePullPolicy:
-                            description: Image pull policy.
                             type: string
                           livenessProbe:
-                            description: Periodic probe of container liveness.
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe
-                                  to be considered failed after having succeeded. Defaults
-                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -2608,120 +1371,66 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe
-                                  to be considered successful after having failed. Defaults
-                                  to 1. Must be 1 for liveness and startup. Minimum
-                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           name:
-                            description: Name of the container specified as a DNS_LABEL.
-                              Each container in a pod must have a unique name (DNS_LABEL).
                             type: string
                           readinessProbe:
-                            description: 'Periodic probe of container service readiness.
-                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe
-                                  to be considered failed after having succeeded. Defaults
-                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -2729,70 +1438,43 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe
-                                  to be considered successful after having failed. Defaults
-                                  to 1. Must be 1 for liveness and startup. Minimum
-                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           resources:
-                            description: Compute Resources required by this container.
                             properties:
                               limits:
                                 additionalProperties:
@@ -2801,8 +1483,6 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -2811,61 +1491,30 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                             type: object
                           startupProbe:
-                            description: StartupProbe indicates that the Pod has successfully
-                              initialized.
                             properties:
                               exec:
-                                description: One and only one of the following should
-                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
-                                description: Minimum consecutive failures for the probe
-                                  to be considered failed after having succeeded. Defaults
-                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
-                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
-                                    description: Custom headers to set in the request.
-                                      HTTP allows repeated headers.
                                     items:
-                                      description: HTTPHeader describes a custom header
-                                        to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name
                                           type: string
                                         value:
-                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -2873,103 +1522,56 @@ spec:
                                       type: object
                                     type: array
                                   path:
-                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
-                                description: 'Number of seconds after the container
-                                has started before liveness probes are initiated.
-                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
-                                description: How often (in seconds) to perform the probe.
-                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
-                                description: Minimum consecutive successes for the probe
-                                  to be considered successful after having failed. Defaults
-                                  to 1. Must be 1 for liveness and startup. Minimum
-                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
-                                description: 'TCPSocket specifies an action involving
-                                a TCP port. TCP hooks not yet supported TODO: implement
-                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
-                                    description: 'Optional: Host name to connect to,
-                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
-                                description: 'Number of seconds after which the probe
-                                times out. Defaults to 1 second. Minimum value is
-                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           volumeMounts:
-                            description: Pod volumes to mount into the container's filesystem.
                             items:
-                              description: VolumeMount describes a mounting of a Volume
-                                within a container.
                               properties:
                                 mountPath:
-                                  description: Path within the container at which the
-                                    volume should be mounted.  Must not contain ':'.
                                   type: string
                                 mountPropagation:
-                                  description: mountPropagation determines how mounts
-                                    are propagated from the host to container and the
-                                    other way around. When not set, MountPropagationNone
-                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
-                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
-                                  description: Mounted read-only if true, read-write
-                                    otherwise (false or unspecified). Defaults to false.
                                   type: boolean
                                 subPath:
-                                  description: Path within the volume from which the
-                                    container's volume should be mounted. Defaults to
-                                    "" (volume's root).
                                   type: string
                                 subPathExpr:
-                                  description: Expanded path within the volume from
-                                    which the container's volume should be mounted.
-                                    Behaves similarly to SubPath but environment variable
-                                    references $(VAR_NAME) are expanded using the container's
-                                    environment. Defaults to "" (volume's root). SubPathExpr
-                                    and SubPath are mutually exclusive.
                                   type: string
                               required:
                                 - mountPath
@@ -2977,158 +1579,81 @@ spec:
                               type: object
                             type: array
                           workingDir:
-                            description: Container's working directory.
                             type: string
                         required:
                           - name
                         type: object
                       type: array
                     terminationGracePeriodSeconds:
-                      description: TerminationGracePeriodSeconds is the amount of time
-                        that kubernetes will give for a pod before terminating it.
                       format: int64
                       type: integer
                     tolerations:
-                      description: Tolerations specifies the tolerations of a Pod
                       items:
-                        description: The pod this Toleration is attached to tolerates
-                          any taint that matches the triple <key,value,effect> using
-                          the matching operator <operator>.
                         properties:
                           effect:
-                            description: Effect indicates the taint effect to match.
-                              Empty means match all taint effects. When specified, allowed
-                              values are NoSchedule, PreferNoSchedule and NoExecute.
                             type: string
                           key:
-                            description: Key is the taint key that the toleration applies
-                              to. Empty means match all taint keys. If the key is empty,
-                              operator must be Exists; this combination means to match
-                              all values and all keys.
                             type: string
                           operator:
-                            description: Operator represents a key's relationship to
-                              the value. Valid operators are Exists and Equal. Defaults
-                              to Equal. Exists is equivalent to wildcard for value,
-                              so that a pod can tolerate all taints of a particular
-                              category.
                             type: string
                           tolerationSeconds:
-                            description: TolerationSeconds represents the period of
-                              time the toleration (which must be of effect NoExecute,
-                              otherwise this field is ignored) tolerates the taint.
-                              By default, it is not set, which means tolerate the taint
-                              forever (do not evict). Zero and negative values will
-                              be treated as 0 (evict immediately) by the system.
                             format: int64
                             type: integer
                           value:
-                            description: Value is the taint value the toleration matches
-                              to. If the operator is Exists, the value should be empty,
-                              otherwise just a regular string.
                             type: string
                         type: object
                       type: array
                     vars:
-                      description: Vars specifies the environment variables of a Pod
                       items:
-                        description: EnvVar represents an environment variable present
-                          in a Container.
                         properties:
                           name:
-                            description: Name of the environment variable. Must be a
-                              C_IDENTIFIER.
                             type: string
                           value:
-                            description: 'Variable references $(VAR_NAME) are expanded
-                            using the previous defined environment variables in the
-                            container and any service environment variables. If a
-                            variable cannot be resolved, the reference in the input
-                            string will be unchanged. The $(VAR_NAME) syntax can be
-                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
-                            will never be expanded, regardless of whether the variable
-                            exists or not. Defaults to "".'
                             type: string
                           valueFrom:
-                            description: Source for the environment variable's value.
-                              Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
-                                description: Selects a key of a ConfigMap.
                                 properties:
                                   key:
-                                    description: The key to select.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the ConfigMap or its
-                                      key must be defined
                                     type: boolean
                                 required:
                                   - key
                                 type: object
                               fieldRef:
-                                description: 'Selects a field of the pod: supports metadata.name,
-                                metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                spec.serviceAccountName, status.hostIP, status.podIP,
-                                status.podIPs.'
                                 properties:
                                   apiVersion:
-                                    description: Version of the schema the FieldPath
-                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
-                                    description: Path of the field to select in the
-                                      specified API version.
                                     type: string
                                 required:
                                   - fieldPath
                                 type: object
                               resourceFieldRef:
-                                description: 'Selects a resource of the container: only
-                                resources limits and requests (limits.cpu, limits.memory,
-                                limits.ephemeral-storage, requests.cpu, requests.memory
-                                and requests.ephemeral-storage) are currently supported.'
                                 properties:
                                   containerName:
-                                    description: 'Container name: required for volumes,
-                                    optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Specifies the output format of the
-                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
-                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                   - resource
                                 type: object
                               secretKeyRef:
-                                description: Selects a key of a secret in the pod's
-                                  namespace
                                 properties:
                                   key:
-                                    description: The key of the secret to select from.  Must
-                                      be a valid secret key.
                                     type: string
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
                                     type: string
                                   optional:
-                                    description: Specify whether the Secret or its key
-                                      must be defined
                                     type: boolean
                                 required:
                                   - key
@@ -3139,66 +1664,22 @@ spec:
                         type: object
                       type: array
                     volumes:
-                      description: Volumes defines extra volumes of the pod.
                       items:
-                        description: Volume represents a named volume in a pod that
-                          may be accessed by any container in the pod. The Volume API
-                          from the core group is not used directly to avoid unneeded
-                          fields defined in `VolumeSource` and reduce the size of the
-                          CRD. New fields in VolumeSource could be added as needed.
                         properties:
                           configMap:
-                            description: ConfigMap represents a configMap that should
-                              populate this volume
                             properties:
                               defaultMode:
-                                description: 'Optional: mode bits used to set permissions
-                                on created files by default. Must be an octal value
-                                between 0000 and 0777 or a decimal value between 0
-                                and 511. YAML accepts both octal and decimal values,
-                                JSON requires decimal values for mode bits. Defaults
-                                to 0644. Directories within the path are not affected
-                                by this setting. This might be in conflict with other
-                                options that affect the file mode, like fsGroup, and
-                                the result can be other mode bits set.'
                                 format: int32
                                 type: integer
                               items:
-                                description: If unspecified, each key-value pair in
-                                  the Data field of the referenced ConfigMap will be
-                                  projected into the volume as a file whose name is
-                                  the key and content is the value. If specified, the
-                                  listed keys will be projected into the specified paths,
-                                  and unlisted keys will not be present. If a key is
-                                  specified which is not present in the ConfigMap, the
-                                  volume setup will error unless it is marked optional.
-                                  Paths must be relative and may not contain the '..'
-                                  path or start with '..'.
                                 items:
-                                  description: Maps a string key to a path within a
-                                    volume.
                                   properties:
                                     key:
-                                      description: The key to project.
                                       type: string
                                     mode:
-                                      description: 'Optional: mode bits used to set
-                                      permissions on this file. Must be an octal value
-                                      between 0000 and 0777 or a decimal value between
-                                      0 and 511. YAML accepts both octal and decimal
-                                      values, JSON requires decimal values for mode
-                                      bits. If not specified, the volume defaultMode
-                                      will be used. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
                                       format: int32
                                       type: integer
                                     path:
-                                      description: The relative path of the file to
-                                        map the key to. May not be an absolute path.
-                                        May not contain the path element '..'. May not
-                                        start with the string '..'.
                                       type: string
                                   required:
                                     - key
@@ -3206,70 +1687,26 @@ spec:
                                   type: object
                                 type: array
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
-                                description: Specify whether the ConfigMap or its keys
-                                  must be defined
                                 type: boolean
                             type: object
                           name:
-                            description: 'Volume''s name. Must be a DNS_LABEL and unique
-                            within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
                           secret:
-                            description: Secret represents a secret that should populate
-                              this volume.
                             properties:
                               defaultMode:
-                                description: 'Optional: mode bits used to set permissions
-                                on created files by default. Must be an octal value
-                                between 0000 and 0777 or a decimal value between 0
-                                and 511. YAML accepts both octal and decimal values,
-                                JSON requires decimal values for mode bits. Defaults
-                                to 0644. Directories within the path are not affected
-                                by this setting. This might be in conflict with other
-                                options that affect the file mode, like fsGroup, and
-                                the result can be other mode bits set.'
                                 format: int32
                                 type: integer
                               items:
-                                description: If unspecified, each key-value pair in
-                                  the Data field of the referenced Secret will be projected
-                                  into the volume as a file whose name is the key and
-                                  content is the value. If specified, the listed keys
-                                  will be projected into the specified paths, and unlisted
-                                  keys will not be present. If a key is specified which
-                                  is not present in the Secret, the volume setup will
-                                  error unless it is marked optional. Paths must be
-                                  relative and may not contain the '..' path or start
-                                  with '..'.
                                 items:
-                                  description: Maps a string key to a path within a
-                                    volume.
                                   properties:
                                     key:
-                                      description: The key to project.
                                       type: string
                                     mode:
-                                      description: 'Optional: mode bits used to set
-                                      permissions on this file. Must be an octal value
-                                      between 0000 and 0777 or a decimal value between
-                                      0 and 511. YAML accepts both octal and decimal
-                                      values, JSON requires decimal values for mode
-                                      bits. If not specified, the volume defaultMode
-                                      will be used. This might be in conflict with
-                                      other options that affect the file mode, like
-                                      fsGroup, and the result can be other mode bits
-                                      set.'
                                       format: int32
                                       type: integer
                                     path:
-                                      description: The relative path of the file to
-                                        map the key to. May not be an absolute path.
-                                        May not contain the path element '..'. May not
-                                        start with the string '..'.
                                       type: string
                                   required:
                                     - key
@@ -3277,12 +1714,8 @@ spec:
                                   type: object
                                 type: array
                               optional:
-                                description: Specify whether the Secret or its keys
-                                  must be defined
                                 type: boolean
                               secretName:
-                                description: 'Name of the secret in the pod''s namespace
-                                to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                 type: string
                             type: object
                         required:
@@ -3291,29 +1724,13 @@ spec:
                       type: array
                   type: object
                 replicas:
-                  description: Replicas is the expected size of the zookeeper cluster.
-                    The zookeeper operator will eventually make the size of the running
-                    cluster equal to the expected size.
                   format: int32
                   type: integer
               type: object
             status:
-              description: ZooKeeperClusterStatus defines the observed state of ZooKeeperCluster
               properties:
                 conditions:
-                  description: Conditions represent observations of the ZookeeperCluster's
-                    state
                   items:
-                    description: "Condition represents an observation of an object's
-                    state. Conditions are an extension mechanism intended to be used
-                    when the details of an observation are not a priori known or would
-                    not apply to all instances of a given Kind. \n Conditions should
-                    be added to explicitly convey properties that users and components
-                    care about rather than requiring those properties to be inferred
-                    from other observations. Once defined, the meaning of a Condition
-                    can not be changed arbitrarily - it becomes part of the API, and
-                    has the same backwards- and forwards-compatibility concerns of
-                    any other part of the API."
                     properties:
                       lastTransitionTime:
                         format: date-time
@@ -3321,20 +1738,10 @@ spec:
                       message:
                         type: string
                       reason:
-                        description: ConditionReason is intended to be a one-word, CamelCase
-                          representation of the category of cause of the current status.
-                          It is intended to be used in concise output, such as one-line
-                          kubectl get output, and in summarizing occurrences of causes.
                         type: string
                       status:
                         type: string
                       type:
-                        description: "ConditionType is the type of the condition and
-                        is typically a CamelCased word or short phrase. \n Condition
-                        types should indicate state in the \"abnormal-true\" polarity.
-                        For example, if the condition indicates when a policy is invalid,
-                        the \"is valid\" case is probably the norm, so the condition
-                        should be called \"Invalid\"."
                         type: string
                     required:
                       - status
@@ -3342,39 +1749,24 @@ spec:
                     type: object
                   type: array
                 externalServiceEndpoint:
-                  description: ExternalServiceEndpoint is the external service endpoint
-                    (ip:port)
                   type: string
                 internalServiceEndpoint:
-                  description: InternalServiceEndpoint is the internal service endpoint
-                    (ip:port)
                   type: string
                 labelSelector:
-                  description: Label selector for scaling
                   type: string
                 numReadyServers:
-                  description: NumReadyServers is the number of zookeeper servers in
-                    the cluster that are in ready status
                   format: int32
                   type: integer
                 observedGeneration:
-                  description: ObservedGeneration is the most recent generation observed
-                    for this cluster. It corresponds to the metadata generation, which
-                    is updated on mutation by the API Server.
                   format: int64
                   type: integer
                 readyReplicas:
-                  description: ReadyReplicas is the number of ready zookeeper servers
-                    in the cluster
                   format: int32
                   type: integer
                 replicas:
-                  description: Replicas is the number of desired zookeeper servers in
-                    the cluster
                   format: int32
                   type: integer
                 servers:
-                  description: Servers is the list of servers in the zookeeper cluster
                   properties:
                     notReady:
                       items:
@@ -3389,8 +1781,6 @@ spec:
                     - ready
                   type: object
                 updatedReplicas:
-                  description: UpdatedReplicas is the number of zookeeper servers that
-                    has been updated to the latest configuration
                   format: int32
                   type: integer
               required:

--- a/charts/pulsar-operator/templates/pulsar-operator/rbac.yaml
+++ b/charts/pulsar-operator/templates/pulsar-operator/rbac.yaml
@@ -352,6 +352,18 @@ rules:
     - patch
     - update
     - watch
+  - apiGroups:
+    - security.istio.io
+    resources:
+    - '*'
+    verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -684,6 +696,18 @@ rules:
       - autoscaling
     resources:
       - horizontalpodautoscalers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - security.istio.io
+    resources:
+      - '*'
     verbs:
       - create
       - delete

--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -171,6 +171,9 @@ spec:
 {{ toYaml .Values.broker.dnsNames | indent 2}}
   {{- end }}
   config:
+    {{- if .Values.pulsar_metadata.clusterName }}
+    clusterName: {{ .Values.pulsar_metadata.clusterName }}
+    {{- end }}
     {{- if .Values.broker.functionmesh.enabled }}
     function:
       enabled: true

--- a/charts/sn-platform/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-cluster.yaml
@@ -146,6 +146,9 @@ spec:
         - {{ .Values.proxy.configData.PULSAR_GC }}
       gcLoggingOptions: []
   config:
+    {{- if .Values.pulsar_metadata.clusterName }}
+    clusterName: {{ .Values.pulsar_metadata.clusterName }}
+    {{- end }}
     tls:
       enabled: {{ and (.Values.tls.enabled) (.Values.tls.proxy.enabled) }}
     custom:


### PR DESCRIPTION
### Motivation
Allow customize Pulsar Cluster name for operator deployment.

### Modifications
Update operator crds, set clustername on pulsarbroker/pulsarproxy object is specified.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is already covered by existing tests, such as *(please describe tests)*.

### Documentation

Check the box below.

Need to update docs? 
- [x] `no-need-doc` 
 Doc about clustername should already be there.
