### PR TITLE
Fixed gcOptions check for jvmOptions

### DIFF
--- a/charts/sn-platform/templates/_helpers.tpl
+++ b/charts/sn-platform/templates/_helpers.tpl
@@ -131,11 +131,12 @@ jvmOptions:
   {{- toYaml . | nindent 2 }}
   {{- end }}
   {{- end }}
-  gcOptions:
   {{- if .configData.PULSAR_GC }}
+  gcOptions:
   - {{ .configData.PULSAR_GC | quote }}
   {{- else }}
   {{- with .jvm.gcOptions }}
+  gcOptions:
   {{- toYaml . | nindent 2 }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION


*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

If neither `.configData.PULSAR_GC` nor `.jvm.gcOptions` is configured, `gcOptions` may be empty, resulting in the following exception:

```
atomic being set: [bookkeepercluster.bookkeeper.streamnative.io](http://bookkeepercluster.bookkeeper.streamnative.io/) "sn-platform-bookie" is invalid: spec.autorecovery.pod.jvmOptions.gcOptions invalid value in body must be of type array null
```

### Modifications

* Add `gcOptions` to the if condition

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

