### PR TITLE
Support config node selector for zk

### DIFF
--- a/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
@@ -144,6 +144,10 @@ spec:
     {{- if .Values.zookeeper.securityContext }}
     securityContext: {{ .Values.zookeeper.securityContext }}
     {{- end }}
+    {{- if .Values.zookeeper.nodeSelector }}
+    nodeSelector:
+{{ toYaml .Values.zookeeper.nodeSelector | indent 8 }}
+    {{- end }}
     {{- if .Values.zookeeper.tolerations }}
     tolerations:
 {{ toYaml .Values.zookeeper.tolerations | indent 6 }}

--- a/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
@@ -146,7 +146,7 @@ spec:
     {{- end }}
     {{- if .Values.zookeeper.nodeSelector }}
     nodeSelector:
-{{ toYaml .Values.zookeeper.nodeSelector | indent 8 }}
+{{ toYaml .Values.zookeeper.nodeSelector | indent 6 }}
     {{- end }}
     {{- if .Values.zookeeper.tolerations }}
     tolerations:


### PR DESCRIPTION


### Motivation

* Support config node selector for zookeeper

### Modifications

* * Support config node selector for zookeeper

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

