### PR TITLE
Merge support for adoption of some ZK and BK resources

### DIFF
--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
@@ -55,6 +55,9 @@ spec:
     {{- if and .Values.affinity.anti_affinity .Values.bookkeeper.affinity.anti_affinity }}
     affinity:
       podAntiAffinity:
+        {{ if .Values.bookkeeper.affinity.customRules }}
+{{ toYaml .Values.bookkeeper.affinity.customRules | indent 8 }}
+        {{ else }}
         {{ .Values.bookkeeper.affinity.type }}:
           {{ if eq .Values.bookkeeper.affinity.type "requiredDuringSchedulingIgnoredDuringExecution" }}
           - labelSelector:
@@ -91,6 +94,7 @@ spec:
                       - {{ .Values.bookkeeper.component }}
               topologyKey: "kubernetes.io/hostname"
           {{ end }}
+      {{ end }}
     {{- end }}
     {{- if .Values.bookkeeper.resources }}
     resources:

--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
@@ -117,6 +117,17 @@ spec:
         - {{ .Values.bookkeeper.configData.PULSAR_MEM }}
       gcOptions:
         - {{ .Values.bookkeeper.configData.PULSAR_GC }}
+    {{- if .Values.bookkeeper.operator.adopt_existing }}
+    volumes:
+    {{- if not (and .Values.volumes.persistence .Values.bookkeeper.volumes.persistence) }}
+    - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.journal.name }}"
+      emptyDir: {}
+    - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.ledgers.name }}"
+      emptyDir: {}
+    {{- end }}
+    {{- include "pulsar.bookkeeper.certs.volumes" . | nindent 4 }}
+    {{- include "pulsar.bookkeeper.log.volumes" . | nindent 4 }}
+    {{- end }}
   {{- if and .Values.volumes.persistence .Values.bookkeeper.volumes.persistence}}
   storage:
     journal:
@@ -159,7 +170,9 @@ spec:
     journalMaxBackups: "0"
     {{- if .Values.bookkeeper.operator.adopt_existing }}
     # if adopting existing bk cluster then also keep existing ledger/journal dir setting
+    journalDirectories: "/pulsar/data/bookkeeper/journal"
     PULSAR_PREFIX_journalDirectories: "/pulsar/data/bookkeeper/journal"
+    ledgerDirectories: "/pulsar/data/bookkeeper/ledgers"
     PULSAR_PREFIX_ledgerDirectories: "/pulsar/data/bookkeeper/ledgers"
     {{- end }}
     BOOKIE_MEM: {{ .Values.bookkeeper.configData.BOOKIE_MEM }}
@@ -295,6 +308,34 @@ spec:
       {{ .Values.bookkeeper.operator.updatePolicy }}
       {{- else }}
         - all
+      {{- end }}
+      {{- if .Values.bookkeeper.operator.adopt_existing }}
+      {{- if and .Values.volumes.persistence .Values.bookkeeper.volumes.persistence}}
+      volumeClaimTemplates:
+      - metadata:
+          name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.journal.name }}"
+        spec:
+          accessModes: [ "ReadWriteOnce" ]
+          resources:
+            requests:
+              storage: {{ .Values.bookkeeper.volumes.journal.size }}
+          {{- include "pulsar.bookkeeper.journal.storage.class" . | nindent 10 }}
+      - metadata:
+          name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.ledgers.name }}"
+        spec:
+          accessModes: [ "ReadWriteOnce" ]
+          resources:
+            requests:
+              storage: {{ .Values.bookkeeper.volumes.ledgers.size }}
+          {{- include "pulsar.bookkeeper.ledgers.storage.class" . | nindent 10 }}
+      {{- end }}
+      volumeMounts:
+      - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.journal.name }}"
+        mountPath: /pulsar/data/bookkeeper/journal
+      - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}-{{ .Values.bookkeeper.volumes.ledgers.name }}"
+        mountPath: /pulsar/data/bookkeeper/ledgers
+      {{- include "pulsar.bookkeeper.certs.volumeMounts" . | nindent 6 }}
+      {{- include "pulsar.bookkeeper.log.volumeMounts" . | nindent 6 }}
       {{- end }}
     autoRecoveryStatefulSet:
       metadata:

