### PR TITLE
[charts/sn-platform] Fix certificate templates

### DIFF
--- a/charts/sn-platform/templates/tls/tls-certs-internal.yaml
+++ b/charts/sn-platform/templates/tls/tls-certs-internal.yaml
@@ -33,8 +33,9 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.proxy.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  #organization:
-#{{ toYaml .Values.tls.common.organization | indent 2 }}
+  subject:
+    organization:
+{{ toYaml .Values.tls.common.organization | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
@@ -80,8 +81,9 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.broker.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
+  subject:
+    organization:
+{{ toYaml .Values.tls.common.organization | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
@@ -120,8 +122,9 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.bookie.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
+  subject:
+    organization:
+{{ toYaml .Values.tls.common.organization | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
@@ -159,8 +162,9 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.autorecovery.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
+  subject:
+    organization:
+{{ toYaml .Values.tls.common.organization | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
@@ -195,8 +199,9 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.zookeeper.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
+  subject:
+    organization:
+{{ toYaml .Values.tls.common.organization | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
@@ -234,8 +239,9 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.streamnative_console.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
+  subject:
+    organization:
+{{ toYaml .Values.tls.common.organization | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.streamnative_console.component }}"
@@ -274,8 +280,9 @@ spec:
   secretName: "{{ .Release.Name }}-{{ .Values.tls.toolset.cert_name }}"
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
-  organization:
-{{ toYaml .Values.tls.common.organization | indent 2 }}
+  subject:
+    organization:
+{{ toYaml .Values.tls.common.organization | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"

--- a/charts/sn-platform/templates/tls/tls-certs-internal.yaml
+++ b/charts/sn-platform/templates/tls/tls-certs-internal.yaml
@@ -35,15 +35,15 @@ spec:
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
   subject:
     organizations:
-{{ toYaml .Values.tls.common.organization | indent 4 }}
+{{ toYaml .Values.tls.common.subject.organizations | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
   isCA: false
   privateKey:
-    size: {{ .Values.tls.common.keySize }}
-    algorithm: {{ .Values.tls.common.keyAlgorithm }}
-    encoding: {{ .Values.tls.common.keyEncoding }}
+    size: {{ .Values.tls.common.privateKey.size }}
+    algorithm: {{ .Values.tls.common.privateKey.algorithm }}
+    encoding: {{ .Values.tls.common.privateKey.encoding }}
   usages:
     - server auth
     - client auth
@@ -83,15 +83,15 @@ spec:
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
   subject:
     organizations:
-{{ toYaml .Values.tls.common.organization | indent 4 }}
+{{ toYaml .Values.tls.common.subject.organizations | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
   isCA: false
   privateKey:
-    size: {{ .Values.tls.common.keySize }}
-    algorithm: {{ .Values.tls.common.keyAlgorithm }}
-    encoding: {{ .Values.tls.common.keyEncoding }}
+    size: {{ .Values.tls.common.privateKey.size }}
+    algorithm: {{ .Values.tls.common.privateKey.algorithm }}
+    encoding: {{ .Values.tls.common.privateKey.encoding }}
   usages:
     - server auth
     - client auth
@@ -124,15 +124,15 @@ spec:
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
   subject:
     organizations:
-{{ toYaml .Values.tls.common.organization | indent 4 }}
+{{ toYaml .Values.tls.common.subject.organizations | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
   isCA: false
   privateKey:
-    size: {{ .Values.tls.common.keySize }}
-    algorithm: {{ .Values.tls.common.keyAlgorithm }}
-    encoding: {{ .Values.tls.common.keyEncoding }}
+    size: {{ .Values.tls.common.privateKey.size }}
+    algorithm: {{ .Values.tls.common.privateKey.algorithm }}
+    encoding: {{ .Values.tls.common.privateKey.encoding }}
   usages:
     - server auth
     - client auth
@@ -164,15 +164,15 @@ spec:
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
   subject:
     organizations:
-{{ toYaml .Values.tls.common.organization | indent 4 }}
+{{ toYaml .Values.tls.common.subject.organizations | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
   isCA: false
   privateKey:
-    size: {{ .Values.tls.common.keySize }}
-    algorithm: {{ .Values.tls.common.keyAlgorithm }}
-    encoding: {{ .Values.tls.common.keyEncoding }}
+    size: {{ .Values.tls.common.privateKey.size }}
+    algorithm: {{ .Values.tls.common.privateKey.algorithm }}
+    encoding: {{ .Values.tls.common.privateKey.encoding }}
   usages:
     - server auth
     - client auth
@@ -201,15 +201,15 @@ spec:
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
   subject:
     organizations:
-{{ toYaml .Values.tls.common.organization | indent 4 }}
+{{ toYaml .Values.tls.common.subject.organizations | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
   isCA: false
   privateKey:
-    size: {{ .Values.tls.common.keySize }}
-    algorithm: {{ .Values.tls.common.keyAlgorithm }}
-    encoding: {{ .Values.tls.common.keyEncoding }}
+    size: {{ .Values.tls.common.privateKey.size }}
+    algorithm: {{ .Values.tls.common.privateKey.algorithm }}
+    encoding: {{ .Values.tls.common.privateKey.encoding }}
   usages:
     - server auth
     - client auth
@@ -241,15 +241,15 @@ spec:
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
   subject:
     organizations:
-{{ toYaml .Values.tls.common.organization | indent 4 }}
+{{ toYaml .Values.tls.common.subject.organizations | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.streamnative_console.component }}"
   isCA: false
   privateKey:
-    size: {{ .Values.tls.common.keySize }}
-    algorithm: {{ .Values.tls.common.keyAlgorithm }}
-    encoding: {{ .Values.tls.common.keyEncoding }}
+    size: {{ .Values.tls.common.privateKey.size }}
+    algorithm: {{ .Values.tls.common.privateKey.algorithm }}
+    encoding: {{ .Values.tls.common.privateKey.encoding }}
   usages:
     - server auth
     - client auth
@@ -282,15 +282,15 @@ spec:
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
   subject:
     organizations:
-{{ toYaml .Values.tls.common.organization | indent 4 }}
+{{ toYaml .Values.tls.common.subject.organizations | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
   isCA: false
   privateKey:
-    size: {{ .Values.tls.common.keySize }}
-    algorithm: {{ .Values.tls.common.keyAlgorithm }}
-    encoding: {{ .Values.tls.common.keyEncoding }}
+    size: {{ .Values.tls.common.privateKey.size }}
+    algorithm: {{ .Values.tls.common.privateKey.algorithm }}
+    encoding: {{ .Values.tls.common.privateKey.encoding }}
   usages:
     - server auth
     - client auth

--- a/charts/sn-platform/templates/tls/tls-certs-internal.yaml
+++ b/charts/sn-platform/templates/tls/tls-certs-internal.yaml
@@ -34,7 +34,7 @@ spec:
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
   subject:
-    organization:
+    organizations:
 {{ toYaml .Values.tls.common.organization | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
@@ -82,7 +82,7 @@ spec:
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
   subject:
-    organization:
+    organizations:
 {{ toYaml .Values.tls.common.organization | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
@@ -123,7 +123,7 @@ spec:
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
   subject:
-    organization:
+    organizations:
 {{ toYaml .Values.tls.common.organization | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
@@ -163,7 +163,7 @@ spec:
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
   subject:
-    organization:
+    organizations:
 {{ toYaml .Values.tls.common.organization | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
@@ -200,7 +200,7 @@ spec:
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
   subject:
-    organization:
+    organizations:
 {{ toYaml .Values.tls.common.organization | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
@@ -240,7 +240,7 @@ spec:
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
   subject:
-    organization:
+    organizations:
 {{ toYaml .Values.tls.common.organization | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.
@@ -281,7 +281,7 @@ spec:
   duration: "{{ .Values.tls.common.duration }}"
   renewBefore: "{{ .Values.tls.common.renewBefore }}"
   subject:
-    organization:
+    organizations:
 {{ toYaml .Values.tls.common.organization | indent 4 }}
   # The use of the common name field has been deprecated since 2000 and is
   # discouraged from being used.

--- a/charts/sn-platform/templates/tls/tls-certs-internal.yaml
+++ b/charts/sn-platform/templates/tls/tls-certs-internal.yaml
@@ -39,9 +39,10 @@ spec:
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
   isCA: false
-  #keySize: {{ .Values.tls.common.keySize }}
-  #keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  #keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.keySize }}
+    algorithm: {{ .Values.tls.common.keyAlgorithm }}
+    encoding: {{ .Values.tls.common.keyEncoding }}
   usages:
     - server auth
     - client auth
@@ -85,9 +86,10 @@ spec:
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.keySize }}
+    algorithm: {{ .Values.tls.common.keyAlgorithm }}
+    encoding: {{ .Values.tls.common.keyEncoding }}
   usages:
     - server auth
     - client auth
@@ -124,9 +126,10 @@ spec:
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.keySize }}
+    algorithm: {{ .Values.tls.common.keyAlgorithm }}
+    encoding: {{ .Values.tls.common.keyEncoding }}
   usages:
     - server auth
     - client auth
@@ -162,9 +165,10 @@ spec:
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.keySize }}
+    algorithm: {{ .Values.tls.common.keyAlgorithm }}
+    encoding: {{ .Values.tls.common.keyEncoding }}
   usages:
     - server auth
     - client auth
@@ -197,9 +201,10 @@ spec:
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.keySize }}
+    algorithm: {{ .Values.tls.common.keyAlgorithm }}
+    encoding: {{ .Values.tls.common.keyEncoding }}
   usages:
     - server auth
     - client auth
@@ -235,9 +240,10 @@ spec:
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.streamnative_console.component }}"
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.keySize }}
+    algorithm: {{ .Values.tls.common.keyAlgorithm }}
+    encoding: {{ .Values.tls.common.keyEncoding }}
   usages:
     - server auth
     - client auth
@@ -274,9 +280,10 @@ spec:
   # discouraged from being used.
   commonName: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
   isCA: false
-  keySize: {{ .Values.tls.common.keySize }}
-  keyAlgorithm: {{ .Values.tls.common.keyAlgorithm }}
-  keyEncoding: {{ .Values.tls.common.keyEncoding }}
+  privateKey:
+    size: {{ .Values.tls.common.keySize }}
+    algorithm: {{ .Values.tls.common.keyAlgorithm }}
+    encoding: {{ .Values.tls.common.keyEncoding }}
   usages:
     - server auth
     - client auth

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -264,11 +264,13 @@ tls:
     duration: 2160h
     # 15d
     renewBefore: 360h
-    organization:
+    subject:
+      organizations:
       - pulsar
-    keySize: 4096
-    keyAlgorithm: RSA
-    keyEncoding: PKCS8
+    privateKey:
+      size: 4096
+      algorithm: RSA
+      encoding: PKCS8
   # settings for generating certs for proxy
   proxy:
     enabled: false

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -304,7 +304,7 @@ tls:
     cert_name: tls-presto
   streamnative_console:
     enabled: false
-    cert_name: tls-streamnative_console
+    cert_name: tls-streamnative-console
 
 # Enable or disable broker authentication and authorization.
 auth:

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -267,8 +267,8 @@ tls:
     organization:
       - pulsar
     keySize: 4096
-    keyAlgorithm: rsa
-    keyEncoding: pkcs8
+    keyAlgorithm: RSA
+    keyEncoding: PKCS8
   # settings for generating certs for proxy
   proxy:
     enabled: false


### PR DESCRIPTION
Fixes https://github.com/streamnative/charts/issues/554

### Motivation

Fix the manifests for Certificate V1 based on the [API document](https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.Certificate).

### Modifications

- Move `organization` to `subject.organizations`
- Move `keySize`, `keyAlgorithm`, `keyEncoding` to under `privateKey.size`, `privateKey.algorithm`, and `encoding`
- Fix the default key encoding and algorithm name for V1
- Fix the certificate name for streamnative console

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

