### PR TITLE
Fix sn-console generated pvc name.

### DIFF
--- a/charts/sn-console/templates/console/streamnative-console-pvc.yaml
+++ b/charts/sn-console/templates/console/streamnative-console-pvc.yaml
@@ -22,7 +22,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: "{{ template "sn_console.fullname" . }}-{{ .Values.component }}-{{ .Values.volumes.data.name }}"
+  name: {{ template "streamnative_console.data.pvc.name" . }}
   namespace: {{ template "sn_console.namespace" . }}
 spec:
   resources:


### PR DESCRIPTION
### Motivation
The pre-generated pvc's name doesn't match the one mounted by sts, fixing it.

### Modifications
Fix the generated pvc name.

### Verifying this change
- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation
- [x] `no-need-doc` 
  