### PR TITLE
Add option to turn off prometheus scarping annotation.

### DIFF
--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-autorecovery-statefulset.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-autorecovery-statefulset.yaml
@@ -46,15 +46,19 @@ spec:
       labels:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.autorecovery.component }}
+{{- if or .Values.prometheus.scrape.autorecovery .Values.autorecovery.autoRollDeployment .Values.autorecovery.annotations }}        
       annotations:
+{{- if .Values.prometheus.scrape.autorecovery}}
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.autorecovery.ports.http }}"
+{{- end}}
         {{- if .Values.autorecovery.autoRollDeployment }}
         checksum/config: {{ include (print $.Template.BasePath "/bookkeeper/bookkeeper-autorecovery-configmap.yaml") . | sha256sum }}
         {{- end }}
 {{- with .Values.autorecovery.annotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}
+{{- end }}    
     spec:
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-autorecovery-statefulset.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-autorecovery-statefulset.yaml
@@ -46,9 +46,9 @@ spec:
       labels:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.autorecovery.component }}
-{{- if or .Values.prometheus.scrape.autorecovery .Values.autorecovery.autoRollDeployment .Values.autorecovery.annotations }}        
+{{- if or (and .Values.prometheus.scrape.autorecovery .Values.prometheus.scrape.enabled) .Values.autorecovery.autoRollDeployment .Values.autorecovery.annotations }}        
       annotations:
-{{- if .Values.prometheus.scrape.autorecovery}}
+{{- if (and .Values.prometheus.scrape.autorecovery .Values.prometheus.scrape.enabled) }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.autorecovery.ports.http }}"
 {{- end}}

--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
@@ -43,14 +43,18 @@ spec:
 {{- with .Values.bookkeeper.labels }}
 {{ toYaml . | indent 6 }}
 {{- end }}
+{{- if or .Values.monitoring.datadog .Values.prometheus.scrape.bookkeeper .Values.bookkeeper.annotations }}
     annotations:
       {{- if .Values.monitoring.datadog }}
       {{- include "pulsar.bookkeeper.datadog.annotation" . | nindent 6 }}
       {{- end }}
+{{- if .Values.prometheus.scrape.bookkeeper }}
       prometheus.io/scrape: "true"
       prometheus.io/port: "{{ .Values.bookkeeper.ports.http }}"
+{{- end }}
 {{- with .Values.bookkeeper.annotations }}
 {{ toYaml . | indent 6 }}
+{{- end }}
 {{- end }}
     {{- if and .Values.affinity.anti_affinity .Values.bookkeeper.affinity.anti_affinity }}
     affinity:
@@ -211,12 +215,16 @@ spec:
       labels:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.autorecovery.component }}
+{{- if or .Values.prometheus.scrape.autorecovery .Values.autorecovery.annotations }}
       annotations:
+{{- if .Values.prometheus.scrape.autorecovery }}        
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.autorecovery.ports.http }}"
+{{- end }}
 {{- with .Values.autorecovery.annotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}
+{{- end }}      
       {{- if .Values.autorecovery.securityContext }}
       securityContext: {{ .Values.autorecovery.securityContext }}
       {{- end }}

--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
@@ -43,12 +43,12 @@ spec:
 {{- with .Values.bookkeeper.labels }}
 {{ toYaml . | indent 6 }}
 {{- end }}
-{{- if or .Values.monitoring.datadog .Values.prometheus.scrape.bookkeeper .Values.bookkeeper.annotations }}
+{{- if or .Values.monitoring.datadog (and .Values.prometheus.scrape.bookkeeper .Values.prometheus.scrape.enabled) .Values.bookkeeper.annotations }}
     annotations:
       {{- if .Values.monitoring.datadog }}
       {{- include "pulsar.bookkeeper.datadog.annotation" . | nindent 6 }}
       {{- end }}
-{{- if .Values.prometheus.scrape.bookkeeper }}
+{{- if (and .Values.prometheus.scrape.bookkeeper .Values.prometheus.scrape.enabled) }}
       prometheus.io/scrape: "true"
       prometheus.io/port: "{{ .Values.bookkeeper.ports.http }}"
 {{- end }}
@@ -215,9 +215,9 @@ spec:
       labels:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.autorecovery.component }}