--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-statefulset.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-statefulset.yaml
@@ -80,6 +80,9 @@ spec:
       affinity:
         {{- if and .Values.affinity.anti_affinity .Values.bookkeeper.affinity.anti_affinity}}
         podAntiAffinity:
+          {{ if .Values.bookkeeper.affinity.customRules }}
+{{ toYaml .Values.bookkeeper.affinity.customRules | indent 10 }}
+          {{ else }}
           {{ .Values.bookkeeper.affinity.type }}:
           {{ if eq .Values.bookkeeper.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}
           - labelSelector:
@@ -110,11 +113,12 @@ spec:
                       operator: In
                       values:
                       - {{ .Release.Name }}
-                    - key: "component" 
+                    - key: "component"
                       operator: In
                       values:
                       - {{ .Values.bookkeeper.component }}
                 topologyKey: "kubernetes.io/hostname"
+          {{ end }}
           {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.bookkeeper.gracePeriod }}

--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -21,7 +21,7 @@
 apiVersion: pulsar.streamnative.io/v1alpha1
 kind: PulsarBroker
 metadata:
-  # no need to add component to name here as operator will add 
+  # no need to add component to name here as operator will add
   name: "{{ template "pulsar.fullname" . }}"
   namespace: {{ template "pulsar.namespace" . }}
   annotations:
@@ -73,6 +73,9 @@ spec:
     {{- if and .Values.affinity.anti_affinity .Values.broker.affinity.anti_affinity }}
     affinity:
       podAntiAffinity:
+        {{ if .Values.broker.affinity.customRules }}
+{{ toYaml .Values.broker.affinity.customRules | indent 8 }}
+        {{ else }}
         {{ .Values.broker.affinity.type }}:
           {{ if eq .Values.broker.affinity.type "requiredDuringSchedulingIgnoredDuringExecution" }}
           - labelSelector:
@@ -109,6 +112,7 @@ spec:
                       - {{ .Values.broker.component }}
               topologyKey: "kubernetes.io/hostname"
           {{ end }}
+      {{ end }}
     {{- end }}
     vars:
     {{- if .Values.auth.authentication.enabled }}

--- a/charts/sn-platform/templates/broker/broker-statefulset.yaml
+++ b/charts/sn-platform/templates/broker/broker-statefulset.yaml
@@ -80,6 +80,9 @@ spec:
       affinity:
         {{- if and .Values.affinity.anti_affinity .Values.broker.affinity.anti_affinity}}
         podAntiAffinity:
+          {{ if .Values.broker.affinity.customRules }}
+{{ toYaml .Values.broker.affinity.customRules | indent 10 }}
+          {{ else }}
           {{ .Values.broker.affinity.type }}:
           {{ if eq .Values.broker.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}
           - labelSelector:
@@ -115,6 +118,7 @@ spec:
                       values:
                       - {{ .Values.broker.component }}
                 topologyKey: "kubernetes.io/hostname"
+          {{ end }}
           {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.broker.gracePeriod }}

--- a/charts/sn-platform/templates/broker/broker-statefulset.yaml
+++ b/charts/sn-platform/templates/broker/broker-statefulset.yaml
@@ -110,7 +110,7 @@ spec:
                       operator: In
                       values:
                       - {{ .Release.Name }}
-                    - key: "component" 
+                    - key: "component"
                       operator: In
                       values:
                       - {{ .Values.broker.component }}

--- a/charts/sn-platform/templates/detector/pulsar-detector-statefulset.yaml
+++ b/charts/sn-platform/templates/detector/pulsar-detector-statefulset.yaml
@@ -92,7 +92,7 @@ spec:
         command: ["sh", "-c"]
         args:
         - >
