### PR TITLE
[sn-platform]Fix Prometheus Scraping promblem with Istio enabled

### DIFF
--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-authorizationpolicy.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-authorizationpolicy.yaml
@@ -36,4 +36,25 @@ spec:
       cloud.streamnative.io/app: pulsar
       cloud.streamnative.io/component: bookie
       cloud.streamnative.io/cluster: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
+{{- if .Values.components.autorecovery }}
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
+  namespace: {{ template "pulsar.namespace" . }}
+spec:
+  rules:
+  - to:
+    - operation:
+        ports:
+        - "{{ .Values.autorecovery.ports.http }}"
+  action: ALLOW
+  selector:
+    matchLabels:
+      cloud.streamnative.io/app: pulsar
+      cloud.streamnative.io/component: bookkeeper-auto-recovery
+      cloud.streamnative.io/cluster: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
+---
+{{- end }}
 {{- end }}

--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -55,6 +55,7 @@ spec:
 {{- if (and .Values.prometheus.scrape.broker .Values.prometheus.scrape.enabled) }}
       prometheus.io/scrape: "true"
       prometheus.io/port: "{{ .Values.broker.ports.http }}"
+      prometheus.io/path: "/metrics/"
 {{- end }}
 {{- with .Values.broker.annotations }}
 {{ toYaml . | indent 6 }}

--- a/charts/sn-platform/templates/prometheus/prometheus-configmap.yaml
+++ b/charts/sn-platform/templates/prometheus/prometheus-configmap.yaml
@@ -67,6 +67,11 @@ data:
             - {{ .Values.namespace }}
 {{- end }}
       relabel_configs:
+{{- if .Values.istio.enabled }}
+      - source_labels: [__meta_kubernetes_pod_label_cloud_streamnative_io_app]
+        action: keep
+        regex: pulsar
+{{- end }}
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true
@@ -96,7 +101,7 @@ data:
 {{ toYaml . | indent 6 }}
 {{- end }}
 {{- end }}
-{{- if eq .Values.prometheus.serviceAccount.clusterRole true }}
+{{- if and (eq .Values.prometheus.serviceAccount.clusterRole true) (ne .Values.istio.enabled true) }}
     - job_name: 'kubernetes-nodes'
       scheme: https
       kubernetes_sd_configs:

--- a/charts/sn-platform/templates/prometheus/prometheus-configmap.yaml
+++ b/charts/sn-platform/templates/prometheus/prometheus-configmap.yaml
@@ -66,6 +66,14 @@ data:
           names:
             - {{ .Values.namespace }}
 {{- end }}
+{{- if .Values.istio.enabled }}
+      scheme: https
+      tls_config:
+        ca_file: /etc/prom-certs/root-cert.pem
+        cert_file: /etc/prom-certs/cert-chain.pem
+        key_file: /etc/prom-certs/key.pem
+        insecure_skip_verify: true
+{{- end }}
       relabel_configs:
 {{- if .Values.istio.enabled }}
       - source_labels: [__meta_kubernetes_pod_label_cloud_streamnative_io_app]

--- a/charts/sn-platform/templates/prometheus/prometheus-statefulset.yaml
+++ b/charts/sn-platform/templates/prometheus/prometheus-statefulset.yaml
@@ -42,6 +42,16 @@ spec:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.prometheus.component }}
       annotations:
+        {{- if .Values.istio.enabled }}
+        # ref: https://istio.io/latest/docs/ops/integrations/prometheus/#tls-settings
+        traffic.sidecar.istio.io/includeOutboundIPRanges: ""  # do not intercept any outbound traffic
+        # configure an env variable `OUTPUT_CERTS` to write certificates to the given folder
+        proxy.istio.io/config: |  
+          proxyMetadata:
+            OUTPUT_CERTS: /etc/istio-output-certs
+        # mount the shared volume at sidecar proxy
+        sidecar.istio.io/userVolumeMount: '[{"name": "istio-certs", "mountPath": "/etc/istio-output-certs"}]'
+        {{- end }}
         {{- if .Values.monitoring.datadog }}
         {{- include "pulsar.prometheus.datadog.annotation" . | nindent 8 }}
         {{- end }}
@@ -188,11 +198,20 @@ spec:
           mountPath: /etc/config
         - name: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}-{{ .Values.prometheus.volumes.data.name }}"
           mountPath: /prometheus
+        {{- if .Values.istio.enabled }}
+        - name: istio-certs
+          mountPath: /etc/prom-certs/
+        {{- end }}
         {{- include "pulsar.prometheus.token.volumeMounts" . | nindent 8 }}
       volumes:
       - name: config-volume
         configMap:
           name: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}"
+      {{- if .Values.istio.enabled }}
+      - emptyDir:
+          medium: Memory
+        name: istio-certs
+      {{- end }}
     {{- range .Values.configmapReload.prometheus.extraConfigmapMounts }}
       - name: {{ $.Values.configmapReload.prometheus.name }}-{{ .name }}
         configMap:

--- a/charts/sn-platform/templates/zookeeper/zookeeper-authorizationpolicy.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-authorizationpolicy.yaml
@@ -32,6 +32,7 @@ spec:
         - "9990"
         - "2888"
         - "3888"
+        - "{{ .Values.zookeeper.ports.metrics  }}"
   action: ALLOW
   selector:
     matchLabels:


### PR DESCRIPTION
Fixes #677 

### Motivation

When Istio enabled, Pod to Pod(IP) communication will fail because of lack of `Host`/`SNI`.
Following the [Istio docs](https://istio.io/latest/docs/ops/integrations/prometheus/#tls-settings), we config Prometheus to scrape Pod metrics with Istio certs and let Istio Sidecar ignore the traffic.

### Modifications
*Only affect Istio enabled mode*

- Configure Prometheus Pod sidecar share Istio certs
- Modify Prometheus job definition to ignore non-Pulsar Pods and scrape metrics with Istio certs
- Add/Modify AuthorizationPolicy for Prometheus access BooKeeper AutoRecovery/ZooKeeper

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Need to update docs? 
  
- [x] `no-need-doc` 