-{{- if or .Values.prometheus.scrape.autorecovery .Values.autorecovery.annotations }}
+{{- if or (and .Values.prometheus.scrape.autorecovery .Values.prometheus.scrape.enabled) .Values.autorecovery.annotations }}
       annotations:
-{{- if .Values.prometheus.scrape.autorecovery }}        
+{{- if and .Values.prometheus.scrape.autorecovery .Values.prometheus.scrape.enabled }}        
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.autorecovery.ports.http }}"
 {{- end }}

--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-statefulset.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-statefulset.yaml
@@ -45,17 +45,21 @@ spec:
       labels:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.bookkeeper.component }}
+{{- if or .Values.prometheus.scrape.bookkeeper .Values.bookkeeper.autoRollDeployment .Values.monitoring.datadog .Values.bookkeeper.annotations }}
       annotations:
         {{- if .Values.monitoring.datadog }}
         {{- include "pulsar.bookkeeper.datadog.annotation" . | nindent 8 }}
         {{- end }}
+{{- if .Values.prometheus.scrape.bookkeeper }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.bookkeeper.ports.http }}"
+{{- end }}
         {{- if .Values.bookkeeper.autoRollDeployment }}
         checksum/config: {{ include (print $.Template.BasePath "/bookkeeper/bookkeeper-configmap.yaml") . | sha256sum }}
         {{- end }}
 {{- with .Values.bookkeeper.annotations }}
 {{ toYaml . | indent 8 }}
+{{- end }}
 {{- end }}
     spec:
       {{- if .Values.imagePullSecrets }}

--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-statefulset.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-statefulset.yaml
@@ -45,12 +45,12 @@ spec:
       labels:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.bookkeeper.component }}
-{{- if or .Values.prometheus.scrape.bookkeeper .Values.bookkeeper.autoRollDeployment .Values.monitoring.datadog .Values.bookkeeper.annotations }}
+{{- if or (and .Values.prometheus.scrape.bookkeeper .Values.prometheus.scrape.enabled) .Values.bookkeeper.autoRollDeployment .Values.monitoring.datadog .Values.bookkeeper.annotations }}
       annotations:
         {{- if .Values.monitoring.datadog }}
         {{- include "pulsar.bookkeeper.datadog.annotation" . | nindent 8 }}
         {{- end }}
-{{- if .Values.prometheus.scrape.bookkeeper }}
+{{- if (and .Values.prometheus.scrape.bookkeeper .Values.prometheus.scrape.enabled) }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.bookkeeper.ports.http }}"
 {{- end }}

--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -48,14 +48,18 @@ spec:
 {{- with .Values.broker.labels }}
 {{ toYaml . | indent 6 }}
 {{- end }}
+{{- if or .Values.prometheus.scrape.broker .Values.monitoring.datadog .Values.broker.annotations }}
     annotations:
       {{- if .Values.monitoring.datadog }}
       {{- include "pulsar.broker.datadog.annotation" . | nindent 6 }}
       {{- end }}
+{{- if .Values.prometheus.scrape.broker }}
       prometheus.io/scrape: "true"
       prometheus.io/port: "{{ .Values.broker.ports.http }}"
+{{- end }}
 {{- with .Values.broker.annotations }}
 {{ toYaml . | indent 6 }}
+{{- end }}
 {{- end }}
     {{- if or .Values.broker.readPublicKeyFromFile (and .Values.broker.offload.gcs.enabled .Values.broker.offload.gcs.secret) }}
     secretRefs:

--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -48,12 +48,12 @@ spec:
 {{- with .Values.broker.labels }}
 {{ toYaml . | indent 6 }}
 {{- end }}
-{{- if or .Values.prometheus.scrape.broker .Values.monitoring.datadog .Values.broker.annotations }}
+{{- if or (and .Values.prometheus.scrape.broker .Values.prometheus.scrape.enabled) .Values.monitoring.datadog .Values.broker.annotations }}
     annotations:
       {{- if .Values.monitoring.datadog }}
       {{- include "pulsar.broker.datadog.annotation" . | nindent 6 }}
       {{- end }}
