### PR TITLE
Toolset extra env

### DIFF
--- a/charts/pulsar/templates/toolset/toolset-statefulset.yaml
+++ b/charts/pulsar/templates/toolset/toolset-statefulset.yaml
@@ -52,7 +52,7 @@ spec:
       {{- if .Values.toolset.imagePullSecrets }}
       imagePullSecrets:
       - name: {{ .Values.toolset.imagePullSecrets }}
-      {{- end }}  
+      {{- end }}
     {{- if .Values.toolset.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.toolset.nodeSelector | indent 8 }}
@@ -83,6 +83,9 @@ spec:
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
+{{- with .Values.toolset.extraEnv}}
+{{ toYaml . | indent 8 }}
+{{- end }}
         volumeMounts:
         {{- include "pulsar.toolset.certs.volumeMounts" . | nindent 8 }}
         {{- include "pulsar.toolset.token.volumeMounts" . | nindent 8 }}
@@ -106,6 +109,9 @@ spec:
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
+{{- with .Values.toolset.extraEnv}}
+{{ toYaml . | indent 8 }}
+{{- end }}
         volumeMounts:
         {{- include "pulsar.toolset.certs.volumeMounts" . | nindent 8 }}
         {{- include "pulsar.toolset.token.volumeMounts" . | nindent 8 }}

--- a/charts/pulsar/templates/toolset/toolset-statefulset.yaml
+++ b/charts/pulsar/templates/toolset/toolset-statefulset.yaml
@@ -83,6 +83,7 @@ spec:
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
+        env:
 {{- with .Values.toolset.extraEnv}}
 {{ toYaml . | indent 8 }}
 {{- end }}
@@ -109,6 +110,7 @@ spec:
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
+        env:
 {{- with .Values.toolset.extraEnv}}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1355,6 +1355,7 @@ toolset:
   autoRollDeployment: true
   # pulsarAdminUrlOverride:
   # pulsarServiceUrlOverride:
+  extraEnv: []
   configData:
     PULSAR_MEM: >
       -Xms64M

--- a/charts/sn-platform/templates/toolset/toolset-statefulset.yaml
+++ b/charts/sn-platform/templates/toolset/toolset-statefulset.yaml
@@ -75,6 +75,7 @@ spec:
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
+        env:
 {{- with .Values.toolset.extraEnv}}
 {{ toYaml . | indent 8 }}
 {{- end }}
@@ -100,6 +101,7 @@ spec:
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
+        env:
 {{- with .Values.toolset.extraEnv}}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/charts/sn-platform/templates/toolset/toolset-statefulset.yaml
+++ b/charts/sn-platform/templates/toolset/toolset-statefulset.yaml
@@ -75,6 +75,9 @@ spec:
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
+{{- with .Values.toolset.extraEnv}}
+{{ toYaml . | indent 8 }}
+{{- end }}
         volumeMounts:
         {{- include "pulsar.toolset.certs.volumeMounts" . | nindent 8 }}
         {{- include "pulsar.toolset.token.volumeMounts" . | nindent 8 }}
@@ -97,6 +100,9 @@ spec:
         envFrom:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
+{{- with .Values.toolset.extraEnv}}
+{{ toYaml . | indent 8 }}
+{{- end }}
         volumeMounts:
         {{- include "pulsar.toolset.certs.volumeMounts" . | nindent 8 }}
         {{- include "pulsar.toolset.token.volumeMounts" . | nindent 8 }}

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1517,6 +1517,7 @@ toolset:
   ##
   # Automtically Roll Deployments when configmap is changed
   autoRollDeployment: true
+  extraEnv: []
   configData:
     PULSAR_MEM: >
       -Xms64M


### PR DESCRIPTION


### Motivation

Add support for extra env vars for toolset pods

### Modifications

Adds `extraEnv` to the toolset pods in pulsar and sn-platform charts

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

