### PR TITLE
[charts/sn-platform] Example Simplify Of Charts

### DIFF
--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -62,16 +62,9 @@ spec:
 {{- end }}
 {{- if or .Values.broker.readPublicKeyFromFile (and .Values.broker.offload.gcs.enabled .Values.broker.offload.gcs.secret) .Values.broker.extraSecretRefs }}
     secretRefs:
-    {{- if .Values.broker.publicKeyPath }}
-    - mountPath: {{ .Values.broker.publicKeyPath }}
-    {{- else }}
-    - mountPath: /pulsar/vault/v1/identity/oidc/.well-known/keys
-    {{- end }}
-      {{- if .Values.broker.publicKeySecret }}
-      secretName: {{ .Values.broker.publicKeySecret }}
-      {{- else }}
-      secretName: {{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-public-key
-      {{- end }}
+    - mountPath: {{ default "/pulsar/vault/v1/identity/oidc/.well-known/keys" .Values.proxy.publicKeyPath }}
+      {{ $defaultSecretName := print (include "pulsar.fullname" .) "-" .Values.vault.component "-public-key" }}
+      secretName: {{ default $defaultSecretName .Values.proxy.publicKeySecret }}
     {{- if .Values.broker.offload.gcs.secret }}
     - mountPath: /pulsar/srvaccts/gcs.json
       secretName: {{ .Values.broker.offload.gcs.secret }}

--- a/charts/sn-platform/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-cluster.yaml
@@ -59,16 +59,9 @@ spec:
 {{- end }}
 {{- if or .Values.proxy.readPublicKeyFromFile .Values.proxy.extraSecretRefs }}
     secretRefs:
-    {{- if .Values.proxy.publicKeyPath }}
-    - mountPath: {{ .Values.proxy.publicKeyPath }}
-    {{- else }}
-    - mountPath: /pulsar/vault/v1/identity/oidc/.well-known/keys
-    {{- end }}
-      {{- if .Values.proxy.publicKeySecret }}
-      secretName: {{ .Values.proxy.publicKeySecret }}
-      {{- else }}
-      secretName: {{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-public-key
-      {{- end }}
+    - mountPath: {{ default "/pulsar/vault/v1/identity/oidc/.well-known/keys" .Values.proxy.publicKeyPath }}
+      {{ $defaultSecretName := print (include "pulsar.fullname" .) "-" .Values.vault.component "-public-key" }}
+      secretName: {{ default $defaultSecretName .Values.proxy.publicKeySecret }}
 {{- with .Values.proxy.extraSecretRefs }}
 {{ toYaml . | indent 4 }}
 {{- end }}


### PR DESCRIPTION
### Motivation

I've been working with Helm for around five years now. I've seen lots of mistakes, made lots of mistakes, seen a lot of fixes for templates, and made a number myself.

I've discovered in this that the easiest way to avoid template bugs is to have simpler templates. This is particularly because Helm isn't expressive and YAML cares deeply for whitespace.

[Yesterday I saw a PR](https://github.com/streamnative/charts/pull/594). The PR was great. The bug it was fixing was sadly a bug I see somewhat often. An `if` condition in the wrong place. I see this happen often in long Helm templates, especially with nested blocks. A way to avoid this pitfall is to not have as many nests.

John Tip \#1 for Helm Templating: 

Prefer this:

```
field: {{ default "foo" .Values.bar }}
```

over this:

```
{{ if .Values.bar }}
field: {{ .Values.bar }}
{{ else }}
field: "foo"
{{ end }}
```

I wanted to show how this looks in a small section of code. I suggest against going through the Helm charts to clean them up but I think we can slowly simplify (and therefore) improve the Helm charts by doing simplifications like this.

It's a lot more easier write eights correct lines of code with one if than it is to write twenty correct lines with three ifs.

![I will simplify you](https://user-images.githubusercontent.com/2904542/162264329-945da569-3bff-4b9f-b066-a0cc52512ec1.jpeg)

### Modifications

I've reduced the code by using the 'default' function in Sprig. This replaces five lines of `if template else template end` with one line of `default x y` typically.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)