### PR TITLE
Add support for additional scrape rules in prom

### DIFF
--- a/charts/pulsar/templates/prometheus/prometheus-configmap.yaml
+++ b/charts/pulsar/templates/prometheus/prometheus-configmap.yaml
@@ -137,6 +137,11 @@ data:
           target_label: __metrics_path__
           replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
 {{- end }}
+{{- if .Values.prometheus.extraScrapeConfigs -}}
+{{- with .Values.prometheus.extraScrapeConfigs }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}
   rules.yml: |
 {{- if .Values.monitoring.alert_manager -}}
 {{- with .Values.alert_manager.rules }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1533,6 +1533,7 @@ prometheus:
       initialDelaySeconds: 30
       periodSeconds: 10
   customRelabelConfigs: []
+  extraScrapeConfigs: []
 
   ## Prometheus service
   ## templates/prometheus-service.yaml

--- a/charts/sn-platform/templates/prometheus/prometheus-configmap.yaml
+++ b/charts/sn-platform/templates/prometheus/prometheus-configmap.yaml
@@ -134,6 +134,11 @@ data:
           target_label: __metrics_path__
           replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
 {{- end }}
+{{- if .Values.prometheus.extraScrapeConfigs -}}
+{{- with .Values.prometheus.extraScrapeConfigs }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}
   rules.yml: |
 {{- if .Values.monitoring.alert_manager -}}
 {{- with .Values.alert_manager.rules }}

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1616,6 +1616,8 @@ prometheus:
       initialDelaySeconds: 30
       periodSeconds: 10
   customRelabelConfigs: []
+  extraScrapeConfigs: []
+
   ## Prometheus service
   ## templates/prometheus-service.yaml
   ##


### PR DESCRIPTION
In some situations, we may want to add a custom scrape config, this adds
support for that in the prometheus components of both charts


### Modifications

Adds the ability to add extra scape rules in prom

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
Small change with a simple new option in the values. We currently don't document all the values files.
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

