### PR TITLE
Use template pulsar.zookeeper.connect for detector zk initContainer.

### DIFF
--- a/charts/sn-platform/templates/detector/pulsar-detector-statefulset.yaml
+++ b/charts/sn-platform/templates/detector/pulsar-detector-statefulset.yaml
@@ -72,7 +72,7 @@ spec:
         command: ["sh", "-c"]
         args:
           - >-
-            until bin/pulsar zookeeper-shell -server {{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }} get {{ .Values.metadataPrefix }}/admin/clusters/{{ template "pulsar.cluster" . }}; do
+            until bin/pulsar zookeeper-shell -server {{ template "pulsar.zookeeper.connect" . }} get {{ .Values.metadataPrefix }}/admin/clusters/{{ template "pulsar.cluster" . }}; do
               sleep 3;
             done;
       # This init container will wait for at least one broker to be ready before


### PR DESCRIPTION
Fixes #638

### Motivation
Don't use hardcoded zk url for detector zk initContainer.

### Modifications
Use template pulsar.zookeeper.connect for detector zk initContainer.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
Verified by installing the chart.

### Documentation

- [x] `no-need-doc` 
 
