### PR TITLE
[pulsar-operator] upgrade operators

### DIFF
--- a/charts/pulsar-operator/Chart.yaml
+++ b/charts/pulsar-operator/Chart.yaml
@@ -18,8 +18,8 @@
 #
 
 apiVersion: v1
-version: 0.8.23
-appVersion: "0.8.21"
+version: 0.9.0
+appVersion: "0.9.4"
 kubeVersion: ">= 1.16.0-0 < 1.24.0-0"
 description: Apache Pulsar Operators Helm chart for Kubernetes
 name: pulsar-operator

--- a/charts/pulsar-operator/values.yaml
+++ b/charts/pulsar-operator/values.yaml
@@ -39,24 +39,24 @@ components:
 ##
 ## Control what images to use for each component
 images:
-  registry: "docker.io"
-  tag: "v0.8.21"
+  registry: "docker.cloudsmith.io"
+  tag: "v0.9.4"
 
   zookeeper:
     registry: ""
-    repository: streamnative/zookeeper-operator
+    repository: streamnative/operators/zookeeper-operator
     tag: ""
     pullPolicy: IfNotPresent
 
   bookkeeper:
     registry: ""
-    repository: streamnative/bookkeeper-operator
+    repository: streamnative/operators/bookkeeper-operator
     tag: ""
     pullPolicy: IfNotPresent
 
   pulsar:
     registry: ""
-    repository: streamnative/pulsar-operator
+    repository: streamnative/operators/pulsar-operator
     tag: ""
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
### Motivation

Upgrade operators' image tags. 

### Modifications

- Upgrade operators' image tags to v0.9.4
- Switch to use cloudsmith as the image registry.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