-          bin/pulsar-detector -service-url {{ template "pulsar.detector.serviceUrl" . }} -webservice-url {{ template "pulsar.detector.webServiceUrl" . }} {{- if .Values.auth.authentication.enabled }} -auth-plugin token -auth-params "{\"token\":\"$brokerClientAuthenticationParameters\"}" {{- end }} ;
+          bin/pulsar-detector -service-url {{ template "pulsar.detector.serviceUrl" . }} -webservice-url {{ template "pulsar.detector.webServiceUrl" . }} {{- if .Values.auth.authentication.enabled }} -auth-plugin token -auth-params "{\"token\":\"$brokerClientAuthenticationParameters\"}" {{- end }} {{- if .Values.pulsar_detector.extraArgs }} {{.Values.pulsar_detector.extraArgs }} {{- end }};
         ports:
         # prometheus needs to access /metrics endpoint
         - name: server

--- a/charts/sn-platform/templates/extra.yaml
+++ b/charts/sn-platform/templates/extra.yaml
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+{{- range .Values.extraResources }}
+{{ toYaml . }}
+---
+{{- end }}

--- a/charts/sn-platform/templates/presto/presto-coordinator-configmap.yaml
+++ b/charts/sn-platform/templates/presto/presto-coordinator-configmap.yaml
@@ -241,6 +241,10 @@ data:
     # default is Runtime.getRuntime().availableProcessors().
     pulsar.managed-ledger-num-scheduler-threads = {{ .Values.presto.catalog.pulsar.mlNumSchedulerThreads }}
 
+    {{- if .Values.presto.coordinator.config.extraConfig }}
+{{ .Values.presto.coordinator.config.extraConfig | indent 4 }}
+    {{- end }}
+
 {{- if or .Values.presto.security.authentication.jwt.enabled .Values.presto.security.authentication.password.enabled }}
   rules.json:
 {{ toYaml .Values.presto.security.rules | indent 2 }}

--- a/charts/sn-platform/templates/presto/presto-worker-configmap.yaml
+++ b/charts/sn-platform/templates/presto/presto-worker-configmap.yaml
@@ -224,6 +224,11 @@ data:
     # Number of threads to be used for managed ledger scheduled tasks,
     # default is Runtime.getRuntime().availableProcessors().
     pulsar.managed-ledger-num-scheduler-threads = {{ .Values.presto.catalog.pulsar.mlNumSchedulerThreads }}
+
+    {{- if .Values.presto.worker.config.extraConfig }}
+{{ .Values.presto.worker.config.extraConfig | indent 4 }}
+    {{- end }}
+
   health_check.sh: |
     #!/bin/bash
     curl --silent {{ template "presto.service" . }}:{{ .Values.presto.coordinator.ports.http }}/v1/node | tr "," "\n" | grep --silent $(hostname)

--- a/charts/sn-platform/templates/prometheus/prometheus-statefulset.yaml
+++ b/charts/sn-platform/templates/prometheus/prometheus-statefulset.yaml
@@ -69,6 +69,50 @@ spec:
       securityContext:
 {{ toYaml .Values.prometheus.securityContext | indent 8 }}
       {{- end }}
