### PR TITLE
[Pulsar] Support using custom cert via mounting custom cert secret.

### DIFF
--- a/charts/pulsar/templates/_helpers.tpl
+++ b/charts/pulsar/templates/_helpers.tpl
@@ -88,3 +88,14 @@ Pulsar Cluster Name.
 {{- template "pulsar.fullname" . }}
 {{- end }}
 {{- end }}
+
+{{/*
+Define TLS CA secret name
+*/}}
+{{- define "pulsar.tls.ca.secret.name" -}}
+{{- if .Values.tls.common.caSecretName -}}
+{{- .Values.tls.common.caSecretName -}}
+{{- else -}}
+{{ .Release.Name }}-ca-tls
+{{- end -}}
+{{- end -}}

--- a/charts/pulsar/templates/bookkeeper/_autorecovery.tpl
+++ b/charts/pulsar/templates/bookkeeper/_autorecovery.tpl
@@ -47,7 +47,7 @@ Define autorecovery tls certs volumes
 {{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
 - name: autorecovery-certs
   secret:
-    secretName: "{{ .Release.Name }}-{{ .Values.tls.autorecovery.cert_name }}"
+    secretName: "{{ template "pulsar.autorecovery.tls.secret.name" . }}"
     items:
     - key: tls.crt
       path: tls.crt
@@ -55,7 +55,7 @@ Define autorecovery tls certs volumes
       path: tls.key
 - name: ca
   secret:
-    secretName: "{{ .Release.Name }}-ca-tls"
+    secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
     items:
     - key: ca.crt
       path: ca.crt
@@ -96,3 +96,14 @@ Define autorecovery log volumes
   configMap:
     name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
 {{- end }}
+
+{{/*
+Define Autorecovery TLS certificate secret name
+*/}}
+{{- define "pulsar.autorecovery.tls.secret.name" -}}
+{{- if .Values.tls.autorecovery.certSecretName -}}
+{{- .Values.tls.autorecovery.certSecretName -}}
+{{- else -}}
+{{ .Release.Name }}-{{ .Values.tls.autorecovery.cert_name }}
+{{- end -}}
+{{- end -}}

--- a/charts/pulsar/templates/bookkeeper/_bookkeeper.tpl
+++ b/charts/pulsar/templates/bookkeeper/_bookkeeper.tpl
@@ -80,7 +80,7 @@ Define bookie tls certs volumes
 {{- if and .Values.tls.enabled (or .Values.tls.bookie.enabled .Values.tls.zookeeper.enabled) }}
 - name: bookie-certs
   secret:
-    secretName: "{{ .Release.Name }}-{{ .Values.tls.bookie.cert_name }}"
+    secretName: "{{ template "pulsar.bookkeeper.tls.secret.name" . }}"
     items:
     - key: tls.crt
       path: tls.crt
@@ -88,7 +88,7 @@ Define bookie tls certs volumes
       path: tls.key
 - name: ca
   secret:
-    secretName: "{{ .Release.Name }}-ca-tls"
+    secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
     items:
     - key: ca.crt
       path: ca.crt
@@ -224,5 +224,16 @@ ad.datadoghq.com/{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.compon
     {{- end -}}
 {{- else -}}
 {{ .Values.bookkeeper.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define BookKeeper TLS certificate secret name
+*/}}
+{{- define "pulsar.bookkeeper.tls.secret.name" -}}
+{{- if .Values.tls.bookie.certSecretName -}}
+{{- .Values.tls.bookie.certSecretName -}}
+{{- else -}}
+{{ .Release.Name }}-{{ .Values.tls.bookie.cert_name }}
 {{- end -}}
 {{- end -}}

--- a/charts/pulsar/templates/broker/_broker.tpl
+++ b/charts/pulsar/templates/broker/_broker.tpl
@@ -97,7 +97,7 @@ Define broker tls certs volumes
 {{- if and .Values.tls.enabled (or .Values.tls.broker.enabled (or .Values.tls.bookie.enabled .Values.tls.zookeeper.enabled)) }}
 - name: broker-certs
   secret:
-    secretName: "{{ .Release.Name }}-{{ .Values.tls.broker.cert_name }}"
+    secretName: "{{ template "pulsar.broker.tls.secret.name" . }}"
     items:
     - key: tls.crt
       path: tls.crt
@@ -105,7 +105,7 @@ Define broker tls certs volumes
       path: tls.key
 - name: ca
   secret:
-    secretName: "{{ .Release.Name }}-ca-tls"
+    secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
     items:
     - key: ca.crt
       path: ca.crt
@@ -399,7 +399,7 @@ Define kop tls certs volumes
 {{- if and .Values.tls.enabled .Values.tls.kop.enabled }}
 - name: kop-certs
   secret:
-    secretName: "{{ .Release.Name }}-{{ .Values.tls.proxy.cert_name }}"
+    secretName: "{{ template "pulsar.proxy.tls.secret.name" . }}"
     items:
     - key: keystore.jks
       path: keystore.jks
@@ -409,3 +409,14 @@ Define kop tls certs volumes
     {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Define Broker TLS certificate secret name
+*/}}
+{{- define "pulsar.broker.tls.secret.name" -}}
+{{- if .Values.tls.broker.certSecretName -}}
+{{- .Values.tls.broker.certSecretName -}}
+{{- else -}}
+{{ .Release.Name }}-{{ .Values.tls.broker.cert_name }}
+{{- end -}}
+{{- end -}}

--- a/charts/pulsar/templates/function-worker/_function_worker.tpl
+++ b/charts/pulsar/templates/function-worker/_function_worker.tpl
@@ -74,9 +74,9 @@ Define function tls certs volumes
 */}}
 {{- define "pulsar.function.certs.volumes" -}}
 {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
-- name: broker-certs
+- name: function-certs
   secret:
-    secretName: "{{ .Release.Name }}-{{ .Values.tls.functions.cert_name }}"
+    secretName: "{{ template "pulsar.function.tls.secret.name" . }}"
     items:
     - key: tls.crt
       path: tls.crt
@@ -84,7 +84,7 @@ Define function tls certs volumes
       path: tls.key
 - name: ca
   secret:
-    secretName: "{{ .Release.Name }}-ca-tls"
+    secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
     items:
     - key: ca.crt
       path: ca.crt
@@ -150,3 +150,14 @@ Define function token volumes
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Define Function TLS certificate secret name
+*/}}
+{{- define "pulsar.function.tls.secret.name" -}}
+{{- if .Values.tls.functions.certSecretName -}}
+{{- .Values.tls.functions.certSecretName -}}
+{{- else -}}
+{{ .Release.Name }}-{{ .Values.tls.functions.cert_name }}
+{{- end -}}
+{{- end -}}

