### PR TITLE
[charts/sn-platform] Allow extra args to be passed to bookie

### DIFF
--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
@@ -186,6 +186,7 @@ spec:
     PULSAR_PREFIX_ledgerDirectories: "/pulsar/data/bookkeeper/ledgers"
     {{- end }}
     BOOKIE_MEM: {{ .Values.bookkeeper.configData.BOOKIE_MEM }}
+    BOOKIE_EXTRA_OPTS: {{ .Values.bookkeeper.configData.BOOKIE_EXTRA_OPTS }}
 {{- include "pulsar.bookkeeper.config.tls" . | nindent 4 }}
 {{ (.Files.Glob "conf/bookie/log4j2.yaml").AsConfig | indent 4 }}
   autoRecovery:

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -877,6 +877,10 @@ bookkeeper:
       -Xms128m
       -Xmx256m
       -XX:MaxDirectMemorySize=256m
+    BOOKIE_EXTRA_OPTS: >
+      -Dio.netty.leakDetectionLevel=disabled
+      -Dio.netty.recycler.maxCapacity.default=1000
+      -Dio.netty.recycler.linkCapacity=1024
     # we use `bin/pulsar` for starting bookie daemons
     PULSAR_MEM: >
       -Xms128m


### PR DESCRIPTION
### Motivation

There's no way to pass addl args to bookie short of grossly abusing the BOOKIE_MEM env. Trying to add `-Dlog4j2.formatMsgNoLookups=true` to bookie invocation.

### Modifications

* Pass the BOOKIE_EXTRA_OPTS setting through the sn-platform helm chart to the generated BookkeeperCluster CR.
* Emulate default settings from `conf/bkenv.sh`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  This is expected behavior
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

