### PR TITLE
Support custom config data for bookkeeper

### DIFF
--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
@@ -164,7 +164,11 @@ spec:
   {{- end }}
   config:
     custom:
+{{- if .Values.bookkeeper.custom }}
+{{ toYaml .Values.bookkeeper.custom | indent 6 }}
+{{- else }}
 {{ toYaml .Values.bookkeeper.configData | indent 6 }}
+{{- end }}
       zkLedgersRootPath: "{{ .Values.metadataPrefix }}/ledgers"
       # enable bookkeeper http server
       httpServerEnabled: "true"

--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
@@ -158,35 +158,31 @@ spec:
         {{- include "pulsar.bookkeeper.ledgers.storage.class" . | nindent 8 }}
     reclaimPolicy: Delete
   {{- end }}
-  {{- if .Values.bookkeeper.custom }}
   config:
     custom:
-{{ toYaml .Values.bookkeeper.custom | indent 6 }}
-  {{- end }}
-  conf:
-{{ toYaml .Values.bookkeeper.configData | indent 4 }}
-    zkLedgersRootPath: "{{ .Values.metadataPrefix }}/ledgers"
-    # enable bookkeeper http server
-    httpServerEnabled: "true"
-    httpServerPort: "{{ .Values.bookkeeper.ports.http }}"
-    # config the stats provider
-    statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
-    # use hostname as the bookie id
-    useHostNameAsBookieID: "true"
-    {{- if .Values.components.autorecovery }}
-    # disable auto recovery on bookies since we will start AutoRecovery in separated pods
-    autoRecoveryDaemonEnabled: "false"
-    {{- end }}
-    # Do not retain journal files as it increase the disk utilization
-    journalMaxBackups: "0"
-    {{- if .Values.bookkeeper.operator.adopt_existing }}
-    # if adopting existing bk cluster then also keep existing ledger/journal dir setting
-    journalDirectories: "/pulsar/data/bookkeeper/journal"
-    PULSAR_PREFIX_journalDirectories: "/pulsar/data/bookkeeper/journal"
-    ledgerDirectories: "/pulsar/data/bookkeeper/ledgers"
-    PULSAR_PREFIX_ledgerDirectories: "/pulsar/data/bookkeeper/ledgers"
-    {{- end }}
-    BOOKIE_MEM: {{ .Values.bookkeeper.configData.BOOKIE_MEM }}
+{{ toYaml .Values.bookkeeper.configData | indent 6 }}
+      zkLedgersRootPath: "{{ .Values.metadataPrefix }}/ledgers"
+      # enable bookkeeper http server
+      httpServerEnabled: "true"
+      httpServerPort: "{{ .Values.bookkeeper.ports.http }}"
+      # config the stats provider
+      statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
+      # use hostname as the bookie id
+      useHostNameAsBookieID: "true"
+      {{- if .Values.components.autorecovery }}
+      # disable auto recovery on bookies since we will start AutoRecovery in separated pods
+      autoRecoveryDaemonEnabled: "false"
+      {{- end }}
+      # Do not retain journal files as it increase the disk utilization
+      journalMaxBackups: "0"
+      {{- if .Values.bookkeeper.operator.adopt_existing }}
+      # if adopting existing bk cluster then also keep existing ledger/journal dir setting
+      journalDirectories: "/pulsar/data/bookkeeper/journal"
+      PULSAR_PREFIX_journalDirectories: "/pulsar/data/bookkeeper/journal"
+      ledgerDirectories: "/pulsar/data/bookkeeper/ledgers"
+      PULSAR_PREFIX_ledgerDirectories: "/pulsar/data/bookkeeper/ledgers"
+      {{- end }}
+      BOOKIE_MEM: {{ .Values.bookkeeper.configData.BOOKIE_MEM }}
 {{- include "pulsar.bookkeeper.config.tls" . | nindent 4 }}
 {{ (.Files.Glob "conf/bookie/log4j2.yaml").AsConfig | indent 4 }}
   autoRecovery:

--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
@@ -187,8 +187,8 @@ spec:
       PULSAR_PREFIX_ledgerDirectories: "/pulsar/data/bookkeeper/ledgers"
       {{- end }}
       BOOKIE_MEM: {{ .Values.bookkeeper.configData.BOOKIE_MEM }}
-{{- include "pulsar.bookkeeper.config.tls" . | nindent 4 }}
-{{ (.Files.Glob "conf/bookie/log4j2.yaml").AsConfig | indent 4 }}
+{{- include "pulsar.bookkeeper.config.tls" . | nindent 6 }}
+{{ (.Files.Glob "conf/bookie/log4j2.yaml").AsConfig | indent 6 }}
   autoRecovery:
     {{- if and .Values.components.autoscaling .Values.autorecovery.autoscaling.maxReplicas }}
     autoScalingPolicy:

--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
@@ -164,6 +164,7 @@ spec:
 {{ toYaml .Values.bookkeeper.custom | indent 6 }}
   {{- end }}
   conf:
+{{ toYaml .Values.bookkeeper.configData | indent 4 }}
     zkLedgersRootPath: "{{ .Values.metadataPrefix }}/ledgers"
     # enable bookkeeper http server
     httpServerEnabled: "true"

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -876,6 +876,7 @@ bookkeeper:
   autoRollDeployment: true
   placementPolicy:
     rackAware: true
+  custom: {}
   configData:
     # `BOOKIE_MEM` is used for `bookie shell`
     BOOKIE_MEM: >

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -870,7 +870,6 @@ bookkeeper:
   autoRollDeployment: true
   placementPolicy:
     rackAware: true
-  custom: {}
   configData:
     # `BOOKIE_MEM` is used for `bookie shell`
     BOOKIE_MEM: >


### PR DESCRIPTION


Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

* Some users complained that some custom configurations could not be loaded into the bookkeeper configuration  so this pr fixes it

### Modifications

* Support load custom configData for bookkeeper

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

