### PR TITLE
[sn-platform] Support extraVolumes and extraVolumeMounts for toolset

### DIFF
--- a/charts/sn-platform/templates/toolset/toolset-statefulset.yaml
+++ b/charts/sn-platform/templates/toolset/toolset-statefulset.yaml
@@ -83,6 +83,9 @@ spec:
         {{- include "pulsar.toolset.certs.volumeMounts" . | nindent 8 }}
         {{- include "pulsar.toolset.token.volumeMounts" . | nindent 8 }}
         {{- include "pulsar.toolset.log.volumeMounts" . | nindent 8 }}
+{{- with .Values.toolset.extraVolumeMounts }}
+{{ toYaml . | indent 8 }}
+{{- end }}
       {{- if .Values.components.kop }}
       - name: "kafka"
         image: "{{ .Values.images.toolset.kafka.repository }}:{{ .Values.images.toolset.kafka.tag }}"
@@ -109,10 +112,16 @@ spec:
         {{- include "pulsar.toolset.certs.volumeMounts" . | nindent 8 }}
         {{- include "pulsar.toolset.token.volumeMounts" . | nindent 8 }}
         {{- include "pulsar.toolset.kafka.conf.volumeMounts" . | nindent 8 }}
+{{- with .Values.toolset.extraVolumeMounts }}
+{{ toYaml . | indent 8 }}
+{{- end }}
       {{- end }}
       volumes:
       {{- include "pulsar.toolset.certs.volumes" . | nindent 6 }}
       {{- include "pulsar.toolset.token.volumes" . | nindent 6 }}
       {{- include "pulsar.toolset.log.volumes" . | nindent 6 }}
       {{- include "pulsar.toolset.kafka.conf.volumes" . | nindent 6 }}
+{{- with .Values.toolset.extraVolumes }}
+{{ toYaml . | indent 6 }}
+{{- end }}
 {{- end }}

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1541,6 +1541,8 @@ toolset:
   ##
   # Automtically Roll Deployments when configmap is changed
   autoRollDeployment: true
+  extraVolumes: []
+  extraVolumeMounts: []
   extraEnv: []
   configData:
     PULSAR_MEM: >


### PR DESCRIPTION

### Motivation

Provide the ability to mount private key for oauth2 client

### Modifications

add `extraVolumes` and `extraVolumeMounts`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

### Documentation

Check the box below.

Need to update docs? 

- [x] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