+      affinity:
+        {{- if and .Values.affinity.anti_affinity .Values.prometheus.affinity.anti_affinity}}
+        podAntiAffinity:
+          {{ if .Values.prometheus.affinity.customRules }}
+{{ toYaml .Values.prometheus.affinity.customRules | indent 10 }}
+          {{ else }}
+          {{ .Values.prometheus.affinity.type }}:
+          {{ if eq .Values.prometheus.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}
+          - labelSelector:
+              matchExpressions:
+              - key: "app"
+                operator: In
+                values:
+                - "{{ template "pulsar.name" . }}"
+              - key: "release"
+                operator: In
+                values:
+                - {{ .Release.Name }}
+              - key: "component"
+                operator: In
+                values:
+                - {{ .Values.prometheus.component }}
+            topologyKey: "kubernetes.io/hostname"
+          {{ else }}
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: "app"
+                      operator: In
+                      values:
+                      - "{{ template "pulsar.name" . }}"
+                    - key: "release"
+                      operator: In
+                      values:
+                      - {{ .Release.Name }}
+                    - key: "component"
+                      operator: In
+                      values:
+                      - {{ .Values.prometheus.component }}
+                topologyKey: "kubernetes.io/hostname"
+          {{ end }}
+          {{ end }}
+        {{- end }}
       containers:
       {{- if .Values.configmapReload.prometheus.enabled }}
       - name: {{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}-{{ .Values.configmapReload.prometheus.name }}

--- a/charts/sn-platform/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-cluster.yaml
@@ -21,7 +21,7 @@
 apiVersion: pulsar.streamnative.io/v1alpha1
 kind: PulsarProxy
 metadata:
-  # no need to append component name to pod name here as operator will add 
+  # no need to append component name to pod name here as operator will add
   name: "{{ template "pulsar.fullname" . }}"
   namespace: {{ template "pulsar.namespace" . }}
   annotations:
@@ -69,6 +69,9 @@ spec:
     {{- if and .Values.affinity.anti_affinity .Values.proxy.affinity.anti_affinity }}
     affinity:
       podAntiAffinity:
+        {{ if .Values.proxy.affinity.customRules }}
+{{ toYaml .Values.proxy.affinity.customRules | indent 8 }}
+        {{ else }}
         {{ .Values.proxy.affinity.type }}:
           {{ if eq .Values.proxy.affinity.type "requiredDuringSchedulingIgnoredDuringExecution" }}
           - labelSelector:
@@ -105,6 +108,7 @@ spec:
                       - {{ .Values.proxy.component }}
               topologyKey: "kubernetes.io/hostname"
           {{ end }}
+        {{ end }}
     {{- end }}
     {{- if .Values.auth.authentication.enabled }}
     vars:

--- a/charts/sn-platform/templates/proxy/proxy-statefulset.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-statefulset.yaml
@@ -80,6 +80,9 @@ spec:
       affinity:
         {{- if and .Values.affinity.anti_affinity .Values.proxy.affinity.anti_affinity}}
         podAntiAffinity:
+          {{ if .Values.proxy.affinity.customRules }}
+{{ toYaml .Values.proxy.affinity.customRules | indent 10 }}
+          {{ else }}
           {{ .Values.proxy.affinity.type }}:
           {{ if eq .Values.proxy.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}
           - labelSelector:
@@ -110,11 +113,12 @@ spec:
                       operator: In
                       values:
                       - {{ .Release.Name }}
-                    - key: "component" 
+                    - key: "component"
                       operator: In
                       values:
                       - {{ .Values.proxy.component }}
                 topologyKey: "kubernetes.io/hostname"
+          {{ end }}
           {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.proxy.gracePeriod }}

--- a/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
@@ -88,6 +88,9 @@ spec:
     affinity:
       {{- if and .Values.affinity.anti_affinity .Values.zookeeper.affinity.anti_affinity }}
       podAntiAffinity:
+        {{ if .Values.zookeeper.affinity.customRules }}
+{{ toYaml .Values.zookeeper.affinity.customRules | indent 8 }}
+        {{ else }}
         {{ .Values.zookeeper.affinity.type }}:
           {{ if eq .Values.zookeeper.affinity.type "requiredDuringSchedulingIgnoredDuringExecution" }}
           - labelSelector:
@@ -125,6 +128,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
           {{ end }}
         {{- end }}
+      {{ end }}
     {{- if .Values.zookeeper.resources }}
     resources:
 {{ toYaml .Values.zookeeper.resources | indent 6 }}

--- a/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
@@ -146,6 +146,18 @@ spec:
         - {{ .Values.zookeeper.configData.PULSAR_MEM }}
       gcOptions:
         - {{ .Values.zookeeper.configData.PULSAR_GC }}
+    {{- if .Values.zookeeper.operator.adopt_existing }}
+    volumes:
+    {{- include "pulsar.zookeeper.data.volumes" . | nindent 4 }}
+    {{- include "pulsar.zookeeper.certs.volumes" . | nindent 4 }}
+    {{- include "pulsar.zookeeper.log.volumes" . | nindent 4 }}
+    {{- include "pulsar.zookeeper.genzkconf.volumes" . | nindent 4 }}
+    {{- if .Values.zookeeper.customTools.restore.enable }}
+    - name: restore-config
+      configMap:
+        name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.customTools.restore.component }}"
+    {{- end }}
+    {{- end }}
   {{- if and .Values.volumes.persistence .Values.zookeeper.volumes.persistence }}
   persistence:
     data:
