### PR TITLE
Allow customizing port exposed by Proxy ingress service.

### DIFF
--- a/charts/sn-platform/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-cluster.yaml
@@ -241,6 +241,10 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- end }}
+      {{- if .Values.ingress.proxy.portOverride }}
+      ports:
+        port: {{ .Values.ingress.proxy.portOverride }}
+      {{- end }}
       {{- if ne .Values.ingress.proxy.type "LoadBalancer" }}
       type: {{ .Values.ingress.proxy.type }}
       {{ else }}

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -430,8 +430,8 @@ ingress:
   ##
   ## Ingresses for exposing pulsar service publicly
   proxy:
-    enabled: false
-
+    enabled: true
+    portOverride: ""
     ## When these conditions are satisfied
     ##   1. Values.ingress.proxy.type == LoadBalancer
     ##   2. Values.tls.enabled == false and Values.tls.proxy.enabled == false

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -430,7 +430,7 @@ ingress:
   ##
   ## Ingresses for exposing pulsar service publicly
   proxy:
-    enabled: true
+    enabled: false
     portOverride: ""
     ## When these conditions are satisfied
     ##   1. Values.ingress.proxy.type == LoadBalancer


### PR DESCRIPTION
### Motivation
Allow customizing port exposed by Proxy ingress service.

### Modifications
Add value as portOverride and apply if configured.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation
- [x] `no-need-doc` 
  