### PR TITLE
Change release trigger event to workflow_dispatch and add callback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,8 @@
 
 name: Post commit - Publish Pulsar Helm Chart
 on:
-  push:
-    branches:
-      - master 
+  workflow_dispatch:
+
 jobs:
   lint-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/release_callback.yaml
+++ b/.github/workflows/release_callback.yaml
@@ -1,0 +1,16 @@
+on:
+  workflow_run:
+    workflows: [ Post commit - Publish Pulsar Helm Chart ]
+    types: [ completed ]
+
+jobs:
+  callback:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Invoke workflow in another repo with inputs
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: post-release
+          repo: streamnative/workflows
+          token: ${{ secrets.SNBOT_TOKEN }}
+          inputs: '{"conclusion": "${{ github.event.workflow_run.conclusion }}", "html_url": "${{ github.event.workflow_run.html_url }}" }'

--- a/.github/workflows/release_callback.yaml
+++ b/.github/workflows/release_callback.yaml
@@ -1,3 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 on:
   workflow_run:
     workflows: [ Post commit - Publish Pulsar Helm Chart ]


### PR DESCRIPTION
### Motivation

Currently, SN/charts uses `push master` event to trigger release, but this produces many fail workflows if the chart version had not be changed, so we would like to trigger it manually.

### Modifications

- Add workflow_dispatch event to trigger release workflow
- Add release callback to integrate with workflows platform

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