--- a/charts/pulsar/templates/presto/_presto.tpl
+++ b/charts/pulsar/templates/presto/_presto.tpl
@@ -52,3 +52,14 @@ image: "{{ .Values.images.presto.repository }}:{{ .Values.images.presto.tag }}"
 imagePullPolicy: {{ .Values.images.presto.pullPolicy }}
 {{- end }}
 {{- end }}
+
+{{/*
+Define Presto TLS certificate secret name
+*/}}
+{{- define "pulsar.presto.tls.secret.name" -}}
+{{- if .Values.tls.presto.certSecretName -}}
+{{- .Values.tls.presto.certSecretName -}}
+{{- else -}}
+{{ .Release.Name }}-{{ .Values.tls.presto.cert_name }}
+{{- end -}}
+{{- end -}}

--- a/charts/pulsar/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/pulsar/templates/presto/presto-coordinator-statefulset.yaml
@@ -242,7 +242,7 @@ spec:
         {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
         - name: ca
           secret:
-            secretName: "{{ .Release.Name }}-ca-tls"
+            secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
             items:
               - key: ca.crt
                 path: ca.crt
@@ -250,7 +250,7 @@ spec:
         {{- if and .Values.tls.enabled (or .Values.tls.broker.enabled (or .Values.tls.zookeeper.enabled .Values.tls.bookie.enabled)) }}
         - name: presto-certs
           secret:
-            secretName: "{{ .Release.Name }}-{{ .Values.tls.presto.cert_name }}"
+            secretName: "{{ template "pulsar.presto.tls.secret.name" . }}"
             items:
               - key: tls.crt
                 path: tls.crt

--- a/charts/pulsar/templates/presto/presto-worker-statefulset.yaml
+++ b/charts/pulsar/templates/presto/presto-worker-statefulset.yaml
@@ -220,7 +220,7 @@ spec:
         {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
         - name: ca
           secret:
-            secretName: "{{ .Release.Name }}-ca-tls"
+            secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
             items:
               - key: ca.crt
                 path: ca.crt
@@ -228,7 +228,7 @@ spec:
         {{- if and .Values.tls.enabled (or .Values.tls.broker.enabled (or .Values.tls.zookeeper.enabled .Values.tls.bookie.enabled)) }}
         - name: presto-certs
           secret:
-            secretName: "{{ .Release.Name }}-{{ .Values.tls.presto.cert_name }}"
+            secretName: "{{ template "pulsar.presto.tls.secret.name" . }}"
             items:
               - key: tls.crt
                 path: tls.crt

--- a/charts/pulsar/templates/proxy/_proxy.tpl
+++ b/charts/pulsar/templates/proxy/_proxy.tpl
@@ -108,7 +108,7 @@ Define proxy certs volumes
       - key: {{ .Values.certs.lets_encrypt.ca_ref.keyName }}
         path: ca.crt
   {{- else }}
-    secretName: "{{ .Release.Name }}-ca-tls"
+    secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
     items:
       - key: ca.crt
         path: ca.crt
@@ -116,7 +116,7 @@ Define proxy certs volumes
   {{- end }}
 - name: proxy-certs
   secret:
-    secretName: "{{ .Release.Name }}-{{ .Values.tls.proxy.cert_name }}"
+    secretName: "{{ template "pulsar.proxy.tls.secret.name" . }}"
     items:
       - key: tls.crt
         path: tls.crt
@@ -126,7 +126,7 @@ Define proxy certs volumes
 {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
 - name: broker-ca
   secret:
-    secretName: "{{ .Release.Name }}-ca-tls"
+    secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
     items:
       - key: ca.crt
         path: ca.crt
@@ -284,5 +284,16 @@ https://{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}:{{ 
     {{- end -}}
 {{- else -}}
 {{ .Values.proxy.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define Proxy TLS certificate secret name
+*/}}
+{{- define "pulsar.proxy.tls.secret.name" -}}
+{{- if .Values.tls.proxy.certSecretName -}}
+{{- .Values.tls.proxy.certSecretName -}}
+{{- else -}}
+{{ .Release.Name }}-{{ .Values.tls.proxy.cert_name }}
 {{- end -}}
 {{- end -}}

--- a/charts/pulsar/templates/pulsar-manager/_pulsar_manager.tpl
+++ b/charts/pulsar/templates/pulsar-manager/_pulsar_manager.tpl
@@ -22,7 +22,7 @@ Define pulsar_manager tls certs volumes
 {{- if and .Values.tls.enabled (or .Values.tls.pulsar_manager.enabled .Values.tls.broker.enabled) }}
 - name: pulsar-manager-certs
   secret:
-    secretName: "{{ .Release.Name }}-{{ .Values.tls.pulsar_manager.cert_name }}"
+    secretName: "{{ template "pulsar.pulsar_manager.tls.secret.name" . }}"
     items:
     - key: tls.crt
       path: tls.crt
@@ -30,7 +30,7 @@ Define pulsar_manager tls certs volumes
       path: tls.key
 - name: ca
   secret:
-    secretName: "{{ .Release.Name }}-ca-tls"
+    secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
     items:
     - key: ca.crt
       path: ca.crt
@@ -149,3 +149,14 @@ storageClassName: "{{ .Values.pulsar_manager.volumes.data.storageClassName }}"
   {{- end -}}
 {{- end }}
 {{- end }}
+
+{{/*
+Define Pulsar manager TLS certificate secret name
+*/}}
+{{- define "pulsar.pulsar_manager.tls.secret.name" -}}
+{{- if .Values.tls.pulsar_manager.certSecretName -}}
+{{- .Values.tls.pulsar_manager.certSecretName -}}
+{{- else -}}
+{{ .Release.Name }}-{{ .Values.tls.pulsar_manager.cert_name }}
+{{- end -}}
+{{- end -}}

--- a/charts/pulsar/templates/toolset/_toolset.tpl
+++ b/charts/pulsar/templates/toolset/_toolset.tpl
@@ -98,7 +98,7 @@ Define toolset tls certs volumes
 {{- if and .Values.tls.enabled (or .Values.tls.zookeeper.enabled .Values.tls.broker.enabled) }}
 - name: toolset-certs
   secret:
-    secretName: "{{ .Release.Name }}-{{ .Values.tls.toolset.cert_name }}"
+    secretName: "{{ template "pulsar.toolset.tls.secret.name" . }}"
     items:
     - key: tls.crt
       path: tls.crt
@@ -106,7 +106,7 @@ Define toolset tls certs volumes
       path: tls.key
 - name: ca
   secret:
-    secretName: "{{ .Release.Name }}-ca-tls"
+    secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
     items:
     - key: ca.crt
       path: ca.crt
@@ -127,7 +127,7 @@ Define toolset tls certs volumes
       - key: {{ .Values.certs.lets_encrypt.ca_ref.keyName }}
         path: ca.crt
   {{- else }}
-    secretName: "{{ .Release.Name }}-ca-tls"
+    secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
     items:
       - key: ca.crt
         path: ca.crt
@@ -253,3 +253,13 @@ Define toolset pulsarctl config volumes
     name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
 {{- end }}
 
+{{/*
+Define toolset TLS certificate secret name
+*/}}
+{{- define "pulsar.toolset.tls.secret.name" -}}
+{{- if .Values.tls.toolset.certSecretName -}}
+{{- .Values.tls.toolset.certSecretName -}}
+{{- else -}}
+{{ .Release.Name }}-{{ .Values.tls.toolset.cert_name }}
+{{- end -}}
+{{- end -}}

--- a/charts/pulsar/templates/zookeeper/_zookeeper.tpl
+++ b/charts/pulsar/templates/zookeeper/_zookeeper.tpl
@@ -69,7 +69,7 @@ Define zookeeper certs volumes
 {{- if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
 - name: zookeeper-certs
   secret:
-    secretName: "{{ .Release.Name }}-{{ .Values.tls.zookeeper.cert_name }}"
+    secretName: "{{ template "pulsar.zookeeper.tls.secret.name" . }}"
     items:
       - key: tls.crt
         path: tls.crt
@@ -77,7 +77,7 @@ Define zookeeper certs volumes
         path: tls.key
 - name: ca
   secret:
-    secretName: "{{ .Release.Name }}-ca-tls"
+    secretName: "{{ template "pulsar.tls.ca.secret.name" . }}"
     items:
       - key: ca.crt
         path: ca.crt
@@ -245,3 +245,14 @@ Define zookeeper gen-zk-conf volumes
     name: "{{ template "pulsar.fullname" . }}-genzkconf-configmap"
     defaultMode: 0755
 {{- end }}
+
+{{/*
+Define Zookeeper TLS certificate secret name
+*/}}
+{{- define "pulsar.zookeeper.tls.secret.name" -}}
+{{- if .Values.tls.zookeeper.certSecretName -}}
+{{- .Values.tls.zookeeper.certSecretName -}}
+{{- else -}}
+{{ .Release.Name }}-{{ .Values.tls.zookeeper.cert_name }}
+{{- end -}}
+{{- end -}}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -217,10 +217,12 @@ tls:
     keySize: 4096
     keyAlgorithm: rsa
     keyEncoding: pkcs8
+    caSecretName:
   # settings for generating certs for proxy
   proxy:
     enabled: false
     cert_name: tls-proxy
+    certSecretName:
     untrustedCa: true
   # settings for generating certs for proxy
   pulsar_detector:
@@ -230,11 +232,13 @@ tls:
   broker:
     enabled: false
     cert_name: tls-broker
+    certSecretName:
   brokerClient:
     enabled: false
   functions:
     enabled: false
     cert_name: tls-function
+    certSecretName:
   # settings for generating certs for kop
   kop:
     enabled: false
@@ -245,22 +249,28 @@ tls:
   bookie:
     enabled: false
     cert_name: tls-bookie
+    certSecretName:
   # settings for generating certs for zookeeper
   zookeeper:
     enabled: false
     cert_name: tls-zookeeper
+    certSecretName:
   # settings for generating certs for recovery
   autorecovery:
     cert_name: tls-recovery
+    certSecretName:
   # settings for generating certs for toolset
   toolset:
     cert_name: tls-toolset
+    certSecretName:
   pulsar_manager:
     enabled: false
     cert_name: tls-pulsar-manager
+    certSecretName:
   presto:
     enabled: false
     cert_name: tls-presto
+    certSecretName:
 
 # Enable or disable broker authentication and authorization.
 auth:


### PR DESCRIPTION
Fixes #563


### Motivation
User might have their own CA and issue cert by themself, we should support using user provided cert for components.

### Modifications
Add certSecretName for components which need to mount certs, so user can mount custom cert through secret.
Assuming there'll be only one CA and all cert secrets will be created in advance which will be out of scope of this chart.

### Verifying this change
- [x] Make sure that the change passes the CI checks.
This change is a trivial rework / code cleanup without any test coverage.

### Documentation
- [x] `no-need-doc` 
