### PR TITLE
Suuport specifying image and config probes for bank-vault container.

### DIFF
--- a/charts/sn-platform/templates/vault/vault-statefulset.yaml
+++ b/charts/sn-platform/templates/vault/vault-statefulset.yaml
@@ -28,6 +28,7 @@ metadata:
 spec:
   size: 3
   image: "{{ .Values.images.vault.repository }}:{{ .Values.images.vault.tag }}"
+  bankVaultsImage: "{{ .Values.images.bank_vaults.repository }}:{{ .Values.images.bank_vaults.tag }}"
   serviceAccount: {{ template "pulsar.vault.serviceAccount" . }}
   serviceType: {{ .Values.vault.serviceType }}
 
@@ -59,7 +60,21 @@ spec:
     imagePullSecrets:
     - name: {{ .Values.imagePullSecrets }}
   {{- end }}
-  
+  {{- if or .Values.vault.config.bankVaults.probe.livenessProbe .Values.vault.config.bankVaults.probe.startupProbe .Values.vault.config.bankVaults.probe.readinessProbe }}
+  vaultContainerSpec:
+    {{- if .Values.vault.config.bankVaults.probe.readinessProbe }}
+    readinessProbe:
+{{ toYaml .Values.vault.config.bankVaults.probe.readinessProbe | indent 6 }}
+    {{- end }}
+    {{- if .Values.vault.config.bankVaults.probe.startupProbe }}
+    startupProbe:
+{{ toYaml .Values.vault.config.bankVaults.probe.startupProbe | indent 6 }}
+    {{- end }}
+    {{- if .Values.vault.config.bankVaults.probe.livenessProbe }}
+    livenessProbe:
+{{ toYaml .Values.vault.config.bankVaults.probe.livenessProbe | indent 6 }}
+    {{- end }}
+  {{- end }}
 {{- if and .Values.volumes.persistence .Values.vault.volume.persistence}}
   volumeClaimTemplates:
   - metadata:

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -218,6 +218,10 @@ images:
     repository: vault
     tag: "1.7.0"
     pullPolicy: "IfNotPresent"
+  bank_vaults:
+    repository: ghcr.io/banzaicloud/bank-vaults
+    tag: "1.15.2"
+    pullPolicy: "IfNotPresent"
   vault_init:
     repository: streamnative/pulsar_vault_init
     tag: "v1.0.2"
@@ -2217,6 +2221,16 @@ vault:
     ui: true
     telemetry:
       statsd_address: ""
+    bankVaults:
+      probe:
+        readinessProbe:
+          failureThreshold: 2
+          httpGet:
+            path: "/v1/sys/init"
+            port: "api-port"
+            scheme: "HTTP"
+        startupProbe: {}
+        livenessProbe: {}
   resources:
     limits:
       memory: "512Mi"


### PR DESCRIPTION
Fixes #617

### Motivation
User might want to set image and configure probes for bank-vaults container.

### Modifications
Support specifying image and config probe for bank-vaults container.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

- [x] `no-need-doc` 
 