### PR TITLE
Disable JKS keystore creation if kop is not enabled

### DIFF
--- a/charts/sn-platform/templates/tls/tls-certs-internal.yaml
+++ b/charts/sn-platform/templates/tls/tls-certs-internal.yaml
@@ -60,12 +60,18 @@ spec:
     # This is optional since cert-manager will default to this value however
     # if you are using an external issuer, change this to that issuer group.
     group: cert-manager.io
+  {{- if or .Values.broker.kop.enabled .Values.components.kop }}
+  {{- if .Values.broker.kop.tls.enabled }}
+  {{- if not .Values.broker.kop.tls.passwordSecretRef }}
   keystores:
     jks:
       create: true
       passwordSecretRef:
         name: cert-jks-passwd
         key: password
+  {{- end }}
+  {{- end }}
+  {{- end }}
 ---
 {{- end }}
 {{- end }}

--- a/charts/sn-platform/templates/tls/tls-certs-public.yaml
+++ b/charts/sn-platform/templates/tls/tls-certs-public.yaml
@@ -43,12 +43,18 @@ spec:
     # This is optional since cert-manager will default to this value however
     # if you are using an external issuer, change this to that issuer group.
     group: cert-manager.io
+  {{- if or .Values.broker.kop.enabled .Values.components.kop }}
+  {{- if .Values.broker.kop.tls.enabled }}
+  {{- if not .Values.broker.kop.tls.passwordSecretRef }}
   keystores:
     jks:
       create: true
       passwordSecretRef:
         name: cert-jks-passwd
         key: password
+  {{- end }}
+  {{- end }}
+  {{- end }}
 ---
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Fixes #569

### Motivation

Due to a [cert-manager issue](https://github.com/cert-manager/cert-manager/issues/4573),
cert-manager is not able to generate certificate if JKS keystore creation is enabled.

This pull request disables JKS keystore creation if kop is not enabled.


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  This is a bug fix. 
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

