### PR TITLE
[sn-platform] support extra secretRefs and variables for proxy and broker

### DIFF
--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -60,8 +60,8 @@ spec:
 {{ toYaml . | indent 6 }}
 {{- end }}
 {{- end }}
-    {{- if or .Values.broker.readPublicKeyFromFile (and .Values.broker.offload.gcs.enabled .Values.broker.offload.gcs.secret) }}
     secretRefs:
+    {{- if or .Values.broker.readPublicKeyFromFile (and .Values.broker.offload.gcs.enabled .Values.broker.offload.gcs.secret) }}
     {{- if .Values.broker.publicKeyPath }}
     - mountPath: {{ .Values.broker.publicKeyPath }}
     {{- else }}
@@ -77,6 +77,9 @@ spec:
       secretName: {{ .Values.broker.offload.gcs.secret }}
     {{- end }}
     {{- end }}
+{{- with .Values.broker.extraSecretRefs }}
+{{ toYaml . | indent 4 }}
+{{- end }}
     {{- if and .Values.affinity.anti_affinity .Values.broker.affinity.anti_affinity }}
     affinity:
       podAntiAffinity:
@@ -158,6 +161,9 @@ spec:
           name: {{ .Values.broker.offload.azureblob.secret }}
           key: AZURE_STORAGE_ACCESS_KEY
     {{- end }}
+{{- with .Values.broker.extraEnv}}
+{{ toYaml . | indent 4 }}
+{{- end }}
     # not support envFrom currently
     #envFrom:
     #- secretRef:

--- a/charts/sn-platform/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-cluster.yaml
@@ -57,8 +57,8 @@ spec:
 {{ toYaml . | indent 6 }}
 {{- end }}
 {{- end }}
-    {{- if .Values.proxy.readPublicKeyFromFile }}
     secretRefs:
+    {{- if .Values.proxy.readPublicKeyFromFile }}
     {{- if .Values.proxy.publicKeyPath }}
     - mountPath: {{ .Values.proxy.publicKeyPath }}
     {{- else }}
@@ -70,6 +70,9 @@ spec:
       secretName: {{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-public-key
       {{- end }}
     {{- end }}
+{{- with .Values.proxy.extraSecretRefs }}
+{{ toYaml . | indent 4 }}
+{{- end }}
     {{- if and .Values.affinity.anti_affinity .Values.proxy.affinity.anti_affinity }}
     affinity:
       podAntiAffinity:
@@ -132,6 +135,9 @@ spec:
             name: {{ template "pulsar.vault-secret-key-name" . }}
             key: brokerClientAuthenticationParameters
     {{- end }}
+{{- with .Values.proxy.extraEnv}}
+{{ toYaml . | indent 4 }}
+{{- end }}
     #envFrom:
     #- secretRef:
     #    name: {{ template "pulsar.vault-secret-key-name" . }}

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1095,6 +1095,13 @@ broker:
   extraInitContainers: []
   extraVolumes: []
   extraVolumeMounts: []
+  # extra environment variable to define for the containers
+  extraEnv: []
+  # extra secrets to mount for the pods
+  # extraSecretRefs:
+  # - mountPath: /path/to/mount
+  #   secretName: "[secret name]"
+  extraSecretRefs: []
   # Definition of the serviceAccount used to run brokers.
   serviceAccount:
     # Specifies whether to use a service account to run this component
@@ -1406,6 +1413,13 @@ proxy:
   extraInitContainers: []
   extraVolumes: []
   extraVolumeMounts: []
+  # extra environment variable to define for the containers
+  extraEnv: []
+  # extra secrets to mount for the pods
+  # extraSecretRefs:
+  # - mountPath: /path/to/mount
+  #   secretName: "[secret name]"
+  extraSecretRefs: []
   # Definition of the serviceAccount used to run proxies.
   serviceAccount:
     # Specifies whether to use a service account to run this component


### PR DESCRIPTION
### Motivation

This allows customers to mount extra secrets or specify extra environment variables.
A common use case is to mount the oauth2 private key for oauth2 authentication.

### Modifications

- introduce `extraSecretRefs` for broker and proxy
- introduce `extraEnv` for broker and proxy

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [x] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

