### PR TITLE
Adjust the syntax position of imagePullSecrets in helm templates

### DIFF
--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
@@ -120,6 +120,10 @@ spec:
         - {{ .Values.bookkeeper.configData.PULSAR_MEM }}
       gcOptions:
         - {{ .Values.bookkeeper.configData.PULSAR_GC }}
+    {{- if .Values.global.imagePullSecrets }}
+    imagePullSecrets:
+{{ toYaml .Values.global.imagePullSecrets | indent 6 }}
+    {{- end }}
     {{- if .Values.bookkeeper.operator.adopt_existing }}
     volumes:
     {{- if not (and .Values.volumes.persistence .Values.bookkeeper.volumes.persistence) }}
@@ -132,10 +136,6 @@ spec:
     {{- include "pulsar.bookkeeper.log.volumes" . | nindent 4 }}
     {{- end }}
   {{- if and .Values.volumes.persistence .Values.bookkeeper.volumes.persistence}}
-    {{- if .Values.global.imagePullSecrets }}
-    imagePullSecrets:
-{{ toYaml .Values.global.imagePullSecrets | indent 6 }}
-    {{- end }}
   storage:
     journal:
       volumeClaimTemplate:

--- a/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
@@ -149,6 +149,10 @@ spec:
         - {{ .Values.zookeeper.configData.PULSAR_MEM }}
       gcOptions:
         - {{ .Values.zookeeper.configData.PULSAR_GC }}
+    {{- if .Values.global.imagePullSecrets }}
+    imagePullSecrets:
+{{ toYaml .Values.global.imagePullSecrets | indent 6 }}
+    {{- end }}
     {{- if .Values.zookeeper.operator.adopt_existing }}
     volumes:
     {{- include "pulsar.zookeeper.data.volumes" . | nindent 4 }}
@@ -162,10 +166,6 @@ spec:
     {{- end }}
     {{- end }}
   {{- if and .Values.volumes.persistence .Values.zookeeper.volumes.persistence }}
-    {{- if .Values.global.imagePullSecrets }}
-    imagePullSecrets:
-{{ toYaml .Values.global.imagePullSecrets | indent 6 }}
-    {{- end }}
   persistence:
     data:
       accessModes:


### PR DESCRIPTION
Fixes #550 


### Motivation

Adjust the syntax position of imagePullSecrets in helm templates.

### Modifications

The position of `imagePullSecrets` if-statement.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 

### Acknowledgement

Thanks @MarvinCai for discovering this error.
 

