### PR TITLE
Add port name in ExternalServiceTemplate for http port override.

### DIFF
--- a/charts/sn-platform/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-cluster.yaml
@@ -250,9 +250,10 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         {{- end }}
-      {{- if .Values.ingress.proxy.portOverride }}
+      {{- if .Values.ingress.proxy.httpPortOverride }}
       ports:
-        port: {{ .Values.ingress.proxy.portOverride }}
+      - port: {{ .Values.ingress.proxy.httpPortOverride }}
+        name: "http"
       {{- end }}
       {{- if ne .Values.ingress.proxy.type "LoadBalancer" }}
       type: {{ .Values.ingress.proxy.type }}

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -433,7 +433,7 @@ ingress:
   ## Ingresses for exposing pulsar service publicly
   proxy:
     enabled: false
-    portOverride: ""
+    httpPortOverride: ""
     ## When these conditions are satisfied
     ##   1. Values.ingress.proxy.type == LoadBalancer
     ##   2. Values.tls.enabled == false and Values.tls.proxy.enabled == false


### PR DESCRIPTION
### Motivation
Fix ExternalServiceTemplate for Proxy.

### Modifications
Add port name when overriding http port.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
This change is a trivial rework / code cleanup without any test coverage.

### Documentation
- [x] `no-need-doc` 
  