### PR TITLE
Update sn platform version to 1.2.36

### DIFF
--- a/charts/sn-platform/Chart.yaml
+++ b/charts/sn-platform/Chart.yaml
@@ -18,10 +18,10 @@
 #
 
 apiVersion: v1
-appVersion: "1.2.35"
+appVersion: "1.2.36"
 description: StreamNative Platform Chart
 name: sn-platform
-version: 1.2.35
+version: 1.2.36
 home: https://streamnative.io
 sources:
 - https://github.com/streamnative/charts/tree/master/charts/sn-platform


### PR DESCRIPTION


* Upgrade sn platform version to 1.2.36 for solve this exception:

```
Downloading loki-stack from repo https://grafana.github.io/loki/charts
Deleting outdated charts
Successfully packaged chart and saved it to: /home/runner/work/charts/charts/.chart-packages/sn-platform-1.2.35.tgz
Uploading charts...
Error: error creating GitHub release: POST https://api.github.com/repos/streamnative/charts/releases: 422 Validation Failed [{Resource:Release Field:tag_name Code:already_exists Message:}]
```