### PR TITLE
[charts/pulsar] Add ability to specify the cert-manager apiVersion

### DIFF
--- a/charts/pulsar/templates/tls/tls-cert-internal-issuer.yaml
+++ b/charts/pulsar/templates/tls/tls-cert-internal-issuer.yaml
@@ -19,7 +19,7 @@
 
 {{- if .Values.certs.internal_issuer.enabled }}
 {{- if eq .Values.certs.internal_issuer.type "selfsigning" }}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: "{{ .Values.certs.api_version }}"
 kind: Issuer
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.certs.internal_issuer.component }}"
@@ -28,7 +28,7 @@ spec:
   selfSigned: {}
 ---
 
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: "{{ .Values.certs.api_version }}"
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-ca"
@@ -50,7 +50,7 @@ spec:
     group: cert-manager.io
 ---
 
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: "{{ .Values.certs.api_version }}"
 kind: Issuer
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.certs.internal_issuer.component }}-ca-issuer"

--- a/charts/pulsar/templates/tls/tls-cert-public-issuer.yaml
+++ b/charts/pulsar/templates/tls/tls-cert-public-issuer.yaml
@@ -21,7 +21,7 @@
 {{- if .Values.certs.public_issuer.enabled }}
 {{- if eq .Values.certs.public_issuer.type "acme" }}
 {{- if not .Values.certs.public_issuer.issuer_override }}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: "{{ .Values.certs.api_version }}"
 kind: Issuer
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.certs.public_issuer.component }}"

--- a/charts/pulsar/templates/tls/tls-certs-internal.yaml
+++ b/charts/pulsar/templates/tls/tls-certs-internal.yaml
@@ -23,7 +23,7 @@
 {{- if .Values.tls.proxy.enabled }}
 {{- if not (and .Values.external_dns.enabled .Values.certs.public_issuer.enabled) }}
 # only configure issue private certicate for proxy when public_issuer is not used
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: "{{ .Values.certs.api_version }}"
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.tls.proxy.cert_name }}"
@@ -33,8 +33,8 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.proxy.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
+  subject:
+    organizations: {{ .Values.tls.common.organizations }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   {{- if .Values.tls.proxy.commonNameOverride }}
@@ -43,9 +43,10 @@ spec:
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
   {{- end }}
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.privateKey.size }}
+    algorithm: "{{ .Values.tls.common.privateKey.algorithm }}"
+    encoding: "{{ .Values.tls.common.privateKey.encoding }}"
   usages:
     - server auth
     - client auth
@@ -67,7 +68,7 @@ spec:
 {{- end }}
 
 {{- if or .Values.tls.broker.enabled (or .Values.tls.bookie.enabled .Values.tls.zookeeper.enabled) }}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: "{{ .Values.certs.api_version }}"
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.tls.broker.cert_name }}"
@@ -77,8 +78,8 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.broker.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
+  subject:
+    organizations: {{ .Values.tls.common.organizations }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   {{- if .Values.tls.broker.commonNameOverride }}
@@ -87,9 +88,10 @@ spec:
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
   {{- end }}
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.privateKey.size }}
+    algorithm: "{{ .Values.tls.common.privateKey.algorithm }}"
+    encoding: "{{ .Values.tls.common.privateKey.encoding }}"
   usages:
     - server auth
     - client auth
@@ -110,7 +112,7 @@ spec:
 {{- end }}
 
 {{- if or .Values.tls.bookie.enabled .Values.tls.zookeeper.enabled }}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: "{{ .Values.certs.api_version }}"
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.tls.bookie.cert_name }}"
@@ -120,8 +122,8 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.bookie.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
+  subject:
+    organizations: {{ .Values.tls.common.organizations }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   {{- if .Values.tls.bookkeeper.commonNameOverride }}
@@ -130,9 +132,10 @@ spec:
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
   {{- end }}
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.privateKey.size }}
+    algorithm: "{{ .Values.tls.common.privateKey.algorithm }}"
+    encoding: "{{ .Values.tls.common.privateKey.encoding }}"
   usages:
     - server auth
     - client auth
@@ -152,7 +155,7 @@ spec:
 {{- end }}
 
 {{- if .Values.tls.zookeeper.enabled }}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: "{{ .Values.certs.api_version }}"
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.tls.autorecovery.cert_name }}"
@@ -162,8 +165,8 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.autorecovery.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
+  subject:
+    organizations: {{ .Values.tls.common.organizations }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   {{- if .Values.tls.autorecovery.commonNameOverride }}
@@ -172,9 +175,10 @@ spec:
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
   {{- end }}
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.privateKey.size }}
+    algorithm: "{{ .Values.tls.common.privateKey.algorithm }}"
+    encoding: "{{ .Values.tls.common.privateKey.encoding }}"
   usages:
     - server auth
     - client auth
