### PR TITLE
[charts/pulsar] Fix issues with openshift deployments

### DIFF
--- a/charts/pulsar/templates/control-center/_control_center.tpl
+++ b/charts/pulsar/templates/control-center/_control_center.tpl
@@ -3,6 +3,9 @@ control center domain
 */}}
 {{- define "pulsar.control_center_domain" -}}
 {{- if .Values.ingress.control_center.enabled -}}
+    {{- if .Values.deployment.openshift -}}
+{{- printf "%s-%s.%s" .Values.pulsar.pulsar_manager.service .Values.pulsar.namespace .Values.domain.suffix -}}
+    {{- else -}}
     {{- if .Values.ingress.control_center.external_domain }}
 {{- printf "%s" .Values.ingress.control_center.external_domain -}}
     {{- else -}}

--- a/charts/pulsar/templates/control-center/_control_center.tpl
+++ b/charts/pulsar/templates/control-center/_control_center.tpl
@@ -3,13 +3,14 @@ control center domain
 */}}
 {{- define "pulsar.control_center_domain" -}}
 {{- if .Values.ingress.control_center.enabled -}}
-    {{- if .Values.deployment.openshift -}}
-{{- printf "%s-%s.%s" .Values.pulsar.pulsar_manager.service .Values.pulsar.namespace .Values.domain.suffix -}}
+    {{- if .Values.deployment.openshift }}
+{{- printf "%s-%s-%s.%s" .Values.pulsar_metadata.clusterName .Values.pulsar_manager.component .Release.Namespace .Values.domain.suffix -}}
     {{- else -}}
-    {{- if .Values.ingress.control_center.external_domain }}
+        {{- if .Values.ingress.control_center.external_domain }}
 {{- printf "%s" .Values.ingress.control_center.external_domain -}}
-    {{- else -}}
+        {{- else -}}
 {{- printf "admin.%s.%s" .Release.Name .Values.domain.suffix -}}
+        {{- end -}}
     {{- end -}}
 {{- else -}}
 {{- print "" -}}

--- a/charts/pulsar/templates/control-center/control-center-ingress.yaml
+++ b/charts/pulsar/templates/control-center/control-center-ingress.yaml
@@ -21,8 +21,11 @@
 {{- $fullName := include "pulsar.fullname" . -}}
 
 {{/* COMMENT */}}
-
+{{- if .Values.deployment.openshift }}
+apiVersion: networking.k8s.io/v1beta1
+{{- else }}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.ingress.control_center.component }}-ingress"
@@ -44,7 +47,9 @@ metadata:
 {{- else }}
     ingress.kubernetes.io/ssl-redirect: "false"
 {{- end }}
+{{- if not .Values.deployment.openshift }}
     kubernetes.io/ingress.class: nginx
+{{- end }}
   {{- with .Values.ingress.control_center.annotations }}
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -68,6 +68,13 @@ volumes:
 affinity:
   anti_affinity: true
 
+## Deployment type
+##
+## Control what configurations of Apache Pulsar to deploy for a specified environment type
+deployment:
+  # This option will configure specific resources/object for a deployment on openshift
+  openshift: false
+
 ## Components
 ##
 ## Control what components of Apache Pulsar to deploy for the cluster


### PR DESCRIPTION
Fixes #507 


### Motivation

Addressing issues with control center's the api version, annotations, and the FQDN that gets built so that this can be deployed on openshift.   

### Modifications

1) Added logic around the `apiversion` in the file `control-center-ingress.yaml` by using the value of `deployment.openshift` being true or false.

2) Added the same logic around the annotation `kubernetes.io/ingress.class: nginx` to address how openshift handles ingress objects and allowing for routes to be created.

3) Added logic in file `_control_center_tpl`  in section `define pulsar.control_center_domain` to build the URL FQDN that openshift expects which also builds the routes.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

Check the box below.

Need to update docs? 
  
- [x] `no-need-doc` 
  
  I made comments in the value.yaml for what this new value does. At this point it is only a few items to change for the openshift deployment. If this were to grow I could see needing more information and documentation.
 
  

