### PR TITLE
[charts/pulsar] adding flag webSocketServiceEnabled cm

### DIFF
--- a/charts/pulsar/templates/broker/broker-configmap.yaml
+++ b/charts/pulsar/templates/broker/broker-configmap.yaml
@@ -42,7 +42,9 @@ data:
   numHttpServerThreads: "8"
   zooKeeperSessionTimeoutMillis: "30000"
   statusFilePath: "{{ template "pulsar.home" . }}/status"
-
+  {{- if .Values.proxy.websocket.enabled }}
+  webSocketServiceEnnabled: "true"
+  {{- end }}
   ## Offloading settings
   {{- if .Values.broker.offload.enabled }}
   offloadersDirectory: "{{ template "pulsar.home" . }}/offloaders"

--- a/charts/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/charts/pulsar/templates/proxy/proxy-configmap.yaml
@@ -59,6 +59,10 @@ data:
   brokerServiceURL: {{ template "pulsar.proxy.broker.service.url" . }}
   brokerWebServiceURL: {{ template "pulsar.proxy.web.service.url" . }}
   {{- end }}
+  # proxy websocketservice
+  {{- if .Values.proxy.websocket.enabled }}
+  webSocketServiceEnabled: "true"
+  {{- end }}
 
   # Authentication Settings
   {{- if .Values.auth.authentication.enabled }}


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[charts/pulsar] add websocketenabled flag broker/proxy CM".
    Skip *[charts/<chart-name>]* if the PR doesn't change a specific chart. E.g. `[docs] Fix typo in README`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

* According to the doc,  proxy supports websocket but the broker and proxy cm template have no option to turn it on.*

### Modifications

*The proxy-configmap.yaml and broker-configmap.yaml are modified to enable websocket services.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.


### Documentation

Check the box below.

Need to update docs? 

  
- [ x ] `no-need-doc` 
  
  (Please explain why)
  

