### PR TITLE
Put vault init job under control of .Values.initialize flag.

### DIFF
--- a/charts/sn-platform/templates/vault/vault-initialize-public-key.yaml
+++ b/charts/sn-platform/templates/vault/vault-initialize-public-key.yaml
@@ -18,7 +18,7 @@
 #
 
 {{- if .Values.components.vault }}
-{{- if .Values.initialize}}
+{{- if .Values.initialize }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/sn-platform/templates/vault/vault-initialize.yaml
+++ b/charts/sn-platform/templates/vault/vault-initialize.yaml
@@ -18,7 +18,7 @@
 #
 
 {{- if .Values.components.vault }}
-{{- if .Values.initialize}}
+{{- if .Values.initialize }}
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
Fixes #508

### Motivation
Vault init job is not controlled by .Values.initialize flag which will cause problem when the job is updated and user do a `helm upgrade` .

### Modifications
Put vault init job under control of .Values.initialize flag

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation
- [x] `no-need-doc` 
 it's bug fix
