### PR TITLE
Fixed broker cluster vars

### DIFF
--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -123,7 +123,6 @@ spec:
     {{- end }}
     {{- if or .Values.auth.authentication.enabled (and .Values.broker.offload.s3.enabled .Values.broker.offload.s3.secret) (and .Values.broker.offload.azureblob.enabled .Values.broker.offload.azureblob.secret) }}
     vars:
-    {{- end }}
     {{- if .Values.auth.authentication.enabled }}
     - name: PULSAR_PREFIX_OIDCTokenAudienceID
       valueFrom:
@@ -159,6 +158,7 @@ spec:
         secretKeyRef:
           name: {{ .Values.broker.offload.azureblob.secret }}
           key: AZURE_STORAGE_ACCESS_KEY
+    {{- end }}
     {{- end }}
     # not support envFrom currently
     #envFrom:

--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -121,7 +121,9 @@ spec:
           {{ end }}
       {{ end }}
     {{- end }}
+    {{- if or .Values.auth.authentication.enabled (and .Values.broker.offload.s3.enabled .Values.broker.offload.s3.secret) (and .Values.broker.offload.azureblob.enabled .Values.broker.offload.azureblob.secret) }}
     vars:
+    {{- end }}
     {{- if .Values.auth.authentication.enabled }}
     - name: PULSAR_PREFIX_OIDCTokenAudienceID
       valueFrom:


### PR DESCRIPTION


### Motivation

```
client.go:128: [debug] creating 41 resource(s)
Error: INSTALLATION FAILED: PulsarBroker.pulsar.streamnative.io "pulsar23-sn-platform" is invalid: spec.pod.vars: Invalid value: "null": spec.pod.vars in body must be of type array: "null"
helm.go:84: [debug] PulsarBroker.pulsar.streamnative.io "pulsar23-sn-platform" is invalid: spec.pod.vars: Invalid value: "null": spec.pod.vars in body must be of type array: "null"
```

### Modifications

* Update broker cluster yaml file

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

