### PR TITLE
Support ImagePullSecrets in pulsar components

### DIFF
--- a/charts/pulsar-operator/crds/bookkeeper.streamnative.io_bookkeeperclusters.yaml
+++ b/charts/pulsar-operator/crds/bookkeeper.streamnative.io_bookkeeperclusters.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -1083,6 +1082,13 @@ spec:
                           additionalProperties:
                             type: string
                           type: object
+                        imagePullSecrets:
+                          items:
+                            properties:
+                              name:
+                                type: string
+                            type: object
+                          type: array
                         initContainers:
                           items:
                             properties:
@@ -2282,6 +2288,13 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                    imagePullSecrets:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                      type: array
                     initContainers:
                       items:
                         properties:

--- a/charts/pulsar-operator/crds/pulsar.streamnative.io_pulsarbrokers.yaml
+++ b/charts/pulsar-operator/crds/pulsar.streamnative.io_pulsarbrokers.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -781,6 +780,9 @@ spec:
                               type: object
                           type: object
                       type: object
+                    serviceURLGenerationPolicy:
+                      default: NameUIDPrefix
+                      type: string
                     transactionEnabled:
                       type: boolean
                   type: object
@@ -1066,6 +1068,13 @@ spec:
                       type: object
                     debug:
                       type: boolean
+                    imagePullSecrets:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                      type: array
                     initContainers:
                       items:
                         properties:
@@ -2336,6 +2345,13 @@ spec:
                       type: object
                     debug:
                       type: boolean
+                    imagePullSecrets:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                      type: array
                     initContainers:
                       items:
                         properties:

--- a/charts/pulsar-operator/crds/pulsar.streamnative.io_pulsarproxies.yaml
+++ b/charts/pulsar-operator/crds/pulsar.streamnative.io_pulsarproxies.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -942,6 +941,13 @@ spec:
                       type: object
                     debug:
                       type: boolean
+                    imagePullSecrets:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                      type: array
                     initContainers:
                       items:
                         properties:

--- a/charts/pulsar-operator/crds/zookeeper.streamnative.io_zookeeperclusters.yaml
+++ b/charts/pulsar-operator/crds/zookeeper.streamnative.io_zookeeperclusters.yaml
@@ -1,4 +1,3 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -798,6 +797,13 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                    imagePullSecrets:
+                      items:
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                      type: array
                     initContainers:
                       items:
                         properties:

--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
@@ -114,6 +114,10 @@ spec:
       gcOptions:
         - {{ .Values.bookkeeper.configData.PULSAR_GC }}
   {{- if and .Values.volumes.persistence .Values.bookkeeper.volumes.persistence}}
+    {{- if .Values.global.imagePullSecrets }}
+    imagePullSecrets:
+{{ toYaml .Values.global.imagePullSecrets | indent 6 }}
+    {{- end }}
   storage:
     journal:
       volumeClaimTemplate:

--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -158,6 +158,10 @@ spec:
       gcOptions:
         - {{ .Values.broker.configData.PULSAR_GC }}
       gcLoggingOptions: []
+    {{- if .Values.global.imagePullSecrets }}
+    imagePullSecrets:
+{{ toYaml .Values.global.imagePullSecrets | indent 6 }}
+    {{- end }}
   {{- if and .Values.broker.kop.enabled .Values.broker.kop.tls.enabled }}
   istio:
     enabled: true

--- a/charts/sn-platform/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-cluster.yaml
@@ -145,6 +145,10 @@ spec:
       gcOptions:
         - {{ .Values.proxy.configData.PULSAR_GC }}
       gcLoggingOptions: []
+    {{- if .Values.global.imagePullSecrets }}
+    imagePullSecrets:
+{{ toYaml .Values.global.imagePullSecrets | indent 6 }}
+    {{- end }}
   config:
     {{- if .Values.pulsar_metadata.clusterName }}
     clusterName: {{ .Values.pulsar_metadata.clusterName }}

--- a/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
@@ -143,6 +143,10 @@ spec:
       gcOptions:
         - {{ .Values.zookeeper.configData.PULSAR_GC }}
   {{- if and .Values.volumes.persistence .Values.zookeeper.volumes.persistence }}
+    {{- if .Values.global.imagePullSecrets }}
+    imagePullSecrets:
+{{ toYaml .Values.global.imagePullSecrets | indent 6 }}
+    {{- end }}
   persistence:
     data:
       accessModes:

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -35,6 +35,12 @@ namespaceCreate: false
 ### Global Settings
 ###
 
+global:
+  ## Reference to one or more secrets to be used when pulling images
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  imagePullSecrets: []
+  ## - name: image-pull-secret
+
 ## Pulsar Metadata Prefix
 ##
 ## By default, pulsar stores all the metadata at root path.


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[charts/<chart-name>] Title of the pull request".
    Skip *[charts/<chart-name>]* if the PR doesn't change a specific chart. E.g. `[docs] Fix typo in README`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->


### Motivation

Able to configure SN Platform to use a private registry.

### Modifications

- New feature values `global.imagePullSecret` in `charts/sn-platform`

- New CRDs that support imagePullSecrets in `charts/pulsar-operator`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [x] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

### Example values to enable imagePullSecrets
Just like the native K8s way

```
global:
    imagePullSecrets:
      - name: ghcr-secret
```
