### PR TITLE
[charts/sn-pulsar] Change the pulsar detector image to sn-platform

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -157,7 +157,7 @@ images:
     tag: 2.8.0.8
     pullPolicy: IfNotPresent
   pulsar_detector:
-    repository: streamnative/sn-pulsar
+    repository: streamnative/sn-platform
     tag: 2.8.0.8
     pullPolicy: IfNotPresent
   functions:


### PR DESCRIPTION
Right now, when enabling pulsar detector, the pod crashloops because bin/pulsar-detector can't be found in the sn-pulsar image. This fixes that by referencing the correct image.

<!--
### Contribution Checklist
  
  - Name the pull request in the form "[charts/<chart-name>] Title of the pull request".
    Skip *[charts/<chart-name>]* if the PR doesn't change a specific chart. E.g. `[docs] Fix typo in README`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #529

### Motivation

Enabling pulsar detector did not work as intended, after investigation this was the solution: correcting the image.

### Modifications

Change the pulsar detector source image `sn-platform` instead of `sn-pulsar`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.


### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