-{{- if .Values.prometheus.scrape.broker }}
+{{- if (and .Values.prometheus.scrape.broker .Values.prometheus.scrape.enabled) }}
       prometheus.io/scrape: "true"
       prometheus.io/port: "{{ .Values.broker.ports.http }}"
 {{- end }}

--- a/charts/sn-platform/templates/broker/broker-statefulset.yaml
+++ b/charts/sn-platform/templates/broker/broker-statefulset.yaml
@@ -45,18 +45,22 @@ spec:
       labels:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.broker.component }}
+{{- if or .Values.prometheus.scrape.broker .Values.monitoring.datadog .Values.broker.autoRollDeployment .Values.broker.annotations }}        
       annotations:
         {{- if .Values.monitoring.datadog }}
         {{- include "pulsar.broker.datadog.annotation" . | nindent 8 }}
         {{- end }}
+{{- if .Values.prometheus.scrape.broker }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.broker.ports.http }}"
+{{- end }}
         {{- if .Values.broker.autoRollDeployment }}
         checksum/config: {{ include (print $.Template.BasePath "/broker/broker-configmap.yaml") . | sha256sum }}
         {{- end }}
 {{- with .Values.broker.annotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}
+{{- end }}    
     spec:
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/sn-platform/templates/broker/broker-statefulset.yaml
+++ b/charts/sn-platform/templates/broker/broker-statefulset.yaml
@@ -45,12 +45,12 @@ spec:
       labels:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.broker.component }}
-{{- if or .Values.prometheus.scrape.broker .Values.monitoring.datadog .Values.broker.autoRollDeployment .Values.broker.annotations }}        
+{{- if or (and .Values.prometheus.scrape.broker .Values.prometheus.scrape.enabled) .Values.monitoring.datadog .Values.broker.autoRollDeployment .Values.broker.annotations }}        
       annotations:
         {{- if .Values.monitoring.datadog }}
         {{- include "pulsar.broker.datadog.annotation" . | nindent 8 }}
         {{- end }}
-{{- if .Values.prometheus.scrape.broker }}
+{{- if (and .Values.prometheus.scrape.broker .Values.prometheus.scrape.enabled) }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.broker.ports.http }}"
 {{- end }}

--- a/charts/sn-platform/templates/control-center/ingress-controller-deployment.yaml
+++ b/charts/sn-platform/templates/control-center/ingress-controller-deployment.yaml
@@ -39,7 +39,7 @@ spec:
       labels:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.ingress.controller.component }}
-{{- if .Values.prometheus.scrape.ingress_controller}}
+{{- if and .Values.prometheus.scrape.ingress_controller .Values.prometheus.scrape.enabled }}
       annotations:
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"

--- a/charts/sn-platform/templates/control-center/ingress-controller-deployment.yaml
+++ b/charts/sn-platform/templates/control-center/ingress-controller-deployment.yaml
@@ -39,9 +39,11 @@ spec:
       labels:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.ingress.controller.component }}
+{{- if .Values.prometheus.scrape.ingress_controller}}
       annotations:
         prometheus.io/port: "10254"
         prometheus.io/scrape: "true"
+{{- end }}
     spec:
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/sn-platform/templates/function-worker/function-worker-statefulset.yaml
+++ b/charts/sn-platform/templates/function-worker/function-worker-statefulset.yaml
@@ -41,9 +41,9 @@ spec:
       labels:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.functions.component }}
-{{- if or .Values.prometheus.scrape.function_worker .Values.functions.autoRollDeployment .Values.functions.annotations }}
+{{- if or (and .Values.prometheus.scrape.function_worker .Values.prometheus.scrape.enabled) .Values.functions.autoRollDeployment .Values.functions.annotations }}
       annotations:
-{{- if .Values.prometheus.scrape.function_worker }}
+{{- if (and .Values.prometheus.scrape.function_worker .Values.prometheus.scrape.enabled) }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.functions.ports.http }}"
 {{- end }}

