### PR TITLE
fix(sn-platform): set readinessProbe in bankVaults default as null

### DIFF
--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -2125,6 +2125,14 @@ vault:
     bankVaults:
       probe:
         readinessProbe: {}
+        #  Note: To use readinessProbe, you can uncomment below configs
+        #  If you want to use readinessProbe with Istio enabled, you have to chagne port from "api-port" to "http-api-port"
+        #
+        #  failureThreshold: 2
+        #  httpGet:
+        #    path: "/v1/sys/init"
+        #    port: "api-port"
+        #    scheme: "HTTP"
         startupProbe: {}
         livenessProbe: {}
   resources:

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -2124,12 +2124,7 @@ vault:
       statsd_address: ""
     bankVaults:
       probe:
-        readinessProbe:
-          failureThreshold: 2
-          httpGet:
-            path: "/v1/sys/init"
-            port: "api-port"
-            scheme: "HTTP"
+        readinessProbe: {}
         startupProbe: {}
         livenessProbe: {}
   resources:

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -2126,7 +2126,7 @@ vault:
       probe:
         readinessProbe: {}
         #  Note: To use readinessProbe, you can uncomment below configs
-        #  If you want to use readinessProbe with Istio enabled, you have to chagne port from "api-port" to "http-api-port"
+        #  If you want to use readinessProbe with Istio enabled, you have to change port from "api-port" to "http-api-port"
         #
         #  failureThreshold: 2
         #  httpGet:


### PR DESCRIPTION
Signed-off-by: ericsyh <ericshenyuhao@outlook.com>

<!--
### Contribution Checklist
  
  - Name the pull request in the form "[charts/<chart-name>] Title of the pull request".
    Skip *[charts/<chart-name>]* if the PR doesn't change a specific chart. E.g. `[docs] Fix typo in README`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

Set the readinessProbe for bankVaults container as null by default to fix the issue when Istio enabld and hang the vault pod up. 

### Modifications

Set the readinessProbe for bankVaults container as null by default to fix the issue when Istio enabld and hang the vault pod up. 

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

