### PR TITLE
Fix the manifest issue that makes some fields out of the `components.vault` control

### DIFF
--- a/charts/sn-platform/templates/vault/vault-statefulset.yaml
+++ b/charts/sn-platform/templates/vault/vault-statefulset.yaml
@@ -75,7 +75,6 @@ spec:
   - name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-{{ .Values.vault.volume.name }}"
     emptyDir: {}
   {{- end }}
-{{- end }}
   volumeMounts:
     - name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-{{ .Values.vault.volume.name }}"
       mountPath: /vault/file
@@ -98,3 +97,4 @@ spec:
 {{ toYaml .Values.vault.resources | indent 6 }}
 {{- end }}
 
+{{- end }}


### PR DESCRIPTION

<!--
### Contribution Checklist
  
  - Name the pull request in the form "[charts/<chart-name>] Title of the pull request".
    Skip *[charts/<chart-name>]* if the PR doesn't change a specific chart. E.g. `[docs] Fix typo in README`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #571 

### Motivation

Fix the manifest issue that makes some fields out of the `components.vault` control which will interrupt the chart installation when setting `components.vault` to `false`

### Modifications

Fix the position of related`{{- end }}`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.


### Documentation

Check the box below.

Need to update docs? 

- [x] `no-need-doc` 
  