@@ -223,6 +235,15 @@ spec:
       {{ .Values.zookeeper.operator.updatePolicy }}
       {{- else }}
         - all
+      {{- end }}
+      {{- if .Values.zookeeper.operator.adopt_existing }}
+      volumeClaimTemplates:
+      {{- include "pulsar.zookeeper.data.volumeClaimTemplates" . | nindent 6 }}
+      volumeMounts:
+      {{- include "pulsar.zookeeper.data.volumeMounts" . | nindent 6 }}
+      {{- include "pulsar.zookeeper.certs.volumeMounts" . | nindent 6 }}
+      {{- include "pulsar.zookeeper.log.volumeMounts" . | nindent 6 }}
+      {{- include "pulsar.zookeeper.genzkconf.volumeMounts" . | nindent 6 }}
       {{- end }}
     configMap:
       metadata:

--- a/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
@@ -226,4 +226,14 @@ spec:
     pdb:
       metadata:
         name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
+  advancedOptions:
+    {{- if .Values.zookeeper.advanced.staticServerList }}
+    staticServerList:
+      servers:
+{{ toYaml .Values.zookeeper.advanced.staticServerList | indent 8 }}
+    {{- end }}
+    {{- if .Values.zookeeper.advanced.customStartupCommand }}
+    customStartupCommand:
+{{ toYaml .Values.zookeeper.advanced.customStartupCommand | indent 6 }}
+    {{- end }}
 {{- end }}

--- a/charts/sn-platform/templates/zookeeper/zookeeper-statefulset.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-statefulset.yaml
@@ -79,6 +79,9 @@ spec:
       affinity:
         {{- if and .Values.affinity.anti_affinity .Values.zookeeper.affinity.anti_affinity}}
         podAntiAffinity:
+          {{ if .Values.zookeeper.affinity.customRules }}
+{{ toYaml .Values.zookeeper.affinity.customRules | indent 10 }}
+          {{ else }}
           {{ .Values.zookeeper.affinity.type }}:
           {{ if eq .Values.zookeeper.affinity.type "requiredDuringSchedulingIgnoredDuringExecution"}}
           - labelSelector:
@@ -114,6 +117,7 @@ spec:
                       values:
                       - {{ .Values.zookeeper.component }}
                 topologyKey: "kubernetes.io/hostname"
+          {{ end }}
           {{ end }}
         {{- end }}
       terminationGracePeriodSeconds: {{ .Values.zookeeper.gracePeriod }}

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -2192,6 +2192,10 @@ vault:
     local_storage: true
     # storageClassName: ""
 
+# Support the addition of arbitrary resources to be deployed
+# This is simply an array of raw manifests
+extraResources: []
+
 custom_metric_server:
   component: "custom-metric-server"
   cert_secret_name: "cert-secret"

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -594,6 +594,8 @@ zookeeper:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "8000"
+  advanced:
+    staticServerList: []
   securityContext: {}
   tolerations: []
   gracePeriod: 30
@@ -1615,6 +1617,12 @@ prometheus:
       memory: 256Mi
       cpu: 0.1
   # Definition of the serviceAccount used to run brokers.
+  affinity:
+    anti_affinity: true
+    # Set the anti affinity type. Valid values:
+    # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
+    # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
+    type: preferredDuringSchedulingIgnoredDuringExecution
   serviceAccount:
     # Specifies whether to use a service account to run this component
     use: true


### PR DESCRIPTION

### Motivation

This commit contains fixes for a few different problems, but primarily is to support additional flexibility needed to customize some aspects of having the operators adopt the ZK and BK resources. 

This commit also adds some additional options that were present in previous versions, but were to be supported when deploying with the operators, such as adding support for custom anti-affinity in most components.

A few other small features are added:
- support for advanced zookeeper options, present in operators
- additional arguments to the detector
- support for arbitrary extra resources

### Modifications

See above

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
 All of the features here are advanced usages of the charts, with adoption being something requires a lot of caution. Other features are self documenting via typical conventions
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

