### PR TITLE
Fixed vault container spec missing name field

### DIFF
--- a/charts/sn-platform/templates/vault/vault-statefulset.yaml
+++ b/charts/sn-platform/templates/vault/vault-statefulset.yaml
@@ -62,6 +62,7 @@ spec:
   {{- end }}
   {{- if or .Values.vault.config.bankVaults.probe.livenessProbe .Values.vault.config.bankVaults.probe.startupProbe .Values.vault.config.bankVaults.probe.readinessProbe }}
   vaultContainerSpec:
+    name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-vault-container-spec"
     {{- if .Values.vault.config.bankVaults.probe.readinessProbe }}
     readinessProbe:
 {{ toYaml .Values.vault.config.bankVaults.probe.readinessProbe | indent 6 }}

--- a/charts/sn-platform/templates/vault/vault-statefulset.yaml
+++ b/charts/sn-platform/templates/vault/vault-statefulset.yaml
@@ -62,7 +62,7 @@ spec:
   {{- end }}
   {{- if or .Values.vault.config.bankVaults.probe.livenessProbe .Values.vault.config.bankVaults.probe.startupProbe .Values.vault.config.bankVaults.probe.readinessProbe }}
   vaultContainerSpec:
-    name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-vault-container-spec"
+    name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-vault"
     {{- if .Values.vault.config.bankVaults.probe.readinessProbe }}
     readinessProbe:
 {{ toYaml .Values.vault.config.bankVaults.probe.readinessProbe | indent 6 }}


### PR DESCRIPTION
Fixed upgrade execption:

```
  vaultContainerSpec:
    name: pulsar25-sn-platform-vault-vault-container-spec
    readinessProbe:
      failureThreshold: 2
      httpGet:
        path: /v1/sys/init
        port: api-port
        scheme: HTTP
```

vault-operator 1.15.1

```
Error: UPGRADE FAILED: error validating "": error validating data: ValidationError(Vault.spec.vaultContainerSpec): missing required field "name" in com.banzaicloud.vault.v1alpha1.Vault.spec.vaultContainerSpec
helm.go:84: [debug] error validating "": error validating data: ValidationError(Vault.spec.vaultContainerSpec): missing required field "name" in com.banzaicloud.vault.v1alpha1.Vault.spec.vaultContainerSpec
```



### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