@@ -191,7 +195,7 @@ spec:
     # if you are using an external issuer, change this to that issuer group.
     group: cert-manager.io
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: "{{ .Values.certs.api_version }}"
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.tls.zookeeper.cert_name }}"
@@ -201,8 +205,8 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.zookeeper.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
+  subject:
+    organizations: {{ .Values.tls.common.organizations }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   {{- if .Values.tls.zookeeper.commonNameOverride }}
@@ -211,9 +215,10 @@ spec:
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
   {{- end }}
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.privateKey.size }}
+    algorithm: "{{ .Values.tls.common.privateKey.algorithm }}"
+    encoding: "{{ .Values.tls.common.privateKey.encoding }}"
   usages:
     - server auth
     - client auth
@@ -233,7 +238,7 @@ spec:
 {{- end }}
 
 {{- if or .Values.tls.pulsar_manager.enabled .Values.tls.broker.enabled }}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: "{{ .Values.certs.api_version }}"
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.tls.pulsar_manager.cert_name }}"
@@ -243,8 +248,8 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.pulsar_manager.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
+  subject:
+    organizations: {{ .Values.tls.common.organizations }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   {{- if .Values.tls.pulsar_manager.commonNameOverride }}
@@ -253,9 +258,10 @@ spec:
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
   {{- end }}
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.privateKey.size }}
+    algorithm: "{{ .Values.tls.common.privateKey.algorithm }}"
+    encoding: "{{ .Values.tls.common.privateKey.encoding }}"
   usages:
     - server auth
     - client auth
@@ -276,7 +282,7 @@ spec:
 {{- end }}
 
 {{- if or .Values.tls.zookeeper.enabled (and .Values.tls.broker.enabled .Values.components.kop) }}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: "{{ .Values.certs.api_version }}"
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.tls.toolset.cert_name }}"
@@ -286,8 +292,8 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.toolset.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
+  subject:
+    organizations: {{ .Values.tls.common.organizations }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   {{- if .Values.tls.toolset.commonNameOverride }}
@@ -296,9 +302,10 @@ spec:
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
   {{- end }}
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.privateKey.size }}
+    algorithm: "{{ .Values.tls.common.privateKey.algorithm }}"
+    encoding: "{{ .Values.tls.common.privateKey.encoding }}"
   usages:
     - server auth
     - client auth

--- a/charts/pulsar/templates/tls/tls-certs-public.yaml
+++ b/charts/pulsar/templates/tls/tls-certs-public.yaml
@@ -21,7 +21,7 @@
 {{- if .Values.certs.public_issuer.enabled }}
 {{- if .Values.tls.enabled }}
 {{- if .Values.tls.proxy.enabled }}
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: "{{ .Values.certs.api_version }}"
 kind: Certificate
 metadata:
   name: "{{ template "pulsar.fullname" . }}-{{ .Values.tls.proxy.cert_name }}"

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -212,11 +212,11 @@ tls:
     duration: 2160h
     # 15d
     renewBefore: 360h
-    organization:
-      - pulsar
-    keySize: 4096
-    keyAlgorithm: rsa
-    keyEncoding: pkcs8
+    organizations: [pulsar]
+    privateKey:
+      size: 4096
+      algorithm: RSA
+      encoding: PKCS8
   # settings for generating certs for proxy
   proxy:
     enabled: false
@@ -306,6 +306,7 @@ certs:
     enabled: false
     component: public-cert-issuer
     type: acme
+  api_version: "cert-manager.io/v1"  
   issuers:
     selfsigning:
     acme:


### PR DESCRIPTION
### Motivation

Without enabled TLS the helm-controller refuses the helmrelease by the reason:
```
      Helm install failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
        line 43: mapping key "brokerServiceURL" already defined at line 41
        line 44: mapping key "brokerWebServiceURL" already defined at line 42
```
This should be solved to enable:
```
    tls:
      enabled: true
      broker:
        enabled: true
```
The condition is [here](https://github.com/streamnative/charts/blob/master/charts/pulsar/templates/proxy/proxy-configmap.yaml#L58-L61). But when trying to use the cert-manager and internal_issuer, the certs are not issued because the templates are using deprecated apiVersion `cert-manager.io/v1alpha2`.

### Modifications

Adding ability to specify the cert-manager apiVersion.

### Documentation

- [x] no-need-doc

I'm not sure if this change needs a docs change.
