### PR TITLE
[SN-Platform] make reclaimPolicy of zk/bk configurable

### DIFF
--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
@@ -160,7 +160,7 @@ spec:
           requests:
             storage: {{ .Values.bookkeeper.volumes.ledgers.size }}
         {{- include "pulsar.bookkeeper.ledgers.storage.class" . | nindent 8 }}
-    reclaimPolicy: Delete
+    reclaimPolicy: {{ .Values.bookkeeper.volumes.reclaimPolicy | default "Delete" }}
   {{- end }}
   config:
     custom:

--- a/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
@@ -210,7 +210,7 @@ spec:
       storageClassName: {{ .Values.zookeeper.volumes.data.storageClassName }}
       {{- end -}}
     {{- end }}
-    reclaimPolicy: Delete
+    reclaimPolicy: {{ .Values.zookeeper.volumes.reclaimPolicy | default "Delete" }}
   {{- end }}
   config:
     serverCnxnFactory: {{ .Values.zookeeper.serverCnxnFactory }}

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -618,7 +618,6 @@ zookeeper:
     persistence: true
     # specify the reclaimPolicy for the persistent volume of zookeeper,
     # valid values are: Delete, Retain
-    # ref: https://github.com/streamnative/pulsar-operators/blob/ae150ffaba558b77fc3cc22645417b4110bf49d2/zookeeper-operator/api/v1alpha1/zookeepercluster_types.go#L329
     reclaimPolicy: "Delete"
     # Add a flag here for backward compatibility. Ideally we should
     # use two disks for production workloads. This flag might be
@@ -833,7 +832,6 @@ bookkeeper:
     persistence: true
     # specify the reclaimPolicy for the persistent volume of bookie data,
     # valid values are: Delete, Retain
-    # ref: https://github.com/streamnative/pulsar-operators/blob/ae150ffaba558b77fc3cc22645417b4110bf49d2/bookkeeper-operator/api/v1alpha1/bookkeepercluster_types.go#L293
     reclaimPolicy: "Delete"
     journal:
       # It determines the directory of journal data

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -616,7 +616,7 @@ zookeeper:
   volumes:
     # use a persistent volume or emptyDir
     persistence: true
-    # specify the reclaimPolicy for the persistent volume of zookeeper, 
+    # specify the reclaimPolicy for the persistent volume of zookeeper,
     # valid values are: Delete, Retain
     # ref: https://github.com/streamnative/pulsar-operators/blob/ae150ffaba558b77fc3cc22645417b4110bf49d2/zookeeper-operator/api/v1alpha1/zookeepercluster_types.go#L329
     reclaimPolicy: "Delete"
@@ -831,7 +831,7 @@ bookkeeper:
   volumes:
     # use a persistent volume or emptyDir
     persistence: true
-    # specify the reclaimPolicy for the persistent volume of bookie data, 
+    # specify the reclaimPolicy for the persistent volume of bookie data,
     # valid values are: Delete, Retain
     # ref: https://github.com/streamnative/pulsar-operators/blob/ae150ffaba558b77fc3cc22645417b4110bf49d2/bookkeeper-operator/api/v1alpha1/bookkeepercluster_types.go#L293
     reclaimPolicy: "Delete"

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -827,6 +827,10 @@ bookkeeper:
   volumes:
     # use a persistent volume or emptyDir
     persistence: true
+    # specify the reclaimPolicy for the persistent volume of bookie data, 
+    # valid values are: Delete, Retain
+    # ref: https://github.com/streamnative/pulsar-operators/blob/ae150ffaba558b77fc3cc22645417b4110bf49d2/bookkeeper-operator/api/v1alpha1/bookkeepercluster_types.go#L293
+    reclaimPolicy: "Delete"
     journal:
       # It determines the directory of journal data
       numVolumes: 1

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -616,6 +616,10 @@ zookeeper:
   volumes:
     # use a persistent volume or emptyDir
     persistence: true
+    # specify the reclaimPolicy for the persistent volume of zookeeper, 
+    # valid values are: Delete, Retain
+    # ref: https://github.com/streamnative/pulsar-operators/blob/ae150ffaba558b77fc3cc22645417b4110bf49d2/zookeeper-operator/api/v1alpha1/zookeepercluster_types.go#L329
+    reclaimPolicy: "Delete"
     # Add a flag here for backward compatibility. Ideally we should
     # use two disks for production workloads. This flag might be
     # removed in the future releases to stick to two-disks mode.


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[charts/<chart-name>] Title of the pull request".
    Skip *[charts/<chart-name>]* if the PR doesn't change a specific chart. E.g. `[docs] Fix typo in README`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #642 

### Motivation

It's feature of BookKeeperCluster and ZooKeeperCluster, We should expose the reclaim policy option (DELETE or RETAIN) to values.yaml.

### Modifications

- expose `spec.storage.reclaimPolicy` of BookKeeperCluster to `bookkeeper.volumes.reclaimPolicy` in values, default value is still "Delete"
- expose `spec.storage.reclaimPolicy` of ZooKeeperCluster to `zookeeper.volumes.reclaimPolicy` in values, default value is still "Delete"
 
### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation
  
- [x] `no-need-doc` 