### PR TITLE
Fixed secretRefs check

### DIFF
--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -60,8 +60,8 @@ spec:
 {{ toYaml . | indent 6 }}
 {{- end }}
 {{- end }}
+{{- if or .Values.broker.readPublicKeyFromFile (and .Values.broker.offload.gcs.enabled .Values.broker.offload.gcs.secret) .Values.broker.extraSecretRefs }}
     secretRefs:
-    {{- if or .Values.broker.readPublicKeyFromFile (and .Values.broker.offload.gcs.enabled .Values.broker.offload.gcs.secret) }}
     {{- if .Values.broker.publicKeyPath }}
     - mountPath: {{ .Values.broker.publicKeyPath }}
     {{- else }}
@@ -76,9 +76,9 @@ spec:
     - mountPath: /pulsar/srvaccts/gcs.json
       secretName: {{ .Values.broker.offload.gcs.secret }}
     {{- end }}
-    {{- end }}
 {{- with .Values.broker.extraSecretRefs }}
 {{ toYaml . | indent 4 }}
+{{- end }}
 {{- end }}
     affinity:
       {{- if .Values.broker.affinity.customRules }}

--- a/charts/sn-platform/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-cluster.yaml
@@ -57,8 +57,8 @@ spec:
 {{ toYaml . | indent 6 }}
 {{- end }}
 {{- end }}
+{{- if or .Values.proxy.readPublicKeyFromFile .Values.proxy.extraSecretRefs }}
     secretRefs:
-    {{- if .Values.proxy.readPublicKeyFromFile }}
     {{- if .Values.proxy.publicKeyPath }}
     - mountPath: {{ .Values.proxy.publicKeyPath }}
     {{- else }}
@@ -69,9 +69,9 @@ spec:
       {{- else }}
       secretName: {{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-public-key
       {{- end }}
-    {{- end }}
 {{- with .Values.proxy.extraSecretRefs }}
 {{ toYaml . | indent 4 }}
+{{- end }}
 {{- end }}
     affinity:
       {{- if .Values.proxy.affinity.customRules }}


### PR DESCRIPTION


### Motivation

Fixed exception: 
```
client.go:98: [debug] creating 35 resource(s)
Error: PulsarBroker.pulsar.streamnative.io "pulsar-poc-sn-platform" is invalid: spec.pod.secretRefs: Invalid value: "null": spec.pod.secretRefs in body must be of type array: "null"
helm.go:75: [debug] PulsarBroker.pulsar.streamnative.io "pulsar-poc-sn-platform" is invalid: spec.pod.secretRefs: Invalid value: "null": spec.pod.secretRefs in body must be of type array: "null"
```

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

