### PR TITLE
Check for condition when creating vault secret.

### DIFF
--- a/charts/sn-platform/templates/vault/vault-public-key-secret.yaml
+++ b/charts/sn-platform/templates/vault/vault-public-key-secret.yaml
@@ -16,7 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-
+  
+{{- if .Values.components.vault }}
 apiVersion: v1
 kind: Secret
 data:
@@ -25,3 +26,4 @@ metadata:
   name: {{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-public-key
   namespace: {{ template "pulsar.namespace" . }}
 type: Opaque
+{{- end }}


### PR DESCRIPTION
### Motivation
The vault secret is only needed when vault is enabled.

### Modifications
So checking the condition when creating the secret.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

- [x] `no-need-doc` 
  