--- a/charts/sn-platform/templates/function-worker/function-worker-statefulset.yaml
+++ b/charts/sn-platform/templates/function-worker/function-worker-statefulset.yaml
@@ -41,15 +41,19 @@ spec:
       labels:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.functions.component }}
+{{- if or .Values.prometheus.scrape.function_worker .Values.functions.autoRollDeployment .Values.functions.annotations }}
       annotations:
+{{- if .Values.prometheus.scrape.function_worker }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.functions.ports.http }}"
+{{- end }}
         {{- if .Values.functions.autoRollDeployment }}
         checksum/config: {{ include (print $.Template.BasePath "/broker/function-worker-configfile-configmap.yaml") . | sha256sum }}
     {{- end }}
 {{- with .Values.functions.annotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}
+{{- end }}    
     spec:
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/sn-platform/templates/node-exporter/node-exporter.yaml
+++ b/charts/sn-platform/templates/node-exporter/node-exporter.yaml
@@ -40,9 +40,9 @@ spec:
       labels:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.node_exporter.component }}
-{{- if or .Values.prometheus.scrape.node_exporter .Values.node_exporter.annotations }}
+{{- if or (and .Values.prometheus.scrape.node_exporter .Values.prometheus.scrape.enabled) .Values.node_exporter.annotations }}
       annotations:
-{{- if .Values.prometheus.scrape.node_exporter }}
+{{- if (and .Values.prometheus.scrape.node_exporter .Values.prometheus.scrape.enabled) }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "9100"
 {{- end}}

--- a/charts/sn-platform/templates/node-exporter/node-exporter.yaml
+++ b/charts/sn-platform/templates/node-exporter/node-exporter.yaml
@@ -40,12 +40,16 @@ spec:
       labels:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.node_exporter.component }}
+{{- if or .Values.prometheus.scrape.node_exporter .Values.node_exporter.annotations }}
       annotations:
+{{- if .Values.prometheus.scrape.node_exporter }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "9100"
+{{- end}}
 {{- with .Values.node_exporter.annotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}
+{{- end }}   
     spec:
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/sn-platform/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-cluster.yaml
@@ -44,14 +44,18 @@ spec:
 {{- with .Values.proxy.labels }}
 {{ toYaml . | indent 6 }}
 {{- end }}
+{{- if or .Values.prometheus.scrape.proxy .Values.monitoring.datadog .Values.proxy.annotations }}
     annotations:
       {{- if .Values.monitoring.datadog }}
       {{- include "pulsar.proxy.datadog.annotation" . | nindent 6 }}
       {{- end }}
+{{- if .Values.prometheus.scrape.proxy }}
       prometheus.io/scrape: "true"
       prometheus.io/port: "{{ .Values.proxy.ports.http }}"
+{{- end }}
 {{- with .Values.proxy.annotations }}
 {{ toYaml . | indent 6 }}
+{{- end }}
 {{- end }}
     {{- if .Values.proxy.readPublicKeyFromFile }}
     secretRefs:
@@ -118,6 +122,11 @@ spec:
             name: {{ template "pulsar.vault-secret-key-name" . }}
             key: PULSAR_PREFIX_OIDCTokenAudienceID
     - name: brokerClientAuthenticationParameters
+      valueFrom:
+          secretKeyRef:
+            name: {{ template "pulsar.vault-secret-key-name" . }}
+            key: brokerClientAuthenticationParameters
+    - name: PROXY_TOKEN
       valueFrom:
           secretKeyRef:
             name: {{ template "pulsar.vault-secret-key-name" . }}

--- a/charts/sn-platform/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-cluster.yaml
@@ -44,12 +44,12 @@ spec:
 {{- with .Values.proxy.labels }}
 {{ toYaml . | indent 6 }}
 {{- end }}
-{{- if or .Values.prometheus.scrape.proxy .Values.monitoring.datadog .Values.proxy.annotations }}
+{{- if or (and .Values.prometheus.scrape.proxy .Values.prometheus.scrape.enabled) .Values.monitoring.datadog .Values.proxy.annotations }}
     annotations:
       {{- if .Values.monitoring.datadog }}
       {{- include "pulsar.proxy.datadog.annotation" . | nindent 6 }}
       {{- end }}
-{{- if .Values.prometheus.scrape.proxy }}
+{{- if (and .Values.prometheus.scrape.proxy .Values.prometheus.scrape.enabled) }}
       prometheus.io/scrape: "true"
       prometheus.io/port: "{{ .Values.proxy.ports.http }}"
 {{- end }}

--- a/charts/sn-platform/templates/proxy/proxy-statefulset.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-statefulset.yaml
@@ -45,17 +45,21 @@ spec:
       labels:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.proxy.component }}
