### PR TITLE
Update local-storage-provisioner chart version to 1.1.0

### DIFF
--- a/charts/local-storage-provisioner/Chart.yaml
+++ b/charts/local-storage-provisioner/Chart.yaml
@@ -21,7 +21,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: Local Storage Provisioner for Kubernetes
 name: local-storage-provisioner
-version: 1.0.0
+version: 1.1.0
 home: https://streamnative.io
 sources:
 - https://github.com/streamnative/charts/local-storage-provisioner


### PR DESCRIPTION
Fixes #502

### Motivation
Update local-storage-provisioner chart version to use app/v1 for DaemonSet.

### Modifications
Update chart version.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.


### Documentation

Check the box below.

- [x] `no-need-doc` 
  