### PR TITLE
Add a dedicated service account for the console

### DIFF
--- a/charts/sn-platform/templates/streamnative-console/_streamnative-console.tpl
+++ b/charts/sn-platform/templates/streamnative-console/_streamnative-console.tpl
@@ -90,3 +90,16 @@ storageClassName: "{{ .Values.streamnative_console.volumes.data.storageClassName
   {{- end -}}
 {{- end }}
 {{- end }}
+
+{{/*Define service account*/}}
+{{- define "pulsar.streamnative_console.serviceAccount" -}}
+{{- if .Values.streamnative_console.serviceAccount.create -}}
+    {{- if .Values.streamnative_console.serviceAccount.name -}}
+{{ .Values.streamnative_console.serviceAccount.name }}
+    {{- else -}}
+{{ template "pulsar.fullname" . }}-{{ .Values.streamnative_console.component }}-acct
+    {{- end -}}
+{{- else -}}
+{{ .Values.streamnative_console.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/sn-platform/templates/streamnative-console/streamnative-console-initialize.yaml
+++ b/charts/sn-platform/templates/streamnative-console/streamnative-console-initialize.yaml
@@ -95,6 +95,9 @@ spec:
             echo "StreamNative Console is ready to use~";
             curl -sf -XPOST http://127.0.0.1:15020/quitquitquit || true;
       restartPolicy: Never
+      {{- if .Values.streamnative_console.serviceAccount.use }}
+      serviceAccountName: {{ template "pulsar.streamnative_console.serviceAccount" . }}
+      {{- end }}
       volumes:
         - name: "{{ template "pulsar.fullname" . }}-{{ .Values.streamnative_console.component }}-init-instance"
           configMap:

--- a/charts/sn-platform/templates/streamnative-console/streamnative-console-service-account.yaml
+++ b/charts/sn-platform/templates/streamnative-console/streamnative-console-service-account.yaml
@@ -30,7 +30,4 @@ metadata:
 {{- with .Values.streamnative_console.serviceAccount.annotations }}
 {{ toYaml . | indent 4 }}
 {{- end }}
-{{- with .Values.streamnative_console.serviceAccount.annotations }}
-{{ toYaml . | indent 4 }}
-{{- end }}
 {{- end }}

--- a/charts/sn-platform/templates/streamnative-console/streamnative-console-service-account.yaml
+++ b/charts/sn-platform/templates/streamnative-console/streamnative-console-service-account.yaml
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+{{- if and .Values.components.streamnative_console .Values.streamnative_console.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "pulsar.streamnative_console.serviceAccount" . }}
+  namespace: {{ template "pulsar.namespace" . }}
+  labels:
+    {{- include "pulsar.standardLabels" . | nindent 4 }}
+    component: {{ .Values.streamnative_console.component }}
+  annotations:
+{{- with .Values.streamnative_console.serviceAccount.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- with .Values.streamnative_console.serviceAccount.annotations }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/sn-platform/templates/streamnative-console/streamnative-console-statefulset.yaml
+++ b/charts/sn-platform/templates/streamnative-console/streamnative-console-statefulset.yaml
@@ -191,11 +191,6 @@ spec:
           - name: streamnative-console-data
             mountPath: /data
 
-          securityContext:
-            capabilities:
-              add:
-              - SETUID
-
       volumes:
       {{- if not (and .Values.volumes.persistence .Values.streamnative_console.volumes.persistence) }}
       - name: streamnative-console-data

--- a/charts/sn-platform/templates/streamnative-console/streamnative-console-statefulset.yaml
+++ b/charts/sn-platform/templates/streamnative-console/streamnative-console-statefulset.yaml
@@ -191,6 +191,11 @@ spec:
           - name: streamnative-console-data
             mountPath: /data
 
+          securityContext:
+            capabilities:
+              add:
+              - SETUID
+
       volumes:
       {{- if not (and .Values.volumes.persistence .Values.streamnative_console.volumes.persistence) }}
       - name: streamnative-console-data
@@ -205,6 +210,9 @@ spec:
       {{- end }}
       {{- if .Values.streamnative_console.securityContext }}
       securityContext: {{- toYaml .Values.streamnative_console.securityContext | nindent 8 }}
+      {{- end }}
+      {{- if .Values.streamnative_console.serviceAccount.use }}
+      serviceAccountName: {{ template "pulsar.streamnative_console.serviceAccount" . }}
       {{- end }}
 
   {{- if or .Values.streamnative_console.volumes.data.storageClass .Values.streamnative_console.volumes.data.storageClassName }}

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1887,7 +1887,7 @@ streamnative_console:
     annotations: {}
     ports:
       frontend: 9527
-      backend: 7750  
+      backend: 7750
 
   serviceAccount:
     # Specifies whether to use a service account to run this component

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1887,7 +1887,20 @@ streamnative_console:
     annotations: {}
     ports:
       frontend: 9527
-      backend: 7750
+      backend: 7750  
+
+  serviceAccount:
+    # Specifies whether to use a service account to run this component
+    use: true
+    # Specifies whether a service account should be created
+    create: true
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    name: ""
+    # Extra annotations for the serviceAccount definition. This can either be
+    # YAML or a YAML-formatted multi-line templated string map of the
+    # annotations to apply to the serviceAccount.
+    annotations: {}
 
   ## cloud console configmap
   ## templates/streamnative-console-configmap.yaml


### PR DESCRIPTION

Fixes https://github.com/streamnative/charts/issues/687

### Motivation

Add a dedicated service account for the console.

### Modifications

Add a dedicated service account for the console.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