+{{- if or .Values.prometheus.scrape.proxy .Values.monitoring.datadog .Values.proxy.autoRollDeployment .Values.proxy.annotations }}
       annotations:
         {{- if .Values.monitoring.datadog }}
         {{- include "pulsar.proxy.datadog.annotation" . | nindent 8 }}
         {{- end }}
+{{- if .Values.prometheus.scrape.proxy }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.proxy.ports.http }}"
+{{- end }}
         {{- if .Values.proxy.autoRollDeployment }}
         checksum/config: {{ include (print $.Template.BasePath "/proxy/proxy-configmap.yaml") . | sha256sum }}
         {{- end }}
 {{- with .Values.proxy.annotations }}
 {{ toYaml . | indent 8 }}
+{{- end }}
 {{- end }}
     spec:
       {{- if .Values.imagePullSecrets }}

--- a/charts/sn-platform/templates/proxy/proxy-statefulset.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-statefulset.yaml
@@ -45,12 +45,12 @@ spec:
       labels:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.proxy.component }}
-{{- if or .Values.prometheus.scrape.proxy .Values.monitoring.datadog .Values.proxy.autoRollDeployment .Values.proxy.annotations }}
+{{- if or (and .Values.prometheus.scrape.proxy .Values.prometheus.scrape.enabled) .Values.monitoring.datadog .Values.proxy.autoRollDeployment .Values.proxy.annotations }}
       annotations:
         {{- if .Values.monitoring.datadog }}
         {{- include "pulsar.proxy.datadog.annotation" . | nindent 8 }}
         {{- end }}
-{{- if .Values.prometheus.scrape.proxy }}
+{{- if (and .Values.prometheus.scrape.proxy .Values.prometheus.scrape.enabled) }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.proxy.ports.http }}"
 {{- end }}

--- a/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
@@ -42,12 +42,12 @@ spec:
 {{- with .Values.zookeeper.labels }}
 {{ toYaml . | indent 6 }}
 {{- end }}
-{{- if or .Values.prometheus.scrape.zookeeper .Values.monitoring.datadog .Values.zookeeper.annotations }}
+{{- if or (and .Values.prometheus.scrape.zookeeper .Values.prometheus.scrape.enabled) .Values.monitoring.datadog .Values.zookeeper.annotations }}
     annotations:
       {{- if .Values.monitoring.datadog }}
       {{- include "pulsar.zookeeper.datadog.annotation" . | nindent 6 }}
       {{- end }}
-{{- if .Values.prometheus.scrape.zookeeper }}
+{{- if (and .Values.prometheus.scrape.zookeeper .Values.prometheus.scrape.enabled) }}
       prometheus.io/scrape: "true"
       prometheus.io/port: "{{ .Values.zookeeper.ports.metrics  }}"
 {{- end }}

--- a/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
@@ -42,12 +42,18 @@ spec:
 {{- with .Values.zookeeper.labels }}
 {{ toYaml . | indent 6 }}
 {{- end }}
+{{- if or .Values.prometheus.scrape.zookeeper .Values.monitoring.datadog .Values.zookeeper.annotations }}
     annotations:
       {{- if .Values.monitoring.datadog }}
       {{- include "pulsar.zookeeper.datadog.annotation" . | nindent 6 }}
       {{- end }}
+{{- if .Values.prometheus.scrape.zookeeper }}
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "{{ .Values.zookeeper.ports.metrics  }}"
+{{- end }}
 {{- with .Values.zookeeper.annotations }}
 {{ toYaml . | indent 6 }}
+{{- end }}
 {{- end }}
     {{- if .Values.zookeeper.customTools.restore.enable }}
     initContainers:

--- a/charts/sn-platform/templates/zookeeper/zookeeper-statefulset.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-statefulset.yaml
@@ -46,6 +46,7 @@ spec:
       labels:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.zookeeper.component }}
+{{- if or .Values.prometheus.scrape.zookeeper .Values.monitoring.datadog .Values.zookeeper.autoRollDeployment .Values.zookeeper.annotations }}
       annotations:
         {{- if .Values.monitoring.datadog }}
         {{- include "pulsar.zookeeper.datadog.annotation" . | nindent 8 }}
@@ -53,8 +54,13 @@ spec:
         {{- if .Values.zookeeper.autoRollDeployment }}
         checksum/config: {{ include (print $.Template.BasePath "/zookeeper/zookeeper-configmap.yaml") . | sha256sum }}
         {{- end }}
+{{- if .Values.prometheus.scrape.zookeeper }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "{{ .Values.zookeeper.ports.metrics  }}"
+{{- end }}
 {{- with .Values.zookeeper.annotations }}
 {{ toYaml . | indent 8 }}
+{{- end }}
 {{- end }}
     spec:
       {{- if .Values.imagePullSecrets }}

--- a/charts/sn-platform/templates/zookeeper/zookeeper-statefulset.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-statefulset.yaml
@@ -46,7 +46,7 @@ spec:
       labels:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.zookeeper.component }}
-{{- if or .Values.prometheus.scrape.zookeeper .Values.monitoring.datadog .Values.zookeeper.autoRollDeployment .Values.zookeeper.annotations }}
+{{- if or (and .Values.prometheus.scrape.zookeeper .Values.prometheus.scrape.enabled) .Values.monitoring.datadog .Values.zookeeper.autoRollDeployment .Values.zookeeper.annotations }}
       annotations:
         {{- if .Values.monitoring.datadog }}
         {{- include "pulsar.zookeeper.datadog.annotation" . | nindent 8 }}
@@ -54,7 +54,7 @@ spec:
         {{- if .Values.zookeeper.autoRollDeployment }}
         checksum/config: {{ include (print $.Template.BasePath "/zookeeper/zookeeper-configmap.yaml") . | sha256sum }}
         {{- end }}
-{{- if .Values.prometheus.scrape.zookeeper }}
+{{- if (and .Values.prometheus.scrape.zookeeper .Values.prometheus.scrape.enabled) }}
         prometheus.io/scrape: "true"
         prometheus.io/port: "{{ .Values.zookeeper.ports.metrics  }}"
 {{- end }}

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -597,9 +597,7 @@ zookeeper:
     # requiredDuringSchedulingIgnoredDuringExecution - rules must be met for pod to be scheduled (hard) requires at least one node per replica
     # preferredDuringSchedulingIgnoredDuringExecution - scheduler will try to enforce but not guranentee
     type: preferredDuringSchedulingIgnoredDuringExecution
-  annotations:
-    prometheus.io/scrape: "true"
-    prometheus.io/port: "8000"
+  annotations: {}
   advanced:
     staticServerList: []
   securityContext: {}
@@ -1624,7 +1622,16 @@ configmapReload:
 prometheus:
   component: prometheus
   replicaCount: 1
-  # nodeSelector:
+  scrape:
+    autorecovery: true
+    bookkeeper: true
+    broker: true
+    function_worker: true
+    ingress_controller: true
+    node_exporter: true
+    proxy: true
+    zookeeper: true
+    # nodeSelector:
     # cloud.google.com/gke-nodepool: default-pool
   annotations: {}
   tolerations: []

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1623,6 +1623,7 @@ prometheus:
   component: prometheus
   replicaCount: 1
   scrape:
+    enabled: true
     autorecovery: true
     bookkeeper: true
     broker: true


### PR DESCRIPTION
Fixes #545

### Motivation
If user don't want prometheus to scrape metrics from some components or already integrated with 3rd party metrics system then chart should provide option to turn off the prometheus scraping.

### Modifications
Add option to turn off prometheus scarping annotation.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation
- [x] `no-need-doc` 
  