### PR TITLE
[Feat]Add description to crd.

### DIFF
--- a/charts/pulsar-operator/crds/bookkeeper.streamnative.io_bookkeeperclusters.yaml
+++ b/charts/pulsar-operator/crds/bookkeeper.streamnative.io_bookkeeperclusters.yaml
@@ -39,112 +39,187 @@ spec:
       name: v1alpha1
       schema:
         openAPIV3Schema:
+          description: BookKeeperCluster is the Schema for the bookkeeperclusters API
           properties:
             apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
             spec:
+              description: BookKeeperClusterSpec defines the desired state of BookKeeperCluster
               properties:
                 apiObjects:
+                  description: APIObjects allows precise control over how components
+                    (services, statefulset and so on) should be managed
                   properties:
                     autoRecoveryConfigMap:
+                      description: AutoRecoveryConfigMap defines the autoRecovery configmap
+                        resource template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     autoRecoveryHPA:
+                      description: AutoRecoveryHPA defines the horizontalPodAutoscaler
+                        resource template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     autoRecoveryHeadlessService:
+                      description: AutoRecoveryHeadlessService defines the service resource
+                        template for autoRecovery headless service.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     autoRecoveryStatefulSet:
+                      description: AutoRecoveryStatefulSet defines the statefulset resource
+                        template for adopting existing autoRecovery statefulset.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          the name, labels, annotations of the object. More info:
+                          https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                         volumeClaimTemplates:
+                          description: VolumeClaimTemplates is a list of claims that
+                            pods are allowed to reference. If a non-empty list is specified,
+                            the original values in the desired STS will be replaced.
                           items:
+                            description: PersistentVolumeClaim is a user's request for
+                              and claim to a persistent volume
                             properties:
                               apiVersion:
+                                description: 'APIVersion defines the versioned schema
+                                of this representation of an object. Servers should
+                                convert recognized schemas to the latest internal
+                                value, and may reject unrecognized values. More info:
+                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                                 type: string
                               kind:
+                                description: 'Kind is a string value representing the
+                                REST resource this object represents. Servers may
+                                infer this from the endpoint the client submits requests
+                                to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                 type: string
                               metadata:
+                                description: 'Standard object''s metadata. More info:
+                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                                 properties:
                                   annotations:
                                     additionalProperties:
@@ -164,24 +239,55 @@ spec:
                                     type: string
                                 type: object
                               spec:
+                                description: 'Spec defines the desired characteristics
+                                of a volume requested by a pod author. More info:
+                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                 properties:
                                   accessModes:
+                                    description: 'AccessModes contains the desired access
+                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                     items:
                                       type: string
                                     type: array
                                   dataSource:
+                                    description: 'This field can be used to specify
+                                    either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                                    - Beta) * An existing PVC (PersistentVolumeClaim)
+                                    * An existing custom resource/object that implements
+                                    data population (Alpha) In order to use VolumeSnapshot
+                                    object types, the appropriate feature gate must
+                                    be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
+                                    If the provisioner or an external controller can
+                                    support the specified data source, it will create
+                                    a new volume based on the contents of the specified
+                                    data source. If the specified data source is not
+                                    supported, the volume will not be created and
+                                    the failure will be reported as an event. In the
+                                    future, we plan to support more data source types
+                                    and the behavior of the provisioner may change.'
                                     properties:
                                       apiGroup:
+                                        description: APIGroup is the group for the resource
+                                          being referenced. If APIGroup is not specified,
+                                          the specified Kind must be in the core API
+                                          group. For any other third-party types, APIGroup
+                                          is required.
                                         type: string
                                       kind:
+                                        description: Kind is the type of resource being
+                                          referenced
                                         type: string
                                       name:
+                                        description: Name is the name of resource being
+                                          referenced
                                         type: string
                                     required:
                                       - kind
                                       - name
                                     type: object
                                   resources:
+                                    description: 'Resources represents the minimum resources
+                                    the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -190,6 +296,8 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum amount
+                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -198,18 +306,46 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum
+                                        amount of compute resources required. If Requests
+                                        is omitted for a container, it defaults to
+                                        Limits if that is explicitly specified, otherwise
+                                        to an implementation-defined value. More info:
+                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   selector:
+                                    description: A label query over volumes to consider
+                                      for binding.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -221,18 +357,37 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   storageClassName:
+                                    description: 'Name of the StorageClass required
+                                    by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                     type: string
                                   volumeMode:
+                                    description: volumeMode defines what type of volume
+                                      is required by the claim. Value of Filesystem
+                                      is implied when not included in claim spec.
                                     type: string
                                   volumeName:
+                                    description: VolumeName is the binding reference
+                                      to the PersistentVolume backing this claim.
                                     type: string
                                 type: object
                               status:
+                                description: 'Status represents the current information/status
+                                of a persistent volume claim. Read-only. More info:
+                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                 properties:
                                   accessModes:
+                                    description: 'AccessModes contains the actual access
+                                    modes the volume backing the PVC has. More info:
+                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                     items:
                                       type: string
                                     type: array
@@ -243,23 +398,43 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: Represents the actual resources of
+                                      the underlying volume.
                                     type: object
                                   conditions:
+                                    description: Current Condition of persistent volume
+                                      claim. If underlying persistent volume is being
+                                      resized then the Condition will be set to 'ResizeStarted'.
                                     items:
+                                      description: PersistentVolumeClaimCondition contails
+                                        details about state of pvc
                                       properties:
                                         lastProbeTime:
+                                          description: Last time we probed the condition.
                                           format: date-time
                                           type: string
                                         lastTransitionTime:
+                                          description: Last time the condition transitioned
+                                            from one status to another.
                                           format: date-time
                                           type: string
                                         message:
+                                          description: Human-readable message indicating
+                                            details about last transition.
                                           type: string
                                         reason:
+                                          description: Unique, this should be a short,
+                                            machine understandable string that gives
+                                            the reason for condition's last transition.
+                                            If it reports "ResizeStarted" that means
+                                            the underlying persistent volume is being
+                                            resized.
                                           type: string
                                         status:
                                           type: string
                                         type:
+                                          description: PersistentVolumeClaimConditionType
+                                            is a valid value of PersistentVolumeClaimCondition.Type
                                           type: string
                                       required:
                                         - status
@@ -267,24 +442,50 @@ spec:
                                       type: object
                                     type: array
                                   phase:
+                                    description: Phase represents the current phase
+                                      of PersistentVolumeClaim.
                                     type: string
                                 type: object
                             type: object
                           type: array
                         volumeMounts:
+                          description: VolumeMounts is a list of volumes to mount into
+                            the container's filesystem. If a non-empty list is specified,
+                            the original values of the main container in the desired
+                            STS will be replaced.
                           items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
                             properties:
                               mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
                                 type: string
                               mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
                                 type: string
                               name:
+                                description: This must match the Name of a Volume.
                                 type: string
                               readOnly:
+                                description: Mounted read-only if true, read-write otherwise
+                                  (false or unspecified). Defaults to false.
                                 type: boolean
                               subPath:
+                                description: Path within the volume from which the container's
+                                  volume should be mounted. Defaults to "" (volume's
+                                  root).
                                 type: string
                               subPathExpr:
+                                description: Expanded path within the volume from which
+                                  the container's volume should be mounted. Behaves
+                                  similarly to SubPath but environment variable references
+                                  $(VAR_NAME) are expanded using the container's environment.
+                                  Defaults to "" (volume's root). SubPathExpr and SubPath
+                                  are mutually exclusive.
                                 type: string
                             required:
                               - mountPath
@@ -293,34 +494,63 @@ spec:
                           type: array
                       type: object
                     bookieStatefulSet:
+                      description: BookieStatefulSet defines the statefulset resource
+                        template for bookie cluster.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          the name, labels, annotations of the object. More info:
+                          https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                         volumeClaimTemplates:
+                          description: VolumeClaimTemplates is a list of claims that
+                            pods are allowed to reference. If a non-empty list is specified,
+                            the original values in the desired STS will be replaced.
                           items:
+                            description: PersistentVolumeClaim is a user's request for
+                              and claim to a persistent volume
                             properties:
                               apiVersion:
+                                description: 'APIVersion defines the versioned schema
+                                of this representation of an object. Servers should
+                                convert recognized schemas to the latest internal
+                                value, and may reject unrecognized values. More info:
+                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                                 type: string
                               kind:
+                                description: 'Kind is a string value representing the
+                                REST resource this object represents. Servers may
+                                infer this from the endpoint the client submits requests
+                                to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                 type: string
                               metadata:
+                                description: 'Standard object''s metadata. More info:
+                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                                 properties:
                                   annotations:
                                     additionalProperties:
@@ -340,24 +570,55 @@ spec:
                                     type: string
                                 type: object
                               spec:
+                                description: 'Spec defines the desired characteristics
+                                of a volume requested by a pod author. More info:
+                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                 properties:
                                   accessModes:
+                                    description: 'AccessModes contains the desired access
+                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                     items:
                                       type: string
                                     type: array
                                   dataSource:
+                                    description: 'This field can be used to specify
+                                    either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                                    - Beta) * An existing PVC (PersistentVolumeClaim)
+                                    * An existing custom resource/object that implements
+                                    data population (Alpha) In order to use VolumeSnapshot
+                                    object types, the appropriate feature gate must
+                                    be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
+                                    If the provisioner or an external controller can
+                                    support the specified data source, it will create
+                                    a new volume based on the contents of the specified
+                                    data source. If the specified data source is not
+                                    supported, the volume will not be created and
+                                    the failure will be reported as an event. In the
+                                    future, we plan to support more data source types
+                                    and the behavior of the provisioner may change.'
                                     properties:
                                       apiGroup:
+                                        description: APIGroup is the group for the resource
+                                          being referenced. If APIGroup is not specified,
+                                          the specified Kind must be in the core API
+                                          group. For any other third-party types, APIGroup
+                                          is required.
                                         type: string
                                       kind:
+                                        description: Kind is the type of resource being
+                                          referenced
                                         type: string
                                       name:
+                                        description: Name is the name of resource being
+                                          referenced
                                         type: string
                                     required:
                                       - kind
                                       - name
                                     type: object
                                   resources:
+                                    description: 'Resources represents the minimum resources
+                                    the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -366,6 +627,8 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum amount
+                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -374,18 +637,46 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum
+                                        amount of compute resources required. If Requests
+                                        is omitted for a container, it defaults to
+                                        Limits if that is explicitly specified, otherwise
+                                        to an implementation-defined value. More info:
+                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   selector:
+                                    description: A label query over volumes to consider
+                                      for binding.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -397,18 +688,37 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   storageClassName:
+                                    description: 'Name of the StorageClass required
+                                    by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                     type: string
                                   volumeMode:
+                                    description: volumeMode defines what type of volume
+                                      is required by the claim. Value of Filesystem
+                                      is implied when not included in claim spec.
                                     type: string
                                   volumeName:
+                                    description: VolumeName is the binding reference
+                                      to the PersistentVolume backing this claim.
                                     type: string
                                 type: object
                               status:
+                                description: 'Status represents the current information/status
+                                of a persistent volume claim. Read-only. More info:
+                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                 properties:
                                   accessModes:
+                                    description: 'AccessModes contains the actual access
+                                    modes the volume backing the PVC has. More info:
+                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                     items:
                                       type: string
                                     type: array
@@ -419,23 +729,43 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: Represents the actual resources of
+                                      the underlying volume.
                                     type: object
                                   conditions:
+                                    description: Current Condition of persistent volume
+                                      claim. If underlying persistent volume is being
+                                      resized then the Condition will be set to 'ResizeStarted'.
                                     items:
+                                      description: PersistentVolumeClaimCondition contails
+                                        details about state of pvc
                                       properties:
                                         lastProbeTime:
+                                          description: Last time we probed the condition.
                                           format: date-time
                                           type: string
                                         lastTransitionTime:
+                                          description: Last time the condition transitioned
+                                            from one status to another.
                                           format: date-time
                                           type: string
                                         message:
+                                          description: Human-readable message indicating
+                                            details about last transition.
                                           type: string
                                         reason:
+                                          description: Unique, this should be a short,
+                                            machine understandable string that gives
+                                            the reason for condition's last transition.
+                                            If it reports "ResizeStarted" that means
+                                            the underlying persistent volume is being
+                                            resized.
                                           type: string
                                         status:
                                           type: string
                                         type:
+                                          description: PersistentVolumeClaimConditionType
+                                            is a valid value of PersistentVolumeClaimCondition.Type
                                           type: string
                                       required:
                                         - status
@@ -443,24 +773,50 @@ spec:
                                       type: object
                                     type: array
                                   phase:
+                                    description: Phase represents the current phase
+                                      of PersistentVolumeClaim.
                                     type: string
                                 type: object
                             type: object
                           type: array
                         volumeMounts:
+                          description: VolumeMounts is a list of volumes to mount into
+                            the container's filesystem. If a non-empty list is specified,
+                            the original values of the main container in the desired
+                            STS will be replaced.
                           items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
                             properties:
                               mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
                                 type: string
                               mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
                                 type: string
                               name:
+                                description: This must match the Name of a Volume.
                                 type: string
                               readOnly:
+                                description: Mounted read-only if true, read-write otherwise
+                                  (false or unspecified). Defaults to false.
                                 type: boolean
                               subPath:
+                                description: Path within the volume from which the container's
+                                  volume should be mounted. Defaults to "" (volume's
+                                  root).
                                 type: string
                               subPathExpr:
+                                description: Expanded path within the volume from which
+                                  the container's volume should be mounted. Behaves
+                                  similarly to SubPath but environment variable references
+                                  $(VAR_NAME) are expanded using the container's environment.
+                                  Defaults to "" (volume's root). SubPathExpr and SubPath
+                                  are mutually exclusive.
                                 type: string
                             required:
                               - mountPath
@@ -469,133 +825,218 @@ spec:
                           type: array
                       type: object
                     clientService:
+                      description: ClientService defines the Bookkeeper Client Service
+                        resource template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     configMap:
+                      description: ConfigMap defines the configmap resource template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     headlessService:
+                      description: HeadlessService defines the Bookkeeper Headless Service
+                        resource template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     hpa:
+                      description: HPA defines the horizontalPodAutoscaler resource
+                        template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     pdb:
+                      description: PDB defines the podDisruptionBudget resource template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                   type: object
                 autoRecovery:
+                  description: AutoRecovery defines configurations of auto recovery
                   properties:
                     autoScalingPolicy:
+                      description: AutoScalingPolicy defines how BookKeeperCluster will
+                        be scaled up/down with given metrics and threshold
                       properties:
                         behavior:
+                          description: Behavior configures the scaling behavior of the
+                            target in both Up and Down directions (scaleUp and scaleDown
+                            fields respectively). If not set, the default HPAScalingRules
+                            for scale up and scale down are used.
                           properties:
                             scaleDown:
+                              description: scaleDown is scaling policy for scaling Down.
+                                If not set, the default value is to allow to scale down
+                                to minReplicas pods, with a 300 second stabilization
+                                window (i.e., the highest recommendation for the last
+                                300sec is used).
                               properties:
                                 policies:
+                                  description: policies is a list of potential scaling
+                                    polices which can be used during scaling. At least
+                                    one policy must be specified, otherwise the HPAScalingRules
+                                    will be discarded as invalid
                                   items:
+                                    description: HPAScalingPolicy is a single policy
+                                      which must hold true for a specified past interval.
                                     properties:
                                       periodSeconds:
+                                        description: PeriodSeconds specifies the window
+                                          of time for which the policy should hold true.
+                                          PeriodSeconds must be greater than zero and
+                                          less than or equal to 1800 (30 min).
                                         format: int32
                                         type: integer
                                       type:
+                                        description: Type is used to specify the scaling
+                                          policy.
                                         type: string
                                       value:
+                                        description: Value contains the amount of change
+                                          which is permitted by the policy. It must
+                                          be greater than zero
                                         format: int32
                                         type: integer
                                     required:
@@ -605,22 +1046,54 @@ spec:
                                     type: object
                                   type: array
                                 selectPolicy:
+                                  description: selectPolicy is used to specify which
+                                    policy should be used. If not set, the default value
+                                    MaxPolicySelect is used.
                                   type: string
                                 stabilizationWindowSeconds:
+                                  description: 'StabilizationWindowSeconds is the number
+                                  of seconds for which past recommendations should
+                                  be considered while scaling up or scaling down.
+                                  StabilizationWindowSeconds must be greater than
+                                  or equal to zero and less than or equal to 3600
+                                  (one hour). If not set, use the default values:
+                                  - For scale up: 0 (i.e. no stabilization is done).
+                                  - For scale down: 300 (i.e. the stabilization window
+                                  is 300 seconds long).'
                                   format: int32
                                   type: integer
                               type: object
                             scaleUp:
+                              description: 'scaleUp is scaling policy for scaling Up.
+                              If not set, the default value is the higher of:   *
+                              increase no more than 4 pods per 60 seconds   * double
+                              the number of pods per 60 seconds No stabilization is
+                              used.'
                               properties:
                                 policies:
+                                  description: policies is a list of potential scaling
+                                    polices which can be used during scaling. At least
+                                    one policy must be specified, otherwise the HPAScalingRules
+                                    will be discarded as invalid
                                   items:
+                                    description: HPAScalingPolicy is a single policy
+                                      which must hold true for a specified past interval.
                                     properties:
                                       periodSeconds:
+                                        description: PeriodSeconds specifies the window
+                                          of time for which the policy should hold true.
+                                          PeriodSeconds must be greater than zero and
+                                          less than or equal to 1800 (30 min).
                                         format: int32
                                         type: integer
                                       type:
+                                        description: Type is used to specify the scaling
+                                          policy.
                                         type: string
                                       value:
+                                        description: Value contains the amount of change
+                                          which is permitted by the policy. It must
+                                          be greater than zero
                                         format: int32
                                         type: integer
                                     required:
@@ -630,8 +1103,20 @@ spec:
                                     type: object
                                   type: array
                                 selectPolicy:
+                                  description: selectPolicy is used to specify which
+                                    policy should be used. If not set, the default value
+                                    MaxPolicySelect is used.
                                   type: string
                                 stabilizationWindowSeconds:
+                                  description: 'StabilizationWindowSeconds is the number
+                                  of seconds for which past recommendations should
+                                  be considered while scaling up or scaling down.
+                                  StabilizationWindowSeconds must be greater than
+                                  or equal to zero and less than or equal to 3600
+                                  (one hour). If not set, use the default values:
+                                  - For scale up: 0 (i.e. no stabilization is done).
+                                  - For scale down: 300 (i.e. the stabilization window
+                                  is 300 seconds long).'
                                   format: int32
                                   type: integer
                               type: object
@@ -640,24 +1125,68 @@ spec:
                           format: int32
                           type: integer
                         metrics:
+                          description: 'Metrics contains the specifications for which
+                          to use to calculate the desired replica count (the maximum
+                          replica count across all metrics will be used). More info:
+                          https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling'
                           items:
+                            description: MetricSpec specifies how to scale based on
+                              a single metric (only `type` and one other matching field
+                              should be set at once).
                             properties:
                               external:
+                                description: external refers to a global metric that
+                                  is not associated with any Kubernetes object. It allows
+                                  autoscaling based on information coming from components
+                                  running outside of cluster (for example length of
+                                  queue in cloud messaging service, or QPS from loadbalancer
+                                  running outside of cluster).
                                 properties:
                                   metric:
+                                    description: metric identifies the target metric
+                                      by name and selector
                                     properties:
                                       name:
+                                        description: name is the name of the given metric
                                         type: string
                                       selector:
+                                        description: selector is the string-encoded
+                                          form of a standard kubernetes label selector
+                                          for the given metric When set, it is passed
+                                          as an additional parameter to the metrics
+                                          server for more specific metrics scoping.
+                                          When unset, just the metricName will be used
+                                          to gather metrics.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -669,28 +1198,49 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                     required:
                                       - name
                                     type: object
                                   target:
+                                    description: target specifies the target value for
+                                      the given metric
                                     properties:
                                       averageUtilization:
+                                        description: averageUtilization is the target
+                                          value of the average of the resource metric
+                                          across all relevant pods, represented as a
+                                          percentage of the requested value of the resource
+                                          for the pods. Currently only valid for Resource
+                                          metric source type
                                         format: int32
                                         type: integer
                                       averageValue:
                                         anyOf:
                                           - type: integer
                                           - type: string
+                                        description: averageValue is the target value
+                                          of the average of the metric across all relevant
+                                          pods (as a quantity)
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       type:
+                                        description: type represents whether the metric
+                                          type is Utilization, Value, or AverageValue
                                         type: string
                                       value:
                                         anyOf:
                                           - type: integer
                                           - type: string
+                                        description: value is the target value of the
+                                          metric (as a quantity).
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     required:
@@ -701,33 +1251,75 @@ spec:
                                   - target
                                 type: object
                               object:
+                                description: object refers to a metric describing a
+                                  single kubernetes object (for example, hits-per-second
+                                  on an Ingress object).
                                 properties:
                                   describedObject:
+                                    description: CrossVersionObjectReference contains
+                                      enough information to let you identify the referred
+                                      resource.
                                     properties:
                                       apiVersion:
+                                        description: API version of the referent
                                         type: string
                                       kind:
+                                        description: 'Kind of the referent; More info:
+                                        https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
                                         type: string
                                       name:
+                                        description: 'Name of the referent; More info:
+                                        http://kubernetes.io/docs/user-guide/identifiers#names'
                                         type: string
                                     required:
                                       - kind
                                       - name
                                     type: object
                                   metric:
+                                    description: metric identifies the target metric
+                                      by name and selector
                                     properties:
                                       name:
+                                        description: name is the name of the given metric
                                         type: string
                                       selector:
+                                        description: selector is the string-encoded
+                                          form of a standard kubernetes label selector
+                                          for the given metric When set, it is passed
+                                          as an additional parameter to the metrics
+                                          server for more specific metrics scoping.
+                                          When unset, just the metricName will be used
+                                          to gather metrics.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -739,28 +1331,49 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                     required:
                                       - name
                                     type: object
                                   target:
+                                    description: target specifies the target value for
+                                      the given metric
                                     properties:
                                       averageUtilization:
+                                        description: averageUtilization is the target
+                                          value of the average of the resource metric
+                                          across all relevant pods, represented as a
+                                          percentage of the requested value of the resource
+                                          for the pods. Currently only valid for Resource
+                                          metric source type
                                         format: int32
                                         type: integer
                                       averageValue:
                                         anyOf:
                                           - type: integer
                                           - type: string
+                                        description: averageValue is the target value
+                                          of the average of the metric across all relevant
+                                          pods (as a quantity)
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       type:
+                                        description: type represents whether the metric
+                                          type is Utilization, Value, or AverageValue
                                         type: string
                                       value:
                                         anyOf:
                                           - type: integer
                                           - type: string
+                                        description: value is the target value of the
+                                          metric (as a quantity).
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     required:
@@ -772,21 +1385,56 @@ spec:
                                   - target
                                 type: object
                               pods:
+                                description: pods refers to a metric describing each
+                                  pod in the current scale target (for example, transactions-processed-per-second).  The
+                                  values will be averaged together before being compared
+                                  to the target value.
                                 properties:
                                   metric:
+                                    description: metric identifies the target metric
+                                      by name and selector
                                     properties:
                                       name:
+                                        description: name is the name of the given metric
                                         type: string
                                       selector:
+                                        description: selector is the string-encoded
+                                          form of a standard kubernetes label selector
+                                          for the given metric When set, it is passed
+                                          as an additional parameter to the metrics
+                                          server for more specific metrics scoping.
+                                          When unset, just the metricName will be used
+                                          to gather metrics.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -798,28 +1446,49 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                     required:
                                       - name
                                     type: object
                                   target:
+                                    description: target specifies the target value for
+                                      the given metric
                                     properties:
                                       averageUtilization:
+                                        description: averageUtilization is the target
+                                          value of the average of the resource metric
+                                          across all relevant pods, represented as a
+                                          percentage of the requested value of the resource
+                                          for the pods. Currently only valid for Resource
+                                          metric source type
                                         format: int32
                                         type: integer
                                       averageValue:
                                         anyOf:
                                           - type: integer
                                           - type: string
+                                        description: averageValue is the target value
+                                          of the average of the metric across all relevant
+                                          pods (as a quantity)
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       type:
+                                        description: type represents whether the metric
+                                          type is Utilization, Value, or AverageValue
                                         type: string
                                       value:
                                         anyOf:
                                           - type: integer
                                           - type: string
+                                        description: value is the target value of the
+                                          metric (as a quantity).
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     required:
@@ -830,26 +1499,50 @@ spec:
                                   - target
                                 type: object
                               resource:
+                                description: resource refers to a resource metric (such
+                                  as those specified in requests and limits) known to
+                                  Kubernetes describing each pod in the current scale
+                                  target (e.g. CPU or memory). Such metrics are built
+                                  in to Kubernetes, and have special scaling options
+                                  on top of those available to normal per-pod metrics
+                                  using the "pods" source.
                                 properties:
                                   name:
+                                    description: name is the name of the resource in
+                                      question.
                                     type: string
                                   target:
+                                    description: target specifies the target value for
+                                      the given metric
                                     properties:
                                       averageUtilization:
+                                        description: averageUtilization is the target
+                                          value of the average of the resource metric
+                                          across all relevant pods, represented as a
+                                          percentage of the requested value of the resource
+                                          for the pods. Currently only valid for Resource
+                                          metric source type
                                         format: int32
                                         type: integer
                                       averageValue:
                                         anyOf:
                                           - type: integer
                                           - type: string
+                                        description: averageValue is the target value
+                                          of the average of the metric across all relevant
+                                          pods (as a quantity)
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       type:
+                                        description: type represents whether the metric
+                                          type is Utilization, Value, or AverageValue
                                         type: string
                                       value:
                                         anyOf:
                                           - type: integer
                                           - type: string
+                                        description: value is the target value of the
+                                          metric (as a quantity).
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     required:
@@ -860,6 +1553,9 @@ spec:
                                   - target
                                 type: object
                               type:
+                                description: type is the type of metric source.  It
+                                  should be one of "Object", "Pods" or "Resource", each
+                                  mapping to a matching field in the object.
                                 type: string
                             required:
                               - type
@@ -874,26 +1570,74 @@ spec:
                     conf:
                       additionalProperties:
                         type: string
+                      description: Conf defines the configuration of auto recovery bookies
+                      nullable: true
                       type: object
                     pod:
+                      description: Pod defines the policy for creating an auto recovery
+                        pod for the cluster
                       properties:
                         affinity:
+                          description: Affinity specifies the scheduling constraints
+                            of a pod
                           properties:
                             nodeAffinity:
+                              description: Describes node affinity scheduling rules
+                                for the pod.
                               properties:
                                 preferredDuringSchedulingIgnoredDuringExecution:
+                                  description: The scheduler will prefer to schedule
+                                    pods to nodes that satisfy the affinity expressions
+                                    specified by this field, but it may choose a node
+                                    that violates one or more of the expressions. The
+                                    node that is most preferred is the one with the
+                                    greatest sum of weights, i.e. for each node that
+                                    meets all of the scheduling requirements (resource
+                                    request, requiredDuringScheduling affinity expressions,
+                                    etc.), compute a sum by iterating through the elements
+                                    of this field and adding "weight" to the sum if
+                                    the node matches the corresponding matchExpressions;
+                                    the node(s) with the highest sum are the most preferred.
                                   items:
+                                    description: An empty preferred scheduling term
+                                      matches all objects with implicit weight 0 (i.e.
+                                      it's a no-op). A null preferred scheduling term
+                                      matches no objects (i.e. is also a no-op).
                                     properties:
                                       preference:
+                                        description: A node selector term, associated
+                                          with the corresponding weight.
                                         properties:
                                           matchExpressions:
+                                            description: A list of node selector requirements
+                                              by node's labels.
                                             items:
+                                              description: A node selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: The label key that the
+                                                    selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: Represents a key's relationship
+                                                    to a set of values. Valid operators
+                                                    are In, NotIn, Exists, DoesNotExist.
+                                                    Gt, and Lt.
                                                   type: string
                                                 values:
+                                                  description: An array of string values.
+                                                    If the operator is In or NotIn,
+                                                    the values array must be non-empty.
+                                                    If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty.
+                                                    If the operator is Gt or Lt, the
+                                                    values array must have a single
+                                                    element, which will be interpreted
+                                                    as an integer. This array is replaced
+                                                    during a strategic merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -903,13 +1647,35 @@ spec:
                                               type: object
                                             type: array
                                           matchFields:
+                                            description: A list of node selector requirements
+                                              by node's fields.
                                             items:
+                                              description: A node selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: The label key that the
+                                                    selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: Represents a key's relationship
+                                                    to a set of values. Valid operators
+                                                    are In, NotIn, Exists, DoesNotExist.
+                                                    Gt, and Lt.
                                                   type: string
                                                 values:
+                                                  description: An array of string values.
+                                                    If the operator is In or NotIn,
+                                                    the values array must be non-empty.
+                                                    If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty.
+                                                    If the operator is Gt or Lt, the
+                                                    values array must have a single
+                                                    element, which will be interpreted
+                                                    as an integer. This array is replaced
+                                                    during a strategic merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -920,6 +1686,9 @@ spec:
                                             type: array
                                         type: object
                                       weight:
+                                        description: Weight associated with matching
+                                          the corresponding nodeSelectorTerm, in the
+                                          range 1-100.
                                         format: int32
                                         type: integer
                                     required:
@@ -928,18 +1697,53 @@ spec:
                                     type: object
                                   type: array
                                 requiredDuringSchedulingIgnoredDuringExecution:
+                                  description: If the affinity requirements specified
+                                    by this field are not met at scheduling time, the
+                                    pod will not be scheduled onto the node. If the
+                                    affinity requirements specified by this field cease
+                                    to be met at some point during pod execution (e.g.
+                                    due to an update), the system may or may not try
+                                    to eventually evict the pod from its node.
                                   properties:
                                     nodeSelectorTerms:
+                                      description: Required. A list of node selector
+                                        terms. The terms are ORed.
                                       items:
+                                        description: A null or empty node selector term
+                                          matches no objects. The requirements of them
+                                          are ANDed. The TopologySelectorTerm type implements
+                                          a subset of the NodeSelectorTerm.
                                         properties:
                                           matchExpressions:
+                                            description: A list of node selector requirements
+                                              by node's labels.
                                             items:
+                                              description: A node selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: The label key that the
+                                                    selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: Represents a key's relationship
+                                                    to a set of values. Valid operators
+                                                    are In, NotIn, Exists, DoesNotExist.
+                                                    Gt, and Lt.
                                                   type: string
                                                 values:
+                                                  description: An array of string values.
+                                                    If the operator is In or NotIn,
+                                                    the values array must be non-empty.
+                                                    If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty.
+                                                    If the operator is Gt or Lt, the
+                                                    values array must have a single
+                                                    element, which will be interpreted
+                                                    as an integer. This array is replaced
+                                                    during a strategic merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -949,13 +1753,35 @@ spec:
                                               type: object
                                             type: array
                                           matchFields:
+                                            description: A list of node selector requirements
+                                              by node's fields.
                                             items:
+                                              description: A node selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: The label key that the
+                                                    selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: Represents a key's relationship
+                                                    to a set of values. Valid operators
+                                                    are In, NotIn, Exists, DoesNotExist.
+                                                    Gt, and Lt.
                                                   type: string
                                                 values:
+                                                  description: An array of string values.
+                                                    If the operator is In or NotIn,
+                                                    the values array must be non-empty.
+                                                    If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty.
+                                                    If the operator is Gt or Lt, the
+                                                    values array must have a single
+                                                    element, which will be interpreted
+                                                    as an integer. This array is replaced
+                                                    during a strategic merge patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -971,22 +1797,67 @@ spec:
                                   type: object
                               type: object
                             podAffinity:
+                              description: Describes pod affinity scheduling rules (e.g.
+                                co-locate this pod in the same node, zone, etc. as some
+                                other pod(s)).
                               properties:
                                 preferredDuringSchedulingIgnoredDuringExecution:
+                                  description: The scheduler will prefer to schedule
+                                    pods to nodes that satisfy the affinity expressions
+                                    specified by this field, but it may choose a node
+                                    that violates one or more of the expressions. The
+                                    node that is most preferred is the one with the
+                                    greatest sum of weights, i.e. for each node that
+                                    meets all of the scheduling requirements (resource
+                                    request, requiredDuringScheduling affinity expressions,
+                                    etc.), compute a sum by iterating through the elements
+                                    of this field and adding "weight" to the sum if
+                                    the node has pods which matches the corresponding
+                                    podAffinityTerm; the node(s) with the highest sum
+                                    are the most preferred.
                                   items:
+                                    description: The weights of all of the matched WeightedPodAffinityTerm
+                                      fields are added per-node to find the most preferred
+                                      node(s)
                                     properties:
                                       podAffinityTerm:
+                                        description: Required. A pod affinity term,
+                                          associated with the corresponding weight.
                                         properties:
                                           labelSelector:
+                                            description: A label query over a set of
+                                              resources, in this case pods.
                                             properties:
                                               matchExpressions:
+                                                description: matchExpressions is a list
+                                                  of label selector requirements. The
+                                                  requirements are ANDed.
                                                 items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
                                                   properties:
                                                     key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
                                                       type: string
                                                     operator:
+                                                      description: operator represents
+                                                        a key's relationship to a set
+                                                        of values. Valid operators are
+                                                        In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values array
+                                                        must be non-empty. If the operator
+                                                        is Exists or DoesNotExist, the
+                                                        values array must be empty.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -998,18 +1869,42 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
+                                                description: matchLabels is a map of
+                                                  {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
                                                 type: object
                                             type: object
                                           namespaces:
+                                            description: namespaces specifies which
+                                              namespaces the labelSelector applies to
+                                              (matches against); null or empty list
+                                              means "this pod's namespace"
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
+                                            description: This pod should be co-located
+                                              (affinity) or not co-located (anti-affinity)
+                                              with the pods matching the labelSelector
+                                              in the specified namespaces, where co-located
+                                              is defined as running on a node whose
+                                              value of the label with key topologyKey
+                                              matches that of any node on which any
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
                                             type: string
                                         required:
                                           - topologyKey
                                         type: object
                                       weight:
+                                        description: weight associated with matching
+                                          the corresponding podAffinityTerm, in the
+                                          range 1-100.
                                         format: int32
                                         type: integer
                                     required:
@@ -1018,18 +1913,59 @@ spec:
                                     type: object
                                   type: array
                                 requiredDuringSchedulingIgnoredDuringExecution:
+                                  description: If the affinity requirements specified
+                                    by this field are not met at scheduling time, the
+                                    pod will not be scheduled onto the node. If the
+                                    affinity requirements specified by this field cease
+                                    to be met at some point during pod execution (e.g.
+                                    due to a pod label update), the system may or may
+                                    not try to eventually evict the pod from its node.
+                                    When there are multiple elements, the lists of nodes
+                                    corresponding to each podAffinityTerm are intersected,
+                                    i.e. all terms must be satisfied.
                                   items:
+                                    description: Defines a set of pods (namely those
+                                      matching the labelSelector relative to the given
+                                      namespace(s)) that this pod should be co-located
+                                      (affinity) or not co-located (anti-affinity) with,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key <topologyKey>
+                                      matches that of any node on which a pod of the
+                                      set of pods is running
                                     properties:
                                       labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1041,13 +1977,30 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the
+                                          pods matching the labelSelector in the specified
+                                          namespaces, where co-located is defined as
+                                          running on a node whose value of the label
+                                          with key topologyKey matches that of any node
+                                          on which any of the selected pods is running.
+                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
@@ -1055,22 +2008,67 @@ spec:
                                   type: array
                               type: object
                             podAntiAffinity:
+                              description: Describes pod anti-affinity scheduling rules
+                                (e.g. avoid putting this pod in the same node, zone,
+                                etc. as some other pod(s)).
                               properties:
                                 preferredDuringSchedulingIgnoredDuringExecution:
+                                  description: The scheduler will prefer to schedule
+                                    pods to nodes that satisfy the anti-affinity expressions
+                                    specified by this field, but it may choose a node
+                                    that violates one or more of the expressions. The
+                                    node that is most preferred is the one with the
+                                    greatest sum of weights, i.e. for each node that
+                                    meets all of the scheduling requirements (resource
+                                    request, requiredDuringScheduling anti-affinity
+                                    expressions, etc.), compute a sum by iterating through
+                                    the elements of this field and adding "weight" to
+                                    the sum if the node has pods which matches the corresponding
+                                    podAffinityTerm; the node(s) with the highest sum
+                                    are the most preferred.
                                   items:
+                                    description: The weights of all of the matched WeightedPodAffinityTerm
+                                      fields are added per-node to find the most preferred
+                                      node(s)
                                     properties:
                                       podAffinityTerm:
+                                        description: Required. A pod affinity term,
+                                          associated with the corresponding weight.
                                         properties:
                                           labelSelector:
+                                            description: A label query over a set of
+                                              resources, in this case pods.
                                             properties:
                                               matchExpressions:
+                                                description: matchExpressions is a list
+                                                  of label selector requirements. The
+                                                  requirements are ANDed.
                                                 items:
+                                                  description: A label selector requirement
+                                                    is a selector that contains values,
+                                                    a key, and an operator that relates
+                                                    the key and values.
                                                   properties:
                                                     key:
+                                                      description: key is the label
+                                                        key that the selector applies
+                                                        to.
                                                       type: string
                                                     operator:
+                                                      description: operator represents
+                                                        a key's relationship to a set
+                                                        of values. Valid operators are
+                                                        In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
+                                                      description: values is an array
+                                                        of string values. If the operator
+                                                        is In or NotIn, the values array
+                                                        must be non-empty. If the operator
+                                                        is Exists or DoesNotExist, the
+                                                        values array must be empty.
+                                                        This array is replaced during
+                                                        a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -1082,18 +2080,42 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
+                                                description: matchLabels is a map of
+                                                  {key,value} pairs. A single {key,value}
+                                                  in the matchLabels map is equivalent
+                                                  to an element of matchExpressions,
+                                                  whose key field is "key", the operator
+                                                  is "In", and the values array contains
+                                                  only "value". The requirements are
+                                                  ANDed.
                                                 type: object
                                             type: object
                                           namespaces:
+                                            description: namespaces specifies which
+                                              namespaces the labelSelector applies to
+                                              (matches against); null or empty list
+                                              means "this pod's namespace"
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
+                                            description: This pod should be co-located
+                                              (affinity) or not co-located (anti-affinity)
+                                              with the pods matching the labelSelector
+                                              in the specified namespaces, where co-located
+                                              is defined as running on a node whose
+                                              value of the label with key topologyKey
+                                              matches that of any node on which any
+                                              of the selected pods is running. Empty
+                                              topologyKey is not allowed.
                                             type: string
                                         required:
                                           - topologyKey
                                         type: object
                                       weight:
+                                        description: weight associated with matching
+                                          the corresponding podAffinityTerm, in the
+                                          range 1-100.
                                         format: int32
                                         type: integer
                                     required:
@@ -1102,18 +2124,59 @@ spec:
                                     type: object
                                   type: array
                                 requiredDuringSchedulingIgnoredDuringExecution:
+                                  description: If the anti-affinity requirements specified
+                                    by this field are not met at scheduling time, the
+                                    pod will not be scheduled onto the node. If the
+                                    anti-affinity requirements specified by this field
+                                    cease to be met at some point during pod execution
+                                    (e.g. due to a pod label update), the system may
+                                    or may not try to eventually evict the pod from
+                                    its node. When there are multiple elements, the
+                                    lists of nodes corresponding to each podAffinityTerm
+                                    are intersected, i.e. all terms must be satisfied.
                                   items:
+                                    description: Defines a set of pods (namely those
+                                      matching the labelSelector relative to the given
+                                      namespace(s)) that this pod should be co-located
+                                      (affinity) or not co-located (anti-affinity) with,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key <topologyKey>
+                                      matches that of any node on which a pod of the
+                                      set of pods is running
                                     properties:
                                       labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1125,13 +2188,30 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the
+                                          pods matching the labelSelector in the specified
+                                          namespaces, where co-located is defined as
+                                          running on a node whose value of the label
+                                          with key topologyKey matches that of any node
+                                          on which any of the selected pods is running.
+                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
@@ -1142,78 +2222,156 @@ spec:
                         annotations:
                           additionalProperties:
                             type: string
+                          description: Annotations specifies the annotations to attach
+                            to pods the operator creates
                           type: object
                         debug:
+                          description: Debug defines a switch enable debug
                           type: boolean
                         imagePullSecrets:
+                          description: ImagePullSecrets is an optional list of references
+                            to secrets in the same namespace to use for pulling any
+                            of the images used by this PodSpec.
                           items:
+                            description: LocalObjectReference contains enough information
+                              to let you locate the referenced object inside the same
+                              namespace.
                             properties:
                               name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                             type: object
                           type: array
                         initContainers:
+                          description: InitContainers defines init containers of the
+                            pod. A typical use case could be using an init container
+                            to download a remote jar to a local path.
                           items:
+                            description: A single application container that you want
+                              to run within a pod. The Container API from the core group
+                              is not used directly to avoid unneeded fields and reduce
+                              the size of the CRD. New fields could be added as needed.
                             properties:
                               args:
+                                description: Arguments to the entrypoint.
                                 items:
                                   type: string
                                 type: array
                               command:
+                                description: Entrypoint array. Not executed within a
+                                  shell.
                                 items:
                                   type: string
                                 type: array
                               env:
+                                description: List of environment variables to set in
+                                  the container.
                                 items:
+                                  description: EnvVar represents an environment variable
+                                    present in a Container.
                                   properties:
                                     name:
+                                      description: Name of the environment variable.
+                                        Must be a C_IDENTIFIER.
                                       type: string
                                     value:
+                                      description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previous defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Defaults to "".'
                                       type: string
                                     valueFrom:
+                                      description: Source for the environment variable's
+                                        value. Cannot be used if value is not empty.
                                       properties:
                                         configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
                                           properties:
                                             key:
+                                              description: The key to select.
                                               type: string
                                             name:
+                                              description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
                                               type: string
                                             optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
                                               type: boolean
                                           required:
                                             - key
                                           type: object
                                         fieldRef:
+                                          description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                          spec.nodeName, spec.serviceAccountName,
+                                          status.hostIP, status.podIP, status.podIPs.'
                                           properties:
                                             apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of, defaults
+                                                to "v1".
                                               type: string
                                             fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
                                               type: string
                                           required:
                                             - fieldPath
                                           type: object
                                         resourceFieldRef:
+                                          description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
                                           properties:
                                             containerName:
+                                              description: 'Container name: required
+                                              for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                                 - type: integer
                                                 - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults to
+                                                "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
+                                              description: 'Required: resource to select'
                                               type: string
                                           required:
                                             - resource
                                           type: object
                                         secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
                                           properties:
                                             key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
                                               type: string
                                             name:
+                                              description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
                                               type: string
                                             optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
                                               type: boolean
                                           required:
                                             - key
@@ -1224,52 +2382,100 @@ spec:
                                   type: object
                                 type: array
                               envFrom:
+                                description: List of sources to populate environment
+                                  variables in the container.
                                 items:
+                                  description: EnvFromSource represents the source of
+                                    a set of ConfigMaps
                                   properties:
                                     configMapRef:
+                                      description: The ConfigMap to select from
                                       properties:
                                         name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            must be defined
                                           type: boolean
                                       type: object
                                     prefix:
+                                      description: An optional identifier to prepend
+                                        to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                       type: string
                                     secretRef:
+                                      description: The Secret to select from
                                       properties:
                                         name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret must
+                                            be defined
                                           type: boolean
                                       type: object
                                   type: object
                                 type: array
                               image:
+                                description: Docker image name.
                                 type: string
                               imagePullPolicy:
+                                description: Image pull policy.
                                 type: string
                               livenessProbe:
+                                description: Periodic probe of container liveness.
                                 properties:
                                   exec:
+                                    description: One and only one of the following should
+                                      be specified. Exec specifies the action to take.
                                     properties:
                                       command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/') in
+                                          the container's filesystem. The command is
+                                          simply exec'd, it is not run inside a shell,
+                                          so traditional shell instructions ('|', etc)
+                                          won't work. To use a shell, you need to explicitly
+                                          call out to that shell. Exit status of 0 is
+                                          treated as live/healthy and non-zero is unhealthy.
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   failureThreshold:
+                                    description: Minimum consecutive failures for the
+                                      probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
                                     properties:
                                       host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set "Host"
+                                          in httpHeaders instead.
                                         type: string
                                       httpHeaders:
+                                        description: Custom headers to set in the request.
+                                          HTTP allows repeated headers.
                                         items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
                                           properties:
                                             name:
+                                              description: The header field name
                                               type: string
                                             value:
+                                              description: The header field value
                                               type: string
                                           required:
                                             - name
@@ -1277,66 +2483,122 @@ spec:
                                           type: object
                                         type: array
                                       path:
+                                        description: Path to access on the HTTP server.
                                         type: string
                                       port:
                                         anyOf:
                                           - type: integer
                                           - type: string
+                                        description: Name or number of the port to access
+                                          on the container. Number must be in the range
+                                          1 to 65535. Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                       scheme:
+                                        description: Scheme to use for connecting to
+                                          the host. Defaults to HTTP.
                                         type: string
                                     required:
                                       - port
                                     type: object
                                   initialDelaySeconds:
+                                    description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     format: int32
                                     type: integer
                                   periodSeconds:
+                                    description: How often (in seconds) to perform the
+                                      probe. Default to 10 seconds. Minimum value is
+                                      1.
                                     format: int32
                                     type: integer
                                   successThreshold:
+                                    description: Minimum consecutive successes for the
+                                      probe to be considered successful after having
+                                      failed. Defaults to 1. Must be 1 for liveness
+                                      and startup. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   tcpSocket:
+                                    description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
                                     properties:
                                       host:
+                                        description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
                                         type: string
                                       port:
                                         anyOf:
                                           - type: integer
                                           - type: string
+                                        description: Number or name of the port to access
+                                          on the container. Number must be in the range
+                                          1 to 65535. Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                     required:
                                       - port
                                     type: object
                                   timeoutSeconds:
+                                    description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     format: int32
                                     type: integer
                                 type: object
                               name:
+                                description: Name of the container specified as a DNS_LABEL.
+                                  Each container in a pod must have a unique name (DNS_LABEL).
                                 type: string
                               readinessProbe:
+                                description: 'Periodic probe of container service readiness.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 properties:
                                   exec:
+                                    description: One and only one of the following should
+                                      be specified. Exec specifies the action to take.
                                     properties:
                                       command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/') in
+                                          the container's filesystem. The command is
+                                          simply exec'd, it is not run inside a shell,
+                                          so traditional shell instructions ('|', etc)
+                                          won't work. To use a shell, you need to explicitly
+                                          call out to that shell. Exit status of 0 is
+                                          treated as live/healthy and non-zero is unhealthy.
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   failureThreshold:
+                                    description: Minimum consecutive failures for the
+                                      probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
                                     properties:
                                       host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set "Host"
+                                          in httpHeaders instead.
                                         type: string
                                       httpHeaders:
+                                        description: Custom headers to set in the request.
+                                          HTTP allows repeated headers.
                                         items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
                                           properties:
                                             name:
+                                              description: The header field name
                                               type: string
                                             value:
+                                              description: The header field value
                                               type: string
                                           required:
                                             - name
@@ -1344,43 +2606,71 @@ spec:
                                           type: object
                                         type: array
                                       path:
+                                        description: Path to access on the HTTP server.
                                         type: string
                                       port:
                                         anyOf:
                                           - type: integer
                                           - type: string
+                                        description: Name or number of the port to access
+                                          on the container. Number must be in the range
+                                          1 to 65535. Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                       scheme:
+                                        description: Scheme to use for connecting to
+                                          the host. Defaults to HTTP.
                                         type: string
                                     required:
                                       - port
                                     type: object
                                   initialDelaySeconds:
+                                    description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     format: int32
                                     type: integer
                                   periodSeconds:
+                                    description: How often (in seconds) to perform the
+                                      probe. Default to 10 seconds. Minimum value is
+                                      1.
                                     format: int32
                                     type: integer
                                   successThreshold:
+                                    description: Minimum consecutive successes for the
+                                      probe to be considered successful after having
+                                      failed. Defaults to 1. Must be 1 for liveness
+                                      and startup. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   tcpSocket:
+                                    description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
                                     properties:
                                       host:
+                                        description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
                                         type: string
                                       port:
                                         anyOf:
                                           - type: integer
                                           - type: string
+                                        description: Number or name of the port to access
+                                          on the container. Number must be in the range
+                                          1 to 65535. Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                     required:
                                       - port
                                     type: object
                                   timeoutSeconds:
+                                    description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     format: int32
                                     type: integer
                                 type: object
                               resources:
+                                description: Compute Resources required by this container.
                                 properties:
                                   limits:
                                     additionalProperties:
@@ -1389,6 +2679,8 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                     type: object
                                   requests:
                                     additionalProperties:
@@ -1397,30 +2689,62 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                     type: object
                                 type: object
                               startupProbe:
+                                description: StartupProbe indicates that the Pod has
+                                  successfully initialized.
                                 properties:
                                   exec:
+                                    description: One and only one of the following should
+                                      be specified. Exec specifies the action to take.
                                     properties:
                                       command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/') in
+                                          the container's filesystem. The command is
+                                          simply exec'd, it is not run inside a shell,
+                                          so traditional shell instructions ('|', etc)
+                                          won't work. To use a shell, you need to explicitly
+                                          call out to that shell. Exit status of 0 is
+                                          treated as live/healthy and non-zero is unhealthy.
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   failureThreshold:
+                                    description: Minimum consecutive failures for the
+                                      probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
                                     properties:
                                       host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set "Host"
+                                          in httpHeaders instead.
                                         type: string
                                       httpHeaders:
+                                        description: Custom headers to set in the request.
+                                          HTTP allows repeated headers.
                                         items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
                                           properties:
                                             name:
+                                              description: The header field name
                                               type: string
                                             value:
+                                              description: The header field value
                                               type: string
                                           required:
                                             - name
@@ -1428,56 +2752,108 @@ spec:
                                           type: object
                                         type: array
                                       path:
+                                        description: Path to access on the HTTP server.
                                         type: string
                                       port:
                                         anyOf:
                                           - type: integer
                                           - type: string
+                                        description: Name or number of the port to access
+                                          on the container. Number must be in the range
+                                          1 to 65535. Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                       scheme:
+                                        description: Scheme to use for connecting to
+                                          the host. Defaults to HTTP.
                                         type: string
                                     required:
                                       - port
                                     type: object
                                   initialDelaySeconds:
+                                    description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     format: int32
                                     type: integer
                                   periodSeconds:
+                                    description: How often (in seconds) to perform the
+                                      probe. Default to 10 seconds. Minimum value is
+                                      1.
                                     format: int32
                                     type: integer
                                   successThreshold:
+                                    description: Minimum consecutive successes for the
+                                      probe to be considered successful after having
+                                      failed. Defaults to 1. Must be 1 for liveness
+                                      and startup. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   tcpSocket:
+                                    description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
                                     properties:
                                       host:
+                                        description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
                                         type: string
                                       port:
                                         anyOf:
                                           - type: integer
                                           - type: string
+                                        description: Number or name of the port to access
+                                          on the container. Number must be in the range
+                                          1 to 65535. Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                     required:
                                       - port
                                     type: object
                                   timeoutSeconds:
+                                    description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     format: int32
                                     type: integer
                                 type: object
                               volumeMounts:
+                                description: Pod volumes to mount into the container's
+                                  filesystem.
                                 items:
+                                  description: VolumeMount describes a mounting of a
+                                    Volume within a container.
                                   properties:
                                     mountPath:
+                                      description: Path within the container at which
+                                        the volume should be mounted.  Must not contain
+                                        ':'.
                                       type: string
                                     mountPropagation:
+                                      description: mountPropagation determines how mounts
+                                        are propagated from the host to container and
+                                        the other way around. When not set, MountPropagationNone
+                                        is used. This field is beta in 1.10.
                                       type: string
                                     name:
+                                      description: This must match the Name of a Volume.
                                       type: string
                                     readOnly:
+                                      description: Mounted read-only if true, read-write
+                                        otherwise (false or unspecified). Defaults to
+                                        false.
                                       type: boolean
                                     subPath:
+                                      description: Path within the volume from which
+                                        the container's volume should be mounted. Defaults
+                                        to "" (volume's root).
                                       type: string
                                     subPathExpr:
+                                      description: Expanded path within the volume from
+                                        which the container's volume should be mounted.
+                                        Behaves similarly to SubPath but environment
+                                        variable references $(VAR_NAME) are expanded
+                                        using the container's environment. Defaults
+                                        to "" (volume's root). SubPathExpr and SubPath
+                                        are mutually exclusive.
                                       type: string
                                   required:
                                     - mountPath
@@ -1485,39 +2861,53 @@ spec:
                                   type: object
                                 type: array
                               workingDir:
+                                description: Container's working directory.
                                 type: string
                             required:
                               - name
                             type: object
                           type: array
                         jvmOptions:
+                          description: JvmOptions defines the Jvm options passed to
+                            the proxy
                           properties:
                             extraOptions:
                               items:
                                 type: string
+                              nullable: true
                               type: array
                             gcLoggingOptions:
                               items:
                                 type: string
+                              nullable: true
                               type: array
                             gcOptions:
                               items:
                                 type: string
+                              nullable: true
                               type: array
                             memoryOptions:
                               items:
                                 type: string
+                              nullable: true
                               type: array
                           type: object
                         labels:
                           additionalProperties:
                             type: string
+                          description: Labels specifies the labels to attach to pod
+                            the operator creates for the cluster.
                           type: object
                         nodeSelector:
                           additionalProperties:
                             type: string
+                          description: NodeSelector specifies a map of key-value pairs.
+                            For a pod to be eligible to run on a node, the node must
+                            have each of the indicated key-value pairs as labels.
                           type: object
                         resources:
+                          description: Resources specifies the resource requirements
+                            of containers to run in the pod
                           properties:
                             limits:
                               additionalProperties:
@@ -1526,6 +2916,8 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                               type: object
                             requests:
                               additionalProperties:
@@ -1534,9 +2926,16 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                               type: object
                           type: object
                         secretRefs:
+                          description: SecretRefs defines how to mount required secrets
+                            into containers
                           items:
                             properties:
                               mountPath:
@@ -1549,51 +2948,128 @@ spec:
                             type: object
                           type: array
                         securityContext:
+                          description: 'SecurityContext specifies the security context
+                          for the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
                           properties:
                             fsGroup:
+                              description: "A special supplemental group that applies
+                              to all containers in a pod. Some volume types allow
+                              the Kubelet to change the ownership of that volume to
+                              be owned by the pod: \n 1. The owning GID will be the
+                              FSGroup 2. The setgid bit is set (new files created
+                              in the volume will be owned by FSGroup) 3. The permission
+                              bits are OR'd with rw-rw---- \n If unset, the Kubelet
+                              will not modify the ownership and permissions of any
+                              volume."
                               format: int64
                               type: integer
                             fsGroupChangePolicy:
+                              description: 'fsGroupChangePolicy defines behavior of
+                              changing ownership and permission of the volume before
+                              being exposed inside Pod. This field will only apply
+                              to volume types which support fsGroup based ownership(and
+                              permissions). It will have no effect on ephemeral volume
+                              types such as: secret, configmaps and emptydir. Valid
+                              values are "OnRootMismatch" and "Always". If not specified
+                              defaults to "Always".'
                               type: string
                             runAsGroup:
+                              description: The GID to run the entrypoint of the container
+                                process. Uses runtime default if unset. May also be
+                                set in SecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence for that container.
                               format: int64
                               type: integer
                             runAsNonRoot:
+                              description: Indicates that the container must run as
+                                a non-root user. If true, the Kubelet will validate
+                                the image at runtime to ensure that it does not run
+                                as UID 0 (root) and fail to start the container if it
+                                does. If unset or false, no such validation will be
+                                performed. May also be set in SecurityContext.  If set
+                                in both SecurityContext and PodSecurityContext, the
+                                value specified in SecurityContext takes precedence.
                               type: boolean
                             runAsUser:
+                              description: The UID to run the entrypoint of the container
+                                process. Defaults to user specified in image metadata
+                                if unspecified. May also be set in SecurityContext.  If
+                                set in both SecurityContext and PodSecurityContext,
+                                the value specified in SecurityContext takes precedence
+                                for that container.
                               format: int64
                               type: integer
                             seLinuxOptions:
+                              description: The SELinux context to be applied to all
+                                containers. If unspecified, the container runtime will
+                                allocate a random SELinux context for each container.  May
+                                also be set in SecurityContext.  If set in both SecurityContext
+                                and PodSecurityContext, the value specified in SecurityContext
+                                takes precedence for that container.
                               properties:
                                 level:
+                                  description: Level is SELinux level label that applies
+                                    to the container.
                                   type: string
                                 role:
+                                  description: Role is a SELinux role label that applies
+                                    to the container.
                                   type: string
                                 type:
+                                  description: Type is a SELinux type label that applies
+                                    to the container.
                                   type: string
                                 user:
+                                  description: User is a SELinux user label that applies
+                                    to the container.
                                   type: string
                               type: object
                             seccompProfile:
+                              description: The seccomp options to use by the containers
+                                in this pod.
                               properties:
                                 localhostProfile:
+                                  description: localhostProfile indicates a profile
+                                    defined in a file on the node should be used. The
+                                    profile must be preconfigured on the node to work.
+                                    Must be a descending path, relative to the kubelet's
+                                    configured seccomp profile location. Must only be
+                                    set if type is "Localhost".
                                   type: string
                                 type:
+                                  description: "type indicates which kind of seccomp
+                                  profile will be applied. Valid options are: \n Localhost
+                                  - a profile defined in a file on the node should
+                                  be used. RuntimeDefault - the container runtime
+                                  default profile should be used. Unconfined - no
+                                  profile should be applied."
                                   type: string
                               required:
                                 - type
                               type: object
                             supplementalGroups:
+                              description: A list of groups applied to the first process
+                                run in each container, in addition to the container's
+                                primary GID.  If unspecified, no groups will be added
+                                to any container.
                               items:
                                 format: int64
                                 type: integer
                               type: array
                             sysctls:
+                              description: Sysctls hold a list of namespaced sysctls
+                                used for the pod. Pods with unsupported sysctls (by
+                                the container runtime) might fail to launch.
                               items:
+                                description: Sysctl defines a kernel parameter to be
+                                  set
                                 properties:
                                   name:
+                                    description: Name of a property to set
                                     type: string
                                   value:
+                                    description: Value of a property to set
                                     type: string
                                 required:
                                   - name
@@ -1601,79 +3077,164 @@ spec:
                                 type: object
                               type: array
                             windowsOptions:
+                              description: The Windows specific settings applied to
+                                all containers. If unspecified, the options within a
+                                container's SecurityContext will be used. If set in
+                                both SecurityContext and PodSecurityContext, the value
+                                specified in SecurityContext takes precedence.
                               properties:
                                 gmsaCredentialSpec:
+                                  description: GMSACredentialSpec is where the GMSA
+                                    admission webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                    inlines the contents of the GMSA credential spec
+                                    named by the GMSACredentialSpecName field.
                                   type: string
                                 gmsaCredentialSpecName:
+                                  description: GMSACredentialSpecName is the name of
+                                    the GMSA credential spec to use.
                                   type: string
                                 runAsUserName:
+                                  description: The UserName in Windows to run the entrypoint
+                                    of the container process. Defaults to the user specified
+                                    in image metadata if unspecified. May also be set
+                                    in PodSecurityContext. If set in both SecurityContext
+                                    and PodSecurityContext, the value specified in SecurityContext
+                                    takes precedence.
                                   type: string
                               type: object
                           type: object
                         serviceAccountName:
+                          description: ServiceAccountName is the name of the ServiceAccount
+                            to use to run pods.
                           type: string
                         sidecars:
+                          description: Sidecars defines sidecar containers running alongside
+                            with the main function container in the pod.
                           items:
+                            description: A single application container that you want
+                              to run within a pod. The Container API from the core group
+                              is not used directly to avoid unneeded fields and reduce
+                              the size of the CRD. New fields could be added as needed.
                             properties:
                               args:
+                                description: Arguments to the entrypoint.
                                 items:
                                   type: string
                                 type: array
                               command:
+                                description: Entrypoint array. Not executed within a
+                                  shell.
                                 items:
                                   type: string
                                 type: array
                               env:
+                                description: List of environment variables to set in
+                                  the container.
                                 items:
+                                  description: EnvVar represents an environment variable
+                                    present in a Container.
                                   properties:
                                     name:
+                                      description: Name of the environment variable.
+                                        Must be a C_IDENTIFIER.
                                       type: string
                                     value:
+                                      description: 'Variable references $(VAR_NAME)
+                                      are expanded using the previous defined environment
+                                      variables in the container and any service environment
+                                      variables. If a variable cannot be resolved,
+                                      the reference in the input string will be unchanged.
+                                      The $(VAR_NAME) syntax can be escaped with a
+                                      double $$, ie: $$(VAR_NAME). Escaped references
+                                      will never be expanded, regardless of whether
+                                      the variable exists or not. Defaults to "".'
                                       type: string
                                     valueFrom:
+                                      description: Source for the environment variable's
+                                        value. Cannot be used if value is not empty.
                                       properties:
                                         configMapKeyRef:
+                                          description: Selects a key of a ConfigMap.
                                           properties:
                                             key:
+                                              description: The key to select.
                                               type: string
                                             name:
+                                              description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
                                               type: string
                                             optional:
+                                              description: Specify whether the ConfigMap
+                                                or its key must be defined
                                               type: boolean
                                           required:
                                             - key
                                           type: object
                                         fieldRef:
+                                          description: 'Selects a field of the pod:
+                                          supports metadata.name, metadata.namespace,
+                                          `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
+                                          spec.nodeName, spec.serviceAccountName,
+                                          status.hostIP, status.podIP, status.podIPs.'
                                           properties:
                                             apiVersion:
+                                              description: Version of the schema the
+                                                FieldPath is written in terms of, defaults
+                                                to "v1".
                                               type: string
                                             fieldPath:
+                                              description: Path of the field to select
+                                                in the specified API version.
                                               type: string
                                           required:
                                             - fieldPath
                                           type: object
                                         resourceFieldRef:
+                                          description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, limits.ephemeral-storage,
+                                          requests.cpu, requests.memory and requests.ephemeral-storage)
+                                          are currently supported.'
                                           properties:
                                             containerName:
+                                              description: 'Container name: required
+                                              for volumes, optional for env vars'
                                               type: string
                                             divisor:
                                               anyOf:
                                                 - type: integer
                                                 - type: string
+                                              description: Specifies the output format
+                                                of the exposed resources, defaults to
+                                                "1"
                                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                               x-kubernetes-int-or-string: true
                                             resource:
+                                              description: 'Required: resource to select'
                                               type: string
                                           required:
                                             - resource
                                           type: object
                                         secretKeyRef:
+                                          description: Selects a key of a secret in
+                                            the pod's namespace
                                           properties:
                                             key:
+                                              description: The key of the secret to
+                                                select from.  Must be a valid secret
+                                                key.
                                               type: string
                                             name:
+                                              description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
                                               type: string
                                             optional:
+                                              description: Specify whether the Secret
+                                                or its key must be defined
                                               type: boolean
                                           required:
                                             - key
@@ -1684,52 +3245,100 @@ spec:
                                   type: object
                                 type: array
                               envFrom:
+                                description: List of sources to populate environment
+                                  variables in the container.
                                 items:
+                                  description: EnvFromSource represents the source of
+                                    a set of ConfigMaps
                                   properties:
                                     configMapRef:
+                                      description: The ConfigMap to select from
                                       properties:
                                         name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            must be defined
                                           type: boolean
                                       type: object
                                     prefix:
+                                      description: An optional identifier to prepend
+                                        to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                       type: string
                                     secretRef:
+                                      description: The Secret to select from
                                       properties:
                                         name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret must
+                                            be defined
                                           type: boolean
                                       type: object
                                   type: object
                                 type: array
                               image:
+                                description: Docker image name.
                                 type: string
                               imagePullPolicy:
+                                description: Image pull policy.
                                 type: string
                               livenessProbe:
+                                description: Periodic probe of container liveness.
                                 properties:
                                   exec:
+                                    description: One and only one of the following should
+                                      be specified. Exec specifies the action to take.
                                     properties:
                                       command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/') in
+                                          the container's filesystem. The command is
+                                          simply exec'd, it is not run inside a shell,
+                                          so traditional shell instructions ('|', etc)
+                                          won't work. To use a shell, you need to explicitly
+                                          call out to that shell. Exit status of 0 is
+                                          treated as live/healthy and non-zero is unhealthy.
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   failureThreshold:
+                                    description: Minimum consecutive failures for the
+                                      probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
                                     properties:
                                       host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set "Host"
+                                          in httpHeaders instead.
                                         type: string
                                       httpHeaders:
+                                        description: Custom headers to set in the request.
+                                          HTTP allows repeated headers.
                                         items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
                                           properties:
                                             name:
+                                              description: The header field name
                                               type: string
                                             value:
+                                              description: The header field value
                                               type: string
                                           required:
                                             - name
@@ -1737,66 +3346,122 @@ spec:
                                           type: object
                                         type: array
                                       path:
+                                        description: Path to access on the HTTP server.
                                         type: string
                                       port:
                                         anyOf:
                                           - type: integer
                                           - type: string
+                                        description: Name or number of the port to access
+                                          on the container. Number must be in the range
+                                          1 to 65535. Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                       scheme:
+                                        description: Scheme to use for connecting to
+                                          the host. Defaults to HTTP.
                                         type: string
                                     required:
                                       - port
                                     type: object
                                   initialDelaySeconds:
+                                    description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     format: int32
                                     type: integer
                                   periodSeconds:
+                                    description: How often (in seconds) to perform the
+                                      probe. Default to 10 seconds. Minimum value is
+                                      1.
                                     format: int32
                                     type: integer
                                   successThreshold:
+                                    description: Minimum consecutive successes for the
+                                      probe to be considered successful after having
+                                      failed. Defaults to 1. Must be 1 for liveness
+                                      and startup. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   tcpSocket:
+                                    description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
                                     properties:
                                       host:
+                                        description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
                                         type: string
                                       port:
                                         anyOf:
                                           - type: integer
                                           - type: string
+                                        description: Number or name of the port to access
+                                          on the container. Number must be in the range
+                                          1 to 65535. Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                     required:
                                       - port
                                     type: object
                                   timeoutSeconds:
+                                    description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     format: int32
                                     type: integer
                                 type: object
                               name:
+                                description: Name of the container specified as a DNS_LABEL.
+                                  Each container in a pod must have a unique name (DNS_LABEL).
                                 type: string
                               readinessProbe:
+                                description: 'Periodic probe of container service readiness.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 properties:
                                   exec:
+                                    description: One and only one of the following should
+                                      be specified. Exec specifies the action to take.
                                     properties:
                                       command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/') in
+                                          the container's filesystem. The command is
+                                          simply exec'd, it is not run inside a shell,
+                                          so traditional shell instructions ('|', etc)
+                                          won't work. To use a shell, you need to explicitly
+                                          call out to that shell. Exit status of 0 is
+                                          treated as live/healthy and non-zero is unhealthy.
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   failureThreshold:
+                                    description: Minimum consecutive failures for the
+                                      probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
                                     properties:
                                       host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set "Host"
+                                          in httpHeaders instead.
                                         type: string
                                       httpHeaders:
+                                        description: Custom headers to set in the request.
+                                          HTTP allows repeated headers.
                                         items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
                                           properties:
                                             name:
+                                              description: The header field name
                                               type: string
                                             value:
+                                              description: The header field value
                                               type: string
                                           required:
                                             - name
@@ -1804,43 +3469,71 @@ spec:
                                           type: object
                                         type: array
                                       path:
+                                        description: Path to access on the HTTP server.
                                         type: string
                                       port:
                                         anyOf:
                                           - type: integer
                                           - type: string
+                                        description: Name or number of the port to access
+                                          on the container. Number must be in the range
+                                          1 to 65535. Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                       scheme:
+                                        description: Scheme to use for connecting to
+                                          the host. Defaults to HTTP.
                                         type: string
                                     required:
                                       - port
                                     type: object
                                   initialDelaySeconds:
+                                    description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     format: int32
                                     type: integer
                                   periodSeconds:
+                                    description: How often (in seconds) to perform the
+                                      probe. Default to 10 seconds. Minimum value is
+                                      1.
                                     format: int32
                                     type: integer
                                   successThreshold:
+                                    description: Minimum consecutive successes for the
+                                      probe to be considered successful after having
+                                      failed. Defaults to 1. Must be 1 for liveness
+                                      and startup. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   tcpSocket:
+                                    description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
                                     properties:
                                       host:
+                                        description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
                                         type: string
                                       port:
                                         anyOf:
                                           - type: integer
                                           - type: string
+                                        description: Number or name of the port to access
+                                          on the container. Number must be in the range
+                                          1 to 65535. Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                     required:
                                       - port
                                     type: object
                                   timeoutSeconds:
+                                    description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     format: int32
                                     type: integer
                                 type: object
                               resources:
+                                description: Compute Resources required by this container.
                                 properties:
                                   limits:
                                     additionalProperties:
@@ -1849,6 +3542,8 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                     type: object
                                   requests:
                                     additionalProperties:
@@ -1857,30 +3552,62 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                     type: object
                                 type: object
                               startupProbe:
+                                description: StartupProbe indicates that the Pod has
+                                  successfully initialized.
                                 properties:
                                   exec:
+                                    description: One and only one of the following should
+                                      be specified. Exec specifies the action to take.
                                     properties:
                                       command:
+                                        description: Command is the command line to
+                                          execute inside the container, the working
+                                          directory for the command  is root ('/') in
+                                          the container's filesystem. The command is
+                                          simply exec'd, it is not run inside a shell,
+                                          so traditional shell instructions ('|', etc)
+                                          won't work. To use a shell, you need to explicitly
+                                          call out to that shell. Exit status of 0 is
+                                          treated as live/healthy and non-zero is unhealthy.
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   failureThreshold:
+                                    description: Minimum consecutive failures for the
+                                      probe to be considered failed after having succeeded.
+                                      Defaults to 3. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   httpGet:
+                                    description: HTTPGet specifies the http request
+                                      to perform.
                                     properties:
                                       host:
+                                        description: Host name to connect to, defaults
+                                          to the pod IP. You probably want to set "Host"
+                                          in httpHeaders instead.
                                         type: string
                                       httpHeaders:
+                                        description: Custom headers to set in the request.
+                                          HTTP allows repeated headers.
                                         items:
+                                          description: HTTPHeader describes a custom
+                                            header to be used in HTTP probes
                                           properties:
                                             name:
+                                              description: The header field name
                                               type: string
                                             value:
+                                              description: The header field value
                                               type: string
                                           required:
                                             - name
@@ -1888,56 +3615,108 @@ spec:
                                           type: object
                                         type: array
                                       path:
+                                        description: Path to access on the HTTP server.
                                         type: string
                                       port:
                                         anyOf:
                                           - type: integer
                                           - type: string
+                                        description: Name or number of the port to access
+                                          on the container. Number must be in the range
+                                          1 to 65535. Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                       scheme:
+                                        description: Scheme to use for connecting to
+                                          the host. Defaults to HTTP.
                                         type: string
                                     required:
                                       - port
                                     type: object
                                   initialDelaySeconds:
+                                    description: 'Number of seconds after the container
+                                    has started before liveness probes are initiated.
+                                    More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     format: int32
                                     type: integer
                                   periodSeconds:
+                                    description: How often (in seconds) to perform the
+                                      probe. Default to 10 seconds. Minimum value is
+                                      1.
                                     format: int32
                                     type: integer
                                   successThreshold:
+                                    description: Minimum consecutive successes for the
+                                      probe to be considered successful after having
+                                      failed. Defaults to 1. Must be 1 for liveness
+                                      and startup. Minimum value is 1.
                                     format: int32
                                     type: integer
                                   tcpSocket:
+                                    description: 'TCPSocket specifies an action involving
+                                    a TCP port. TCP hooks not yet supported TODO:
+                                    implement a realistic TCP lifecycle hook'
                                     properties:
                                       host:
+                                        description: 'Optional: Host name to connect
+                                        to, defaults to the pod IP.'
                                         type: string
                                       port:
                                         anyOf:
                                           - type: integer
                                           - type: string
+                                        description: Number or name of the port to access
+                                          on the container. Number must be in the range
+                                          1 to 65535. Name must be an IANA_SVC_NAME.
                                         x-kubernetes-int-or-string: true
                                     required:
                                       - port
                                     type: object
                                   timeoutSeconds:
+                                    description: 'Number of seconds after which the
+                                    probe times out. Defaults to 1 second. Minimum
+                                    value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     format: int32
                                     type: integer
                                 type: object
                               volumeMounts:
+                                description: Pod volumes to mount into the container's
+                                  filesystem.
                                 items:
+                                  description: VolumeMount describes a mounting of a
+                                    Volume within a container.
                                   properties:
                                     mountPath:
+                                      description: Path within the container at which
+                                        the volume should be mounted.  Must not contain
+                                        ':'.
                                       type: string
                                     mountPropagation:
+                                      description: mountPropagation determines how mounts
+                                        are propagated from the host to container and
+                                        the other way around. When not set, MountPropagationNone
+                                        is used. This field is beta in 1.10.
                                       type: string
                                     name:
+                                      description: This must match the Name of a Volume.
                                       type: string
                                     readOnly:
+                                      description: Mounted read-only if true, read-write
+                                        otherwise (false or unspecified). Defaults to
+                                        false.
                                       type: boolean
                                     subPath:
+                                      description: Path within the volume from which
+                                        the container's volume should be mounted. Defaults
+                                        to "" (volume's root).
                                       type: string
                                     subPathExpr:
+                                      description: Expanded path within the volume from
+                                        which the container's volume should be mounted.
+                                        Behaves similarly to SubPath but environment
+                                        variable references $(VAR_NAME) are expanded
+                                        using the container's environment. Defaults
+                                        to "" (volume's root). SubPathExpr and SubPath
+                                        are mutually exclusive.
                                       type: string
                                   required:
                                     - mountPath
@@ -1945,81 +3724,165 @@ spec:
                                   type: object
                                 type: array
                               workingDir:
+                                description: Container's working directory.
                                 type: string
                             required:
                               - name
                             type: object
                           type: array
                         terminationGracePeriodSeconds:
+                          description: TerminationGracePeriodSeconds is the amount of
+                            time that kubernetes will give for a pod before terminating
+                            it.
                           format: int64
                           type: integer
                         tolerations:
+                          description: Tolerations specifies the tolerations of a Pod
                           items:
+                            description: The pod this Toleration is attached to tolerates
+                              any taint that matches the triple <key,value,effect> using
+                              the matching operator <operator>.
                             properties:
                               effect:
+                                description: Effect indicates the taint effect to match.
+                                  Empty means match all taint effects. When specified,
+                                  allowed values are NoSchedule, PreferNoSchedule and
+                                  NoExecute.
                                 type: string
                               key:
+                                description: Key is the taint key that the toleration
+                                  applies to. Empty means match all taint keys. If the
+                                  key is empty, operator must be Exists; this combination
+                                  means to match all values and all keys.
                                 type: string
                               operator:
+                                description: Operator represents a key's relationship
+                                  to the value. Valid operators are Exists and Equal.
+                                  Defaults to Equal. Exists is equivalent to wildcard
+                                  for value, so that a pod can tolerate all taints of
+                                  a particular category.
                                 type: string
                               tolerationSeconds:
+                                description: TolerationSeconds represents the period
+                                  of time the toleration (which must be of effect NoExecute,
+                                  otherwise this field is ignored) tolerates the taint.
+                                  By default, it is not set, which means tolerate the
+                                  taint forever (do not evict). Zero and negative values
+                                  will be treated as 0 (evict immediately) by the system.
                                 format: int64
                                 type: integer
                               value:
+                                description: Value is the taint value the toleration
+                                  matches to. If the operator is Exists, the value should
+                                  be empty, otherwise just a regular string.
                                 type: string
                             type: object
                           type: array
                         vars:
+                          description: Vars specifies the environment variables of a
+                            Pod
                           items:
+                            description: EnvVar represents an environment variable present
+                              in a Container.
                             properties:
                               name:
+                                description: Name of the environment variable. Must
+                                  be a C_IDENTIFIER.
                                 type: string
                               value:
+                                description: 'Variable references $(VAR_NAME) are expanded
+                                using the previous defined environment variables in
+                                the container and any service environment variables.
+                                If a variable cannot be resolved, the reference in
+                                the input string will be unchanged. The $(VAR_NAME)
+                                syntax can be escaped with a double $$, ie: $$(VAR_NAME).
+                                Escaped references will never be expanded, regardless
+                                of whether the variable exists or not. Defaults to
+                                "".'
                                 type: string
                               valueFrom:
+                                description: Source for the environment variable's value.
+                                  Cannot be used if value is not empty.
                                 properties:
                                   configMapKeyRef:
+                                    description: Selects a key of a ConfigMap.
                                     properties:
                                       key:
+                                        description: The key to select.
                                         type: string
                                       name:
+                                        description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
                                         type: string
                                       optional:
+                                        description: Specify whether the ConfigMap or
+                                          its key must be defined
                                         type: boolean
                                     required:
                                       - key
                                     type: object
                                   fieldRef:
+                                    description: 'Selects a field of the pod: supports
+                                    metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                    `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                    spec.serviceAccountName, status.hostIP, status.podIP,
+                                    status.podIPs.'
                                     properties:
                                       apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
                                         type: string
                                       fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
                                         type: string
                                     required:
                                       - fieldPath
                                     type: object
                                   resourceFieldRef:
+                                    description: 'Selects a resource of the container:
+                                    only resources limits and requests (limits.cpu,
+                                    limits.memory, limits.ephemeral-storage, requests.cpu,
+                                    requests.memory and requests.ephemeral-storage)
+                                    are currently supported.'
                                     properties:
                                       containerName:
+                                        description: 'Container name: required for volumes,
+                                        optional for env vars'
                                         type: string
                                       divisor:
                                         anyOf:
                                           - type: integer
                                           - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                       resource:
+                                        description: 'Required: resource to select'
                                         type: string
                                     required:
                                       - resource
                                     type: object
                                   secretKeyRef:
+                                    description: Selects a key of a secret in the pod's
+                                      namespace
                                     properties:
                                       key:
+                                        description: The key of the secret to select
+                                          from.  Must be a valid secret key.
                                         type: string
                                       name:
+                                        description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
                                         type: string
                                       optional:
+                                        description: Specify whether the Secret or its
+                                          key must be defined
                                         type: boolean
                                     required:
                                       - key
@@ -2030,22 +3893,69 @@ spec:
                             type: object
                           type: array
                         volumes:
+                          description: Volumes defines extra volumes of the pod.
                           items:
+                            description: Volume represents a named volume in a pod that
+                              may be accessed by any container in the pod. The Volume
+                              API from the core group is not used directly to avoid
+                              unneeded fields defined in `VolumeSource` and reduce the
+                              size of the CRD. New fields in VolumeSource could be added
+                              as needed.
                             properties:
                               configMap:
+                                description: ConfigMap represents a configMap that should
+                                  populate this volume
                                 properties:
                                   defaultMode:
+                                    description: 'Optional: mode bits used to set permissions
+                                    on created files by default. Must be an octal
+                                    value between 0000 and 0777 or a decimal value
+                                    between 0 and 511. YAML accepts both octal and
+                                    decimal values, JSON requires decimal values for
+                                    mode bits. Defaults to 0644. Directories within
+                                    the path are not affected by this setting. This
+                                    might be in conflict with other options that affect
+                                    the file mode, like fsGroup, and the result can
+                                    be other mode bits set.'
                                     format: int32
                                     type: integer
                                   items:
+                                    description: If unspecified, each key-value pair
+                                      in the Data field of the referenced ConfigMap
+                                      will be projected into the volume as a file whose
+                                      name is the key and content is the value. If specified,
+                                      the listed keys will be projected into the specified
+                                      paths, and unlisted keys will not be present.
+                                      If a key is specified which is not present in
+                                      the ConfigMap, the volume setup will error unless
+                                      it is marked optional. Paths must be relative
+                                      and may not contain the '..' path or start with
+                                      '..'.
                                     items:
+                                      description: Maps a string key to a path within
+                                        a volume.
                                       properties:
                                         key:
+                                          description: The key to project.
                                           type: string
                                         mode:
+                                          description: 'Optional: mode bits used to
+                                          set permissions on this file. Must be an
+                                          octal value between 0000 and 0777 or a decimal
+                                          value between 0 and 511. YAML accepts both
+                                          octal and decimal values, JSON requires
+                                          decimal values for mode bits. If not specified,
+                                          the volume defaultMode will be used. This
+                                          might be in conflict with other options
+                                          that affect the file mode, like fsGroup,
+                                          and the result can be other mode bits set.'
                                           format: int32
                                           type: integer
                                         path:
+                                          description: The relative path of the file
+                                            to map the key to. May not be an absolute
+                                            path. May not contain the path element '..'.
+                                            May not start with the string '..'.
                                           type: string
                                       required:
                                         - key
@@ -2053,26 +3963,73 @@ spec:
                                       type: object
                                     type: array
                                   name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                     type: string
                                   optional:
+                                    description: Specify whether the ConfigMap or its
+                                      keys must be defined
                                     type: boolean
                                 type: object
                               name:
+                                description: 'Volume''s name. Must be a DNS_LABEL and
+                                unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                 type: string
                               secret:
+                                description: Secret represents a secret that should
+                                  populate this volume.
                                 properties:
                                   defaultMode:
+                                    description: 'Optional: mode bits used to set permissions
+                                    on created files by default. Must be an octal
+                                    value between 0000 and 0777 or a decimal value
+                                    between 0 and 511. YAML accepts both octal and
+                                    decimal values, JSON requires decimal values for
+                                    mode bits. Defaults to 0644. Directories within
+                                    the path are not affected by this setting. This
+                                    might be in conflict with other options that affect
+                                    the file mode, like fsGroup, and the result can
+                                    be other mode bits set.'
                                     format: int32
                                     type: integer
                                   items:
+                                    description: If unspecified, each key-value pair
+                                      in the Data field of the referenced Secret will
+                                      be projected into the volume as a file whose name
+                                      is the key and content is the value. If specified,
+                                      the listed keys will be projected into the specified
+                                      paths, and unlisted keys will not be present.
+                                      If a key is specified which is not present in
+                                      the Secret, the volume setup will error unless
+                                      it is marked optional. Paths must be relative
+                                      and may not contain the '..' path or start with
+                                      '..'.
                                     items:
+                                      description: Maps a string key to a path within
+                                        a volume.
                                       properties:
                                         key:
+                                          description: The key to project.
                                           type: string
                                         mode:
+                                          description: 'Optional: mode bits used to
+                                          set permissions on this file. Must be an
+                                          octal value between 0000 and 0777 or a decimal
+                                          value between 0 and 511. YAML accepts both
+                                          octal and decimal values, JSON requires
+                                          decimal values for mode bits. If not specified,
+                                          the volume defaultMode will be used. This
+                                          might be in conflict with other options
+                                          that affect the file mode, like fsGroup,
+                                          and the result can be other mode bits set.'
                                           format: int32
                                           type: integer
                                         path:
+                                          description: The relative path of the file
+                                            to map the key to. May not be an absolute
+                                            path. May not contain the path element '..'.
+                                            May not start with the string '..'.
                                           type: string
                                       required:
                                         - key
@@ -2080,8 +4037,12 @@ spec:
                                       type: object
                                     type: array
                                   optional:
+                                    description: Specify whether the Secret or its keys
+                                      must be defined
                                     type: boolean
                                   secretName:
+                                    description: 'Name of the secret in the pod''s namespace
+                                    to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     type: string
                                 type: object
                             required:
@@ -2090,25 +4051,54 @@ spec:
                           type: array
                       type: object
                     replicas:
+                      description: Replicas defines the number of replicas of auto recovery
+                        bookies, defaults to 1, a value less or equal to 0 implies auto
+                        recovery is disabled for the cluster
                       format: int32
                       minimum: 0
                       type: integer
                   type: object
                 autoScalingPolicy:
+                  description: AutoScalingPolicy defines how Bookie will be scaled up/down
+                    with given metrics and threshold
                   properties:
                     behavior:
+                      description: Behavior configures the scaling behavior of the target
+                        in both Up and Down directions (scaleUp and scaleDown fields
+                        respectively). If not set, the default HPAScalingRules for scale
+                        up and scale down are used.
                       properties:
                         scaleDown:
+                          description: scaleDown is scaling policy for scaling Down.
+                            If not set, the default value is to allow to scale down
+                            to minReplicas pods, with a 300 second stabilization window
+                            (i.e., the highest recommendation for the last 300sec is
+                            used).
                           properties:
                             policies:
+                              description: policies is a list of potential scaling polices
+                                which can be used during scaling. At least one policy
+                                must be specified, otherwise the HPAScalingRules will
+                                be discarded as invalid
                               items:
+                                description: HPAScalingPolicy is a single policy which
+                                  must hold true for a specified past interval.
                                 properties:
                                   periodSeconds:
+                                    description: PeriodSeconds specifies the window
+                                      of time for which the policy should hold true.
+                                      PeriodSeconds must be greater than zero and less
+                                      than or equal to 1800 (30 min).
                                     format: int32
                                     type: integer
                                   type:
+                                    description: Type is used to specify the scaling
+                                      policy.
                                     type: string
                                   value:
+                                    description: Value contains the amount of change
+                                      which is permitted by the policy. It must be greater
+                                      than zero
                                     format: int32
                                     type: integer
                                 required:
@@ -2118,22 +4108,52 @@ spec:
                                 type: object
                               type: array
                             selectPolicy:
+                              description: selectPolicy is used to specify which policy
+                                should be used. If not set, the default value MaxPolicySelect
+                                is used.
                               type: string
                             stabilizationWindowSeconds:
+                              description: 'StabilizationWindowSeconds is the number
+                              of seconds for which past recommendations should be
+                              considered while scaling up or scaling down. StabilizationWindowSeconds
+                              must be greater than or equal to zero and less than
+                              or equal to 3600 (one hour). If not set, use the default
+                              values: - For scale up: 0 (i.e. no stabilization is
+                              done). - For scale down: 300 (i.e. the stabilization
+                              window is 300 seconds long).'
                               format: int32
                               type: integer
                           type: object
                         scaleUp:
+                          description: 'scaleUp is scaling policy for scaling Up. If
+                          not set, the default value is the higher of:   * increase
+                          no more than 4 pods per 60 seconds   * double the number
+                          of pods per 60 seconds No stabilization is used.'
                           properties:
                             policies:
+                              description: policies is a list of potential scaling polices
+                                which can be used during scaling. At least one policy
+                                must be specified, otherwise the HPAScalingRules will
+                                be discarded as invalid
                               items:
+                                description: HPAScalingPolicy is a single policy which
+                                  must hold true for a specified past interval.
                                 properties:
                                   periodSeconds:
+                                    description: PeriodSeconds specifies the window
+                                      of time for which the policy should hold true.
+                                      PeriodSeconds must be greater than zero and less
+                                      than or equal to 1800 (30 min).
                                     format: int32
                                     type: integer
                                   type:
+                                    description: Type is used to specify the scaling
+                                      policy.
                                     type: string
                                   value:
+                                    description: Value contains the amount of change
+                                      which is permitted by the policy. It must be greater
+                                      than zero
                                     format: int32
                                     type: integer
                                 required:
@@ -2143,8 +4163,19 @@ spec:
                                 type: object
                               type: array
                             selectPolicy:
+                              description: selectPolicy is used to specify which policy
+                                should be used. If not set, the default value MaxPolicySelect
+                                is used.
                               type: string
                             stabilizationWindowSeconds:
+                              description: 'StabilizationWindowSeconds is the number
+                              of seconds for which past recommendations should be
+                              considered while scaling up or scaling down. StabilizationWindowSeconds
+                              must be greater than or equal to zero and less than
+                              or equal to 3600 (one hour). If not set, use the default
+                              values: - For scale up: 0 (i.e. no stabilization is
+                              done). - For scale down: 300 (i.e. the stabilization
+                              window is 300 seconds long).'
                               format: int32
                               type: integer
                           type: object
@@ -2153,24 +4184,64 @@ spec:
                       format: int32
                       type: integer
                     metrics:
+                      description: 'Metrics contains the specifications for which to
+                      use to calculate the desired replica count (the maximum replica
+                      count across all metrics will be used). More info: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling'
                       items:
+                        description: MetricSpec specifies how to scale based on a single
+                          metric (only `type` and one other matching field should be
+                          set at once).
                         properties:
                           external:
+                            description: external refers to a global metric that is
+                              not associated with any Kubernetes object. It allows autoscaling
+                              based on information coming from components running outside
+                              of cluster (for example length of queue in cloud messaging
+                              service, or QPS from loadbalancer running outside of cluster).
                             properties:
                               metric:
+                                description: metric identifies the target metric by
+                                  name and selector
                                 properties:
                                   name:
+                                    description: name is the name of the given metric
                                     type: string
                                   selector:
+                                    description: selector is the string-encoded form
+                                      of a standard kubernetes label selector for the
+                                      given metric When set, it is passed as an additional
+                                      parameter to the metrics server for more specific
+                                      metrics scoping. When unset, just the metricName
+                                      will be used to gather metrics.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2182,28 +4253,49 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                 required:
                                   - name
                                 type: object
                               target:
+                                description: target specifies the target value for the
+                                  given metric
                                 properties:
                                   averageUtilization:
+                                    description: averageUtilization is the target value
+                                      of the average of the resource metric across all
+                                      relevant pods, represented as a percentage of
+                                      the requested value of the resource for the pods.
+                                      Currently only valid for Resource metric source
+                                      type
                                     format: int32
                                     type: integer
                                   averageValue:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: averageValue is the target value of
+                                      the average of the metric across all relevant
+                                      pods (as a quantity)
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type:
+                                    description: type represents whether the metric
+                                      type is Utilization, Value, or AverageValue
                                     type: string
                                   value:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: value is the target value of the metric
+                                      (as a quantity).
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 required:
@@ -2214,33 +4306,70 @@ spec:
                               - target
                             type: object
                           object:
+                            description: object refers to a metric describing a single
+                              kubernetes object (for example, hits-per-second on an
+                              Ingress object).
                             properties:
                               describedObject:
+                                description: CrossVersionObjectReference contains enough
+                                  information to let you identify the referred resource.
                                 properties:
                                   apiVersion:
+                                    description: API version of the referent
                                     type: string
                                   kind:
+                                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
                                     type: string
                                   name:
+                                    description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                                     type: string
                                 required:
                                   - kind
                                   - name
                                 type: object
                               metric:
+                                description: metric identifies the target metric by
+                                  name and selector
                                 properties:
                                   name:
+                                    description: name is the name of the given metric
                                     type: string
                                   selector:
+                                    description: selector is the string-encoded form
+                                      of a standard kubernetes label selector for the
+                                      given metric When set, it is passed as an additional
+                                      parameter to the metrics server for more specific
+                                      metrics scoping. When unset, just the metricName
+                                      will be used to gather metrics.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2252,28 +4381,49 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                 required:
                                   - name
                                 type: object
                               target:
+                                description: target specifies the target value for the
+                                  given metric
                                 properties:
                                   averageUtilization:
+                                    description: averageUtilization is the target value
+                                      of the average of the resource metric across all
+                                      relevant pods, represented as a percentage of
+                                      the requested value of the resource for the pods.
+                                      Currently only valid for Resource metric source
+                                      type
                                     format: int32
                                     type: integer
                                   averageValue:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: averageValue is the target value of
+                                      the average of the metric across all relevant
+                                      pods (as a quantity)
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type:
+                                    description: type represents whether the metric
+                                      type is Utilization, Value, or AverageValue
                                     type: string
                                   value:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: value is the target value of the metric
+                                      (as a quantity).
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 required:
@@ -2285,21 +4435,54 @@ spec:
                               - target
                             type: object
                           pods:
+                            description: pods refers to a metric describing each pod
+                              in the current scale target (for example, transactions-processed-per-second).  The
+                              values will be averaged together before being compared
+                              to the target value.
                             properties:
                               metric:
+                                description: metric identifies the target metric by
+                                  name and selector
                                 properties:
                                   name:
+                                    description: name is the name of the given metric
                                     type: string
                                   selector:
+                                    description: selector is the string-encoded form
+                                      of a standard kubernetes label selector for the
+                                      given metric When set, it is passed as an additional
+                                      parameter to the metrics server for more specific
+                                      metrics scoping. When unset, just the metricName
+                                      will be used to gather metrics.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2311,28 +4494,49 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                 required:
                                   - name
                                 type: object
                               target:
+                                description: target specifies the target value for the
+                                  given metric
                                 properties:
                                   averageUtilization:
+                                    description: averageUtilization is the target value
+                                      of the average of the resource metric across all
+                                      relevant pods, represented as a percentage of
+                                      the requested value of the resource for the pods.
+                                      Currently only valid for Resource metric source
+                                      type
                                     format: int32
                                     type: integer
                                   averageValue:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: averageValue is the target value of
+                                      the average of the metric across all relevant
+                                      pods (as a quantity)
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type:
+                                    description: type represents whether the metric
+                                      type is Utilization, Value, or AverageValue
                                     type: string
                                   value:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: value is the target value of the metric
+                                      (as a quantity).
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 required:
@@ -2343,26 +4547,48 @@ spec:
                               - target
                             type: object
                           resource:
+                            description: resource refers to a resource metric (such
+                              as those specified in requests and limits) known to Kubernetes
+                              describing each pod in the current scale target (e.g.
+                              CPU or memory). Such metrics are built in to Kubernetes,
+                              and have special scaling options on top of those available
+                              to normal per-pod metrics using the "pods" source.
                             properties:
                               name:
+                                description: name is the name of the resource in question.
                                 type: string
                               target:
+                                description: target specifies the target value for the
+                                  given metric
                                 properties:
                                   averageUtilization:
+                                    description: averageUtilization is the target value
+                                      of the average of the resource metric across all
+                                      relevant pods, represented as a percentage of
+                                      the requested value of the resource for the pods.
+                                      Currently only valid for Resource metric source
+                                      type
                                     format: int32
                                     type: integer
                                   averageValue:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: averageValue is the target value of
+                                      the average of the metric across all relevant
+                                      pods (as a quantity)
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type:
+                                    description: type represents whether the metric
+                                      type is Utilization, Value, or AverageValue
                                     type: string
                                   value:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: value is the target value of the metric
+                                      (as a quantity).
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 required:
@@ -2373,6 +4599,9 @@ spec:
                               - target
                             type: object
                           type:
+                            description: type is the type of metric source.  It should
+                              be one of "Object", "Pods" or "Resource", each mapping
+                              to a matching field in the object.
                             type: string
                         required:
                           - type
@@ -2387,71 +4616,154 @@ spec:
                 conf:
                   additionalProperties:
                     type: string
+                  description: 'Conf defines the bookkeeper configuration. It will be
+                  used for generating the configuration file used by bookie process.
+                  Deprecated: use `config`'
+                  nullable: true
                   type: object
                 config:
+                  description: Config defines the bookkeeper configuration
                   properties:
                     compactionRateByBytes:
+                      description: "CompactionRateByBytes is the rate at which compaction
+                      will read entries. The unit is adds per second. \n The default
+                      value is 52428800."
                       format: int64
                       minimum: 0
                       type: integer
                     custom:
                       additionalProperties:
                         type: string
+                      description: Custom accepts other configurations
+                      nullable: true
                       type: object
                     fileInfoFormatVersionToWrite:
+                      description: "FileInfoFormatVersionToWrite is the fileinfo format
+                      version to write. Available formats are 0 and 1. \n The default
+                      value is 1"
                       format: int32
                       maximum: 1
                       minimum: 0
                       type: integer
                     gcWaitTime:
+                      description: "GCWaitTime is the interval to trigger next garbage
+                      collection, in milliseconds. \n The default value is 300000"
                       format: int32
                       minimum: 0
                       type: integer
                     isThrottleByBytes:
+                      description: "IsThrottleByBytes defines the throttle compaction
+                      by bytes or by entries. \n The default value is true."
                       type: boolean
                     journalFormatVersionToWrite:
+                      description: JournalFormatVersionToWrite is the journal format
+                        version to write. Available value are from 0 to 6. The default
+                        value is 6.
                       format: int32
                       maximum: 6
                       minimum: 0
                       type: integer
                     journalMaxBackups:
+                      description: "JournalMaxBackups is the max number of old journal
+                      file to kept. \n The default value is 0."
                       format: int32
                       minimum: 0
                       type: integer
                     persistBookieStatusEnabled:
+                      description: "PersistBookieStatusEnabled persists the bookie status
+                      locally on the disks. TODO: enable this after https://github.com/apache/bookkeeper/issues/2374
+                      is fixed. \n The default value is false."
                       type: boolean
                     useTransactionalCompaction:
+                      description: "UseTransactionalCompaction is the flag to enable/disable
+                      transactional compaction. If it is set to true, it will use
+                      transactional compaction, which uses new entry log files to
+                      store entries after compaction. \n The default value is true."
                       type: boolean
                   type: object
                 image:
+                  description: Image is the container image used to run bookie pods.
+                    default is apachepulsar/pulsar:latest
                   type: string
                 imagePullPolicy:
+                  description: Image pull policy, one of Always, Never, IfNotPresent,
+                    default to Always.
                   type: string
                 initialized:
+                  description: Initialized determines whether to create the job to initialize
+                    the cluster metadata.
                   type: boolean
                 labels:
                   additionalProperties:
                     type: string
+                  description: Labels specifies the labels to attach to the stateful
+                    set the operator creates for the bookkeeper cluster.
+                  nullable: true
                   type: object
                 pod:
+                  description: Pod defines the policy for creating a bookkeeper pod
+                    for the cluster
                   properties:
                     affinity:
+                      description: Affinity specifies the scheduling constraints of
+                        a pod
                       properties:
                         nodeAffinity:
+                          description: Describes node affinity scheduling rules for
+                            the pod.
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node matches the corresponding matchExpressions;
+                                the node(s) with the highest sum are the most preferred.
                               items:
+                                description: An empty preferred scheduling term matches
+                                  all objects with implicit weight 0 (i.e. it's a no-op).
+                                  A null preferred scheduling term matches no objects
+                                  (i.e. is also a no-op).
                                 properties:
                                   preference:
+                                    description: A node selector term, associated with
+                                      the corresponding weight.
                                     properties:
                                       matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
                                         items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2461,13 +4773,35 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
                                         items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2478,6 +4812,8 @@ spec:
                                         type: array
                                     type: object
                                   weight:
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -2486,18 +4822,53 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by
+                                this field are not met at scheduling time, the pod will
+                                not be scheduled onto the node. If the affinity requirements
+                                specified by this field cease to be met at some point
+                                during pod execution (e.g. due to an update), the system
+                                may or may not try to eventually evict the pod from
+                                its node.
                               properties:
                                 nodeSelectorTerms:
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
                                   items:
+                                    description: A null or empty node selector term
+                                      matches no objects. The requirements of them are
+                                      ANDed. The TopologySelectorTerm type implements
+                                      a subset of the NodeSelectorTerm.
                                     properties:
                                       matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
                                         items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2507,13 +4878,35 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
                                         items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2529,22 +4922,65 @@ spec:
                               type: object
                           type: object
                         podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g.
+                            co-locate this pod in the same node, zone, etc. as some
+                            other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the corresponding
+                                podAffinityTerm; the node(s) with the highest sum are
+                                the most preferred.
                               items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
                                 properties:
                                   podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
                                     properties:
                                       labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -2556,18 +4992,37 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the
+                                          pods matching the labelSelector in the specified
+                                          namespaces, where co-located is defined as
+                                          running on a node whose value of the label
+                                          with key topologyKey matches that of any node
+                                          on which any of the selected pods is running.
+                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -2576,18 +5031,56 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by
+                                this field are not met at scheduling time, the pod will
+                                not be scheduled onto the node. If the affinity requirements
+                                specified by this field cease to be met at some point
+                                during pod execution (e.g. due to a pod label update),
+                                the system may or may not try to eventually evict the
+                                pod from its node. When there are multiple elements,
+                                the lists of nodes corresponding to each podAffinityTerm
+                                are intersected, i.e. all terms must be satisfied.
                               items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or not
+                                  co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any node
+                                  on which a pod of the set of pods is running
                                 properties:
                                   labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2599,13 +5092,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -2613,22 +5122,65 @@ spec:
                               type: array
                           type: object
                         podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules
+                            (e.g. avoid putting this pod in the same node, zone, etc.
+                            as some other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the anti-affinity expressions
+                                specified by this field, but it may choose a node that
+                                violates one or more of the expressions. The node that
+                                is most preferred is the one with the greatest sum of
+                                weights, i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                anti-affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the corresponding
+                                podAffinityTerm; the node(s) with the highest sum are
+                                the most preferred.
                               items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
                                 properties:
                                   podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
                                     properties:
                                       labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -2640,18 +5192,37 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the
+                                          pods matching the labelSelector in the specified
+                                          namespaces, where co-located is defined as
+                                          running on a node whose value of the label
+                                          with key topologyKey matches that of any node
+                                          on which any of the selected pods is running.
+                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -2660,18 +5231,56 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the anti-affinity requirements specified
+                                by this field are not met at scheduling time, the pod
+                                will not be scheduled onto the node. If the anti-affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod
+                                label update), the system may or may not try to eventually
+                                evict the pod from its node. When there are multiple
+                                elements, the lists of nodes corresponding to each podAffinityTerm
+                                are intersected, i.e. all terms must be satisfied.
                               items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or not
+                                  co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any node
+                                  on which a pod of the set of pods is running
                                 properties:
                                   labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2683,13 +5292,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -2700,78 +5325,151 @@ spec:
                     annotations:
                       additionalProperties:
                         type: string
+                      description: Annotations specifies the annotations to attach to
+                        pods the operator creates
                       type: object
                     debug:
+                      description: Debug defines a switch enable debug
                       type: boolean
                     imagePullSecrets:
+                      description: ImagePullSecrets is an optional list of references
+                        to secrets in the same namespace to use for pulling any of the
+                        images used by this PodSpec.
                       items:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same namespace.
                         properties:
                           name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       type: array
                     initContainers:
+                      description: InitContainers defines init containers of the pod.
+                        A typical use case could be using an init container to download
+                        a remote jar to a local path.
                       items:
+                        description: A single application container that you want to
+                          run within a pod. The Container API from the core group is
+                          not used directly to avoid unneeded fields and reduce the
+                          size of the CRD. New fields could be added as needed.
                         properties:
                           args:
+                            description: Arguments to the entrypoint.
                             items:
                               type: string
                             type: array
                           command:
+                            description: Entrypoint array. Not executed within a shell.
                             items:
                               type: string
                             type: array
                           env:
+                            description: List of environment variables to set in the
+                              container.
                             items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
                               properties:
                                 name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previous defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  The $(VAR_NAME) syntax can be escaped with a double
+                                  $$, ie: $$(VAR_NAME). Escaped references will never
+                                  be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
                                   type: string
                                 valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
+                                          description: The key to select.
                                           type: string
                                         name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
                                           type: boolean
                                       required:
                                         - key
                                       type: object
                                     fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
                                       properties:
                                         apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
+                                          description: Path of the field to select in
+                                            the specified API version.
                                           type: string
                                       required:
                                         - fieldPath
                                       type: object
                                     resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
                                       properties:
                                         containerName:
+                                          description: 'Container name: required for
+                                          volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                             - type: integer
                                             - type: string
+                                          description: Specifies the output format of
+                                            the exposed resources, defaults to "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
+                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                         - resource
                                       type: object
                                     secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
                                       properties:
                                         key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret or
+                                            its key must be defined
                                           type: boolean
                                       required:
                                         - key
@@ -2782,52 +5480,99 @@ spec:
                               type: object
                             type: array
                           envFrom:
+                            description: List of sources to populate environment variables
+                              in the container.
                             items:
+                              description: EnvFromSource represents the source of a
+                                set of ConfigMaps
                               properties:
                                 configMapRef:
+                                  description: The ConfigMap to select from
                                   properties:
                                     name:
+                                      description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                       type: string
                                     optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
                                       type: boolean
                                   type: object
                                 prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
+                                  description: The Secret to select from
                                   properties:
                                     name:
+                                      description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                       type: string
                                     optional:
+                                      description: Specify whether the Secret must be
+                                        defined
                                       type: boolean
                                   type: object
                               type: object
                             type: array
                           image:
+                            description: Docker image name.
                             type: string
                           imagePullPolicy:
+                            description: Image pull policy.
                             type: string
                           livenessProbe:
+                            description: Periodic probe of container liveness.
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -2835,66 +5580,120 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           name:
+                            description: Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
                             type: string
                           readinessProbe:
+                            description: 'Periodic probe of container service readiness.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -2902,43 +5701,70 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           resources:
+                            description: Compute Resources required by this container.
                             properties:
                               limits:
                                 additionalProperties:
@@ -2947,6 +5773,8 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -2955,30 +5783,61 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                             type: object
                           startupProbe:
+                            description: StartupProbe indicates that the Pod has successfully
+                              initialized.
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -2986,56 +5845,103 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           volumeMounts:
+                            description: Pod volumes to mount into the container's filesystem.
                             items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
                               properties:
                                 mountPath:
+                                  description: Path within the container at which the
+                                    volume should be mounted.  Must not contain ':'.
                                   type: string
                                 mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and the
+                                    other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
+                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to false.
                                   type: boolean
                                 subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults to
+                                    "" (volume's root).
                                   type: string
                                 subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the container's
+                                    environment. Defaults to "" (volume's root). SubPathExpr
+                                    and SubPath are mutually exclusive.
                                   type: string
                               required:
                                 - mountPath
@@ -3043,39 +5949,53 @@ spec:
                               type: object
                             type: array
                           workingDir:
+                            description: Container's working directory.
                             type: string
                         required:
                           - name
                         type: object
                       type: array
                     jvmOptions:
+                      description: JvmOptions defines the Jvm options passed to the
+                        proxy
                       properties:
                         extraOptions:
                           items:
                             type: string
+                          nullable: true
                           type: array
                         gcLoggingOptions:
                           items:
                             type: string
+                          nullable: true
                           type: array
                         gcOptions:
                           items:
                             type: string
+                          nullable: true
                           type: array
                         memoryOptions:
                           items:
                             type: string
+                          nullable: true
                           type: array
                       type: object
                     labels:
                       additionalProperties:
                         type: string
+                      description: Labels specifies the labels to attach to pod the
+                        operator creates for the cluster.
                       type: object
                     nodeSelector:
                       additionalProperties:
                         type: string
+                      description: NodeSelector specifies a map of key-value pairs.
+                        For a pod to be eligible to run on a node, the node must have
+                        each of the indicated key-value pairs as labels.
                       type: object
                     resources:
+                      description: Resources specifies the resource requirements of
+                        containers to run in the pod
                       properties:
                         limits:
                           additionalProperties:
@@ -3084,6 +6004,8 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
@@ -3092,9 +6014,15 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
                     secretRefs:
+                      description: SecretRefs defines how to mount required secrets
+                        into containers
                       items:
                         properties:
                           mountPath:
@@ -3107,51 +6035,120 @@ spec:
                         type: object
                       type: array
                     securityContext:
+                      description: 'SecurityContext specifies the security context for
+                      the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
                       properties:
                         fsGroup:
+                          description: "A special supplemental group that applies to
+                          all containers in a pod. Some volume types allow the Kubelet
+                          to change the ownership of that volume to be owned by the
+                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
+                          bit is set (new files created in the volume will be owned
+                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
+                          \n If unset, the Kubelet will not modify the ownership and
+                          permissions of any volume."
                           format: int64
                           type: integer
                         fsGroupChangePolicy:
+                          description: 'fsGroupChangePolicy defines behavior of changing
+                          ownership and permission of the volume before being exposed
+                          inside Pod. This field will only apply to volume types which
+                          support fsGroup based ownership(and permissions). It will
+                          have no effect on ephemeral volume types such as: secret,
+                          configmaps and emptydir. Valid values are "OnRootMismatch"
+                          and "Always". If not specified defaults to "Always".'
                           type: string
                         runAsGroup:
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container.
                           format: int64
                           type: integer
                         runAsNonRoot:
+                          description: Indicates that the container must run as a non-root
+                            user. If true, the Kubelet will validate the image at runtime
+                            to ensure that it does not run as UID 0 (root) and fail
+                            to start the container if it does. If unset or false, no
+                            such validation will be performed. May also be set in SecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
                           type: boolean
                         runAsUser:
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata if
+                            unspecified. May also be set in SecurityContext.  If set
+                            in both SecurityContext and PodSecurityContext, the value
+                            specified in SecurityContext takes precedence for that container.
                           format: int64
                           type: integer
                         seLinuxOptions:
+                          description: The SELinux context to be applied to all containers.
+                            If unspecified, the container runtime will allocate a random
+                            SELinux context for each container.  May also be set in
+                            SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence
+                            for that container.
                           properties:
                             level:
+                              description: Level is SELinux level label that applies
+                                to the container.
                               type: string
                             role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
                               type: string
                             type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
                               type: string
                             user:
+                              description: User is a SELinux user label that applies
+                                to the container.
                               type: string
                           type: object
                         seccompProfile:
+                          description: The seccomp options to use by the containers
+                            in this pod.
                           properties:
                             localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used. The profile must
+                                be preconfigured on the node to work. Must be a descending
+                                path, relative to the kubelet's configured seccomp profile
+                                location. Must only be set if type is "Localhost".
                               type: string
                             type:
+                              description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a
+                              profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile
+                              should be used. Unconfined - no profile should be applied."
                               type: string
                           required:
                             - type
                           type: object
                         supplementalGroups:
+                          description: A list of groups applied to the first process
+                            run in each container, in addition to the container's primary
+                            GID.  If unspecified, no groups will be added to any container.
                           items:
                             format: int64
                             type: integer
                           type: array
                         sysctls:
+                          description: Sysctls hold a list of namespaced sysctls used
+                            for the pod. Pods with unsupported sysctls (by the container
+                            runtime) might fail to launch.
                           items:
+                            description: Sysctl defines a kernel parameter to be set
                             properties:
                               name:
+                                description: Name of a property to set
                                 type: string
                               value:
+                                description: Value of a property to set
                                 type: string
                             required:
                               - name
@@ -3159,79 +6156,160 @@ spec:
                             type: object
                           type: array
                         windowsOptions:
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options within a container's
+                            SecurityContext will be used. If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
                           properties:
                             gmsaCredentialSpec:
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field.
                               type: string
                             gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
                               type: string
                             runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set in
+                                PodSecurityContext. If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
                               type: string
                           type: object
                       type: object
                     serviceAccountName:
+                      description: ServiceAccountName is the name of the ServiceAccount
+                        to use to run pods.
                       type: string
                     sidecars:
+                      description: Sidecars defines sidecar containers running alongside
+                        with the main function container in the pod.
                       items:
+                        description: A single application container that you want to
+                          run within a pod. The Container API from the core group is
+                          not used directly to avoid unneeded fields and reduce the
+                          size of the CRD. New fields could be added as needed.
                         properties:
                           args:
+                            description: Arguments to the entrypoint.
                             items:
                               type: string
                             type: array
                           command:
+                            description: Entrypoint array. Not executed within a shell.
                             items:
                               type: string
                             type: array
                           env:
+                            description: List of environment variables to set in the
+                              container.
                             items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
                               properties:
                                 name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previous defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  The $(VAR_NAME) syntax can be escaped with a double
+                                  $$, ie: $$(VAR_NAME). Escaped references will never
+                                  be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
                                   type: string
                                 valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
+                                          description: The key to select.
                                           type: string
                                         name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
                                           type: boolean
                                       required:
                                         - key
                                       type: object
                                     fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
                                       properties:
                                         apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
+                                          description: Path of the field to select in
+                                            the specified API version.
                                           type: string
                                       required:
                                         - fieldPath
                                       type: object
                                     resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
                                       properties:
                                         containerName:
+                                          description: 'Container name: required for
+                                          volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                             - type: integer
                                             - type: string
+                                          description: Specifies the output format of
+                                            the exposed resources, defaults to "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
+                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                         - resource
                                       type: object
                                     secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
                                       properties:
                                         key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret or
+                                            its key must be defined
                                           type: boolean
                                       required:
                                         - key
@@ -3242,52 +6320,99 @@ spec:
                               type: object
                             type: array
                           envFrom:
+                            description: List of sources to populate environment variables
+                              in the container.
                             items:
+                              description: EnvFromSource represents the source of a
+                                set of ConfigMaps
                               properties:
                                 configMapRef:
+                                  description: The ConfigMap to select from
                                   properties:
                                     name:
+                                      description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                       type: string
                                     optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
                                       type: boolean
                                   type: object
                                 prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
+                                  description: The Secret to select from
                                   properties:
                                     name:
+                                      description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                       type: string
                                     optional:
+                                      description: Specify whether the Secret must be
+                                        defined
                                       type: boolean
                                   type: object
                               type: object
                             type: array
                           image:
+                            description: Docker image name.
                             type: string
                           imagePullPolicy:
+                            description: Image pull policy.
                             type: string
                           livenessProbe:
+                            description: Periodic probe of container liveness.
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -3295,66 +6420,120 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           name:
+                            description: Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
                             type: string
                           readinessProbe:
+                            description: 'Periodic probe of container service readiness.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -3362,43 +6541,70 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           resources:
+                            description: Compute Resources required by this container.
                             properties:
                               limits:
                                 additionalProperties:
@@ -3407,6 +6613,8 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -3415,30 +6623,61 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                             type: object
                           startupProbe:
+                            description: StartupProbe indicates that the Pod has successfully
+                              initialized.
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -3446,56 +6685,103 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           volumeMounts:
+                            description: Pod volumes to mount into the container's filesystem.
                             items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
                               properties:
                                 mountPath:
+                                  description: Path within the container at which the
+                                    volume should be mounted.  Must not contain ':'.
                                   type: string
                                 mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and the
+                                    other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
+                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to false.
                                   type: boolean
                                 subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults to
+                                    "" (volume's root).
                                   type: string
                                 subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the container's
+                                    environment. Defaults to "" (volume's root). SubPathExpr
+                                    and SubPath are mutually exclusive.
                                   type: string
                               required:
                                 - mountPath
@@ -3503,81 +6789,158 @@ spec:
                               type: object
                             type: array
                           workingDir:
+                            description: Container's working directory.
                             type: string
                         required:
                           - name
                         type: object
                       type: array
                     terminationGracePeriodSeconds:
+                      description: TerminationGracePeriodSeconds is the amount of time
+                        that kubernetes will give for a pod before terminating it.
                       format: int64
                       type: integer
                     tolerations:
+                      description: Tolerations specifies the tolerations of a Pod
                       items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
                         properties:
                           effect:
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified, allowed
+                              values are NoSchedule, PreferNoSchedule and NoExecute.
                             type: string
                           key:
+                            description: Key is the taint key that the toleration applies
+                              to. Empty means match all taint keys. If the key is empty,
+                              operator must be Exists; this combination means to match
+                              all values and all keys.
                             type: string
                           operator:
+                            description: Operator represents a key's relationship to
+                              the value. Valid operators are Exists and Equal. Defaults
+                              to Equal. Exists is equivalent to wildcard for value,
+                              so that a pod can tolerate all taints of a particular
+                              category.
                             type: string
                           tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the taint
+                              forever (do not evict). Zero and negative values will
+                              be treated as 0 (evict immediately) by the system.
                             format: int64
                             type: integer
                           value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
                             type: string
                         type: object
                       type: array
                     vars:
+                      description: Vars specifies the environment variables of a Pod
                       items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
                         properties:
                           name:
+                            description: Name of the environment variable. Must be a
+                              C_IDENTIFIER.
                             type: string
                           value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
                             type: string
                           valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
                                 properties:
                                   key:
+                                    description: The key to select.
                                     type: string
                                   name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                     type: string
                                   optional:
+                                    description: Specify whether the ConfigMap or its
+                                      key must be defined
                                     type: boolean
                                 required:
                                   - key
                                 type: object
                               fieldRef:
+                                description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
                                 properties:
                                   apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
                                     type: string
                                 required:
                                   - fieldPath
                                 type: object
                               resourceFieldRef:
+                                description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
                                 properties:
                                   containerName:
+                                    description: 'Container name: required for volumes,
+                                    optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
+                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                   - resource
                                 type: object
                               secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
                                 properties:
                                   key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
                                     type: string
                                   name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                     type: string
                                   optional:
+                                    description: Specify whether the Secret or its key
+                                      must be defined
                                     type: boolean
                                 required:
                                   - key
@@ -3588,22 +6951,66 @@ spec:
                         type: object
                       type: array
                     volumes:
+                      description: Volumes defines extra volumes of the pod.
                       items:
+                        description: Volume represents a named volume in a pod that
+                          may be accessed by any container in the pod. The Volume API
+                          from the core group is not used directly to avoid unneeded
+                          fields defined in `VolumeSource` and reduce the size of the
+                          CRD. New fields in VolumeSource could be added as needed.
                         properties:
                           configMap:
+                            description: ConfigMap represents a configMap that should
+                              populate this volume
                             properties:
                               defaultMode:
+                                description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0
+                                and 511. YAML accepts both octal and decimal values,
+                                JSON requires decimal values for mode bits. Defaults
+                                to 0644. Directories within the path are not affected
+                                by this setting. This might be in conflict with other
+                                options that affect the file mode, like fsGroup, and
+                                the result can be other mode bits set.'
                                 format: int32
                                 type: integer
                               items:
+                                description: If unspecified, each key-value pair in
+                                  the Data field of the referenced ConfigMap will be
+                                  projected into the volume as a file whose name is
+                                  the key and content is the value. If specified, the
+                                  listed keys will be projected into the specified paths,
+                                  and unlisted keys will not be present. If a key is
+                                  specified which is not present in the ConfigMap, the
+                                  volume setup will error unless it is marked optional.
+                                  Paths must be relative and may not contain the '..'
+                                  path or start with '..'.
                                 items:
+                                  description: Maps a string key to a path within a
+                                    volume.
                                   properties:
                                     key:
+                                      description: The key to project.
                                       type: string
                                     mode:
+                                      description: 'Optional: mode bits used to set
+                                      permissions on this file. Must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
                                       format: int32
                                       type: integer
                                     path:
+                                      description: The relative path of the file to
+                                        map the key to. May not be an absolute path.
+                                        May not contain the path element '..'. May not
+                                        start with the string '..'.
                                       type: string
                                   required:
                                     - key
@@ -3611,26 +7018,70 @@ spec:
                                   type: object
                                 type: array
                               name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
+                                description: Specify whether the ConfigMap or its keys
+                                  must be defined
                                 type: boolean
                             type: object
                           name:
+                            description: 'Volume''s name. Must be a DNS_LABEL and unique
+                            within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
                           secret:
+                            description: Secret represents a secret that should populate
+                              this volume.
                             properties:
                               defaultMode:
+                                description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0
+                                and 511. YAML accepts both octal and decimal values,
+                                JSON requires decimal values for mode bits. Defaults
+                                to 0644. Directories within the path are not affected
+                                by this setting. This might be in conflict with other
+                                options that affect the file mode, like fsGroup, and
+                                the result can be other mode bits set.'
                                 format: int32
                                 type: integer
                               items:
+                                description: If unspecified, each key-value pair in
+                                  the Data field of the referenced Secret will be projected
+                                  into the volume as a file whose name is the key and
+                                  content is the value. If specified, the listed keys
+                                  will be projected into the specified paths, and unlisted
+                                  keys will not be present. If a key is specified which
+                                  is not present in the Secret, the volume setup will
+                                  error unless it is marked optional. Paths must be
+                                  relative and may not contain the '..' path or start
+                                  with '..'.
                                 items:
+                                  description: Maps a string key to a path within a
+                                    volume.
                                   properties:
                                     key:
+                                      description: The key to project.
                                       type: string
                                     mode:
+                                      description: 'Optional: mode bits used to set
+                                      permissions on this file. Must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
                                       format: int32
                                       type: integer
                                     path:
+                                      description: The relative path of the file to
+                                        map the key to. May not be an absolute path.
+                                        May not contain the path element '..'. May not
+                                        start with the string '..'.
                                       type: string
                                   required:
                                     - key
@@ -3638,8 +7089,12 @@ spec:
                                   type: object
                                 type: array
                               optional:
+                                description: Specify whether the Secret or its keys
+                                  must be defined
                                 type: boolean
                               secretName:
+                                description: 'Name of the secret in the pod''s namespace
+                                to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                 type: string
                             type: object
                         required:
@@ -3648,38 +7103,76 @@ spec:
                       type: array
                   type: object
                 replicas:
+                  description: Replicas is the expected size of the bookkeeper cluster.
+                    The bookkeeper operator will eventually make the size of the running
+                    cluster equal to the expected size. Use a pointer to distinguish
+                    between a specified zero or unspecified.
                   format: int32
                   minimum: 0
                   type: integer
                 storage:
+                  description: Persistence defines the persistent volume used for the
+                    bookie pod
                   properties:
                     journal:
+                      description: Journal is the spec to define journal storage
                       properties:
                         numDirsPerVolume:
+                          description: NumDirsPerVolume defines the number of directories
+                            provisioned for this type of storage.
                           format: int32
                           type: integer
                         numVolumes:
+                          description: NumVolumes defines the number of volumes provisioned
+                            for this type of storage.
                           format: int32
                           type: integer
                         volumeClaimTemplate:
+                          description: VolumeClaimSpec is the spec to define PVC for
+                            the storage
                           properties:
                             accessModes:
+                              description: 'AccessModes contains the desired access
+                              modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                               items:
                                 type: string
                               type: array
                             dataSource:
+                              description: 'This field can be used to specify either:
+                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                              - Beta) * An existing PVC (PersistentVolumeClaim) *
+                              An existing custom resource/object that implements data
+                              population (Alpha) In order to use VolumeSnapshot object
+                              types, the appropriate feature gate must be enabled
+                              (VolumeSnapshotDataSource or AnyVolumeDataSource) If
+                              the provisioner or an external controller can support
+                              the specified data source, it will create a new volume
+                              based on the contents of the specified data source.
+                              If the specified data source is not supported, the volume
+                              will not be created and the failure will be reported
+                              as an event. In the future, we plan to support more
+                              data source types and the behavior of the provisioner
+                              may change.'
                               properties:
                                 apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
                                   type: string
                                 kind:
+                                  description: Kind is the type of resource being referenced
                                   type: string
                                 name:
+                                  description: Name is the name of resource being referenced
                                   type: string
                               required:
                                 - kind
                                 - name
                               type: object
                             resources:
+                              description: 'Resources represents the minimum resources
+                              the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                               properties:
                                 limits:
                                   additionalProperties:
@@ -3688,6 +7181,8 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -3696,18 +7191,41 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                   type: object
                               type: object
                             selector:
+                              description: A label query over volumes to consider for
+                                binding.
                               properties:
                                 matchExpressions:
+                                  description: matchExpressions is a list of label selector
+                                    requirements. The requirements are ANDed.
                                   items:
+                                    description: A label selector requirement is a selector
+                                      that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
+                                        description: key is the label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are In,
+                                          NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
+                                        description: values is an array of string values.
+                                          If the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator is
+                                          Exists or DoesNotExist, the values array must
+                                          be empty. This array is replaced during a
+                                          strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -3719,45 +7237,89 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
+                                  description: matchLabels is a map of {key,value} pairs.
+                                    A single {key,value} in the matchLabels map is equivalent
+                                    to an element of matchExpressions, whose key field
+                                    is "key", the operator is "In", and the values array
+                                    contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                             storageClassName:
+                              description: 'Name of the StorageClass required by the
+                              claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                               type: string
                             volumeMode:
+                              description: volumeMode defines what type of volume is
+                                required by the claim. Value of Filesystem is implied
+                                when not included in claim spec.
                               type: string
                             volumeName:
+                              description: VolumeName is the binding reference to the
+                                PersistentVolume backing this claim.
                               type: string
                           type: object
                       required:
                         - volumeClaimTemplate
                       type: object
                     ledger:
+                      description: Ledger is the spec to define the ledger storage
                       properties:
                         numDirsPerVolume:
+                          description: NumDirsPerVolume defines the number of directories
+                            provisioned for this type of storage.
                           format: int32
                           type: integer
                         numVolumes:
+                          description: NumVolumes defines the number of volumes provisioned
+                            for this type of storage.
                           format: int32
                           type: integer
                         volumeClaimTemplate:
+                          description: VolumeClaimSpec is the spec to define PVC for
+                            the storage
                           properties:
                             accessModes:
+                              description: 'AccessModes contains the desired access
+                              modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                               items:
                                 type: string
                               type: array
                             dataSource:
+                              description: 'This field can be used to specify either:
+                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                              - Beta) * An existing PVC (PersistentVolumeClaim) *
+                              An existing custom resource/object that implements data
+                              population (Alpha) In order to use VolumeSnapshot object
+                              types, the appropriate feature gate must be enabled
+                              (VolumeSnapshotDataSource or AnyVolumeDataSource) If
+                              the provisioner or an external controller can support
+                              the specified data source, it will create a new volume
+                              based on the contents of the specified data source.
+                              If the specified data source is not supported, the volume
+                              will not be created and the failure will be reported
+                              as an event. In the future, we plan to support more
+                              data source types and the behavior of the provisioner
+                              may change.'
                               properties:
                                 apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
                                   type: string
                                 kind:
+                                  description: Kind is the type of resource being referenced
                                   type: string
                                 name:
+                                  description: Name is the name of resource being referenced
                                   type: string
                               required:
                                 - kind
                                 - name
                               type: object
                             resources:
+                              description: 'Resources represents the minimum resources
+                              the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                               properties:
                                 limits:
                                   additionalProperties:
@@ -3766,6 +7328,8 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -3774,18 +7338,41 @@ spec:
                                       - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                   type: object
                               type: object
                             selector:
+                              description: A label query over volumes to consider for
+                                binding.
                               properties:
                                 matchExpressions:
+                                  description: matchExpressions is a list of label selector
+                                    requirements. The requirements are ANDed.
                                   items:
+                                    description: A label selector requirement is a selector
+                                      that contains values, a key, and an operator that
+                                      relates the key and values.
                                     properties:
                                       key:
+                                        description: key is the label key that the selector
+                                          applies to.
                                         type: string
                                       operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are In,
+                                          NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
+                                        description: values is an array of string values.
+                                          If the operator is In or NotIn, the values
+                                          array must be non-empty. If the operator is
+                                          Exists or DoesNotExist, the values array must
+                                          be empty. This array is replaced during a
+                                          strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -3797,28 +7384,54 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
+                                  description: matchLabels is a map of {key,value} pairs.
+                                    A single {key,value} in the matchLabels map is equivalent
+                                    to an element of matchExpressions, whose key field
+                                    is "key", the operator is "In", and the values array
+                                    contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                             storageClassName:
+                              description: 'Name of the StorageClass required by the
+                              claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                               type: string
                             volumeMode:
+                              description: volumeMode defines what type of volume is
+                                required by the claim. Value of Filesystem is implied
+                                when not included in claim spec.
                               type: string
                             volumeName:
+                              description: VolumeName is the binding reference to the
+                                PersistentVolume backing this claim.
                               type: string
                           type: object
                       required:
                         - volumeClaimTemplate
                       type: object
                     reclaimPolicy:
+                      description: VolumeReclaimPolicy defines how to reclaim PV.
                       type: string
                   type: object
                 zkServers:
+                  description: Zookeeper server list
                   type: string
               type: object
             status:
+              description: BookKeeperClusterStatus defines the observed state of BookKeeperCluster
               properties:
                 conditions:
+                  description: Conditions is the current conditions of the cluster
                   items:
+                    description: "Condition represents an observation of an object's
+                    state. Conditions are an extension mechanism intended to be used
+                    when the details of an observation are not a priori known or would
+                    not apply to all instances of a given Kind. \n Conditions should
+                    be added to explicitly convey properties that users and components
+                    care about rather than requiring those properties to be inferred
+                    from other observations. Once defined, the meaning of a Condition
+                    can not be changed arbitrarily - it becomes part of the API, and
+                    has the same backwards- and forwards-compatibility concerns of
+                    any other part of the API."
                     properties:
                       lastTransitionTime:
                         format: date-time
@@ -3826,10 +7439,20 @@ spec:
                       message:
                         type: string
                       reason:
+                        description: ConditionReason is intended to be a one-word, CamelCase
+                          representation of the category of cause of the current status.
+                          It is intended to be used in concise output, such as one-line
+                          kubectl get output, and in summarizing occurrences of causes.
                         type: string
                       status:
                         type: string
                       type:
+                        description: "ConditionType is the type of the condition and
+                        is typically a CamelCased word or short phrase. \n Condition
+                        types should indicate state in the \"abnormal-true\" polarity.
+                        For example, if the condition indicates when a policy is invalid,
+                        the \"is valid\" case is probably the norm, so the condition
+                        should be called \"Invalid\"."
                         type: string
                     required:
                       - status
@@ -3837,19 +7460,28 @@ spec:
                     type: object
                   type: array
                 currentVersion:
+                  description: CurrentVersion is the current cluster version
                   type: string
                 labelSelector:
+                  description: Label selector for scaling
                   type: string
                 observedGeneration:
+                  description: ObservedGeneration is the most recent generation observed
+                    for this cluster. It corresponds to the metadata generation, which
+                    is updated on mutation by the API Server.
                   format: int64
                   type: integer
                 readyReplicas:
+                  description: ReadyReplicas is the number of ready servers in the cluster
                   format: int32
                   type: integer
                 replicas:
+                  description: Replicas
                   format: int32
                   type: integer
                 updatedReplicas:
+                  description: UpdatedReplicas is the number of servers that has been
+                    updated to the latest configuration
                   format: int32
                   type: integer
               required:

--- a/charts/pulsar-operator/crds/pulsar.streamnative.io_pulsarbrokers.yaml
+++ b/charts/pulsar-operator/crds/pulsar.streamnative.io_pulsarbrokers.yaml
@@ -37,244 +37,390 @@ spec:
       name: v1alpha1
       schema:
         openAPIV3Schema:
+          description: PulsarBroker defines a Pulsar broker
           properties:
             apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
             spec:
+              description: PulsarBrokerSpec defines the desired state of PulsarBroker
               properties:
                 apiObjects:
+                  description: APIObjects allows precise control over how components
+                    (services, statefulset and so on) should be managed
                   properties:
                     brokerConfigMap:
+                      description: BrokerConfigMap defines the broker ConfigMap resource
+                        template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     externalService:
+                      description: ExternalService defines the Pulsar External Service
+                        resource template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     functionMeshConfigMap:
+                      description: FunctionMeshConfigMap defines the FunctionMesh ConfigMap
+                        resource template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     functionWorkerConfigMap:
+                      description: FunctionWorkerConfigMap defines the function worker
+                        ConfigMap resource template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     headlessService:
+                      description: HeadlessService defines the Pulsar Headless Service
+                        resource template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     hpa:
+                      description: HPA defines the horizontalPodAutoscaler resource
+                        template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     interceptorConfigMap:
+                      description: InterceptorConfigMap defines the interceptor ConfigMap
+                        resource template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     internalService:
+                      description: InternalService defines the Pulsar Client Service
+                        resource template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     pdb:
+                      description: PDB defines the PodDisruptionBudget resource template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     statefulSet:
+                      description: StatefulSet defines the broker StatefulSet resource
+                        template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          the name, labels, annotations of the object. More info:
+                          https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                         volumeClaimTemplates:
+                          description: VolumeClaimTemplates is a list of claims that
+                            pods are allowed to reference. If a non-empty list is specified,
+                            the original values in the desired STS will be replaced.
                           items:
+                            description: PersistentVolumeClaim is a user's request for
+                              and claim to a persistent volume
                             properties:
                               apiVersion:
+                                description: 'APIVersion defines the versioned schema
+                                of this representation of an object. Servers should
+                                convert recognized schemas to the latest internal
+                                value, and may reject unrecognized values. More info:
+                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                                 type: string
                               kind:
+                                description: 'Kind is a string value representing the
+                                REST resource this object represents. Servers may
+                                infer this from the endpoint the client submits requests
+                                to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                 type: string
                               metadata:
+                                description: 'Standard object''s metadata. More info:
+                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                                 properties:
                                   annotations:
                                     additionalProperties:
@@ -294,24 +440,55 @@ spec:
                                     type: string
                                 type: object
                               spec:
+                                description: 'Spec defines the desired characteristics
+                                of a volume requested by a pod author. More info:
+                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                 properties:
                                   accessModes:
+                                    description: 'AccessModes contains the desired access
+                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                     items:
                                       type: string
                                     type: array
                                   dataSource:
+                                    description: 'This field can be used to specify
+                                    either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                                    - Beta) * An existing PVC (PersistentVolumeClaim)
+                                    * An existing custom resource/object that implements
+                                    data population (Alpha) In order to use VolumeSnapshot
+                                    object types, the appropriate feature gate must
+                                    be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
+                                    If the provisioner or an external controller can
+                                    support the specified data source, it will create
+                                    a new volume based on the contents of the specified
+                                    data source. If the specified data source is not
+                                    supported, the volume will not be created and
+                                    the failure will be reported as an event. In the
+                                    future, we plan to support more data source types
+                                    and the behavior of the provisioner may change.'
                                     properties:
                                       apiGroup:
+                                        description: APIGroup is the group for the resource
+                                          being referenced. If APIGroup is not specified,
+                                          the specified Kind must be in the core API
+                                          group. For any other third-party types, APIGroup
+                                          is required.
                                         type: string
                                       kind:
+                                        description: Kind is the type of resource being
+                                          referenced
                                         type: string
                                       name:
+                                        description: Name is the name of resource being
+                                          referenced
                                         type: string
                                     required:
                                       - kind
                                       - name
                                     type: object
                                   resources:
+                                    description: 'Resources represents the minimum resources
+                                    the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -320,6 +497,8 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum amount
+                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -328,18 +507,46 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum
+                                        amount of compute resources required. If Requests
+                                        is omitted for a container, it defaults to
+                                        Limits if that is explicitly specified, otherwise
+                                        to an implementation-defined value. More info:
+                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   selector:
+                                    description: A label query over volumes to consider
+                                      for binding.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -351,18 +558,37 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   storageClassName:
+                                    description: 'Name of the StorageClass required
+                                    by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                     type: string
                                   volumeMode:
+                                    description: volumeMode defines what type of volume
+                                      is required by the claim. Value of Filesystem
+                                      is implied when not included in claim spec.
                                     type: string
                                   volumeName:
+                                    description: VolumeName is the binding reference
+                                      to the PersistentVolume backing this claim.
                                     type: string
                                 type: object
                               status:
+                                description: 'Status represents the current information/status
+                                of a persistent volume claim. Read-only. More info:
+                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                 properties:
                                   accessModes:
+                                    description: 'AccessModes contains the actual access
+                                    modes the volume backing the PVC has. More info:
+                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                     items:
                                       type: string
                                     type: array
@@ -373,23 +599,43 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: Represents the actual resources of
+                                      the underlying volume.
                                     type: object
                                   conditions:
+                                    description: Current Condition of persistent volume
+                                      claim. If underlying persistent volume is being
+                                      resized then the Condition will be set to 'ResizeStarted'.
                                     items:
+                                      description: PersistentVolumeClaimCondition contails
+                                        details about state of pvc
                                       properties:
                                         lastProbeTime:
+                                          description: Last time we probed the condition.
                                           format: date-time
                                           type: string
                                         lastTransitionTime:
+                                          description: Last time the condition transitioned
+                                            from one status to another.
                                           format: date-time
                                           type: string
                                         message:
+                                          description: Human-readable message indicating
+                                            details about last transition.
                                           type: string
                                         reason:
+                                          description: Unique, this should be a short,
+                                            machine understandable string that gives
+                                            the reason for condition's last transition.
+                                            If it reports "ResizeStarted" that means
+                                            the underlying persistent volume is being
+                                            resized.
                                           type: string
                                         status:
                                           type: string
                                         type:
+                                          description: PersistentVolumeClaimConditionType
+                                            is a valid value of PersistentVolumeClaimCondition.Type
                                           type: string
                                       required:
                                         - status
@@ -397,24 +643,50 @@ spec:
                                       type: object
                                     type: array
                                   phase:
+                                    description: Phase represents the current phase
+                                      of PersistentVolumeClaim.
                                     type: string
                                 type: object
                             type: object
                           type: array
                         volumeMounts:
+                          description: VolumeMounts is a list of volumes to mount into
+                            the container's filesystem. If a non-empty list is specified,
+                            the original values of the main container in the desired
+                            STS will be replaced.
                           items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
                             properties:
                               mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
                                 type: string
                               mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
                                 type: string
                               name:
+                                description: This must match the Name of a Volume.
                                 type: string
                               readOnly:
+                                description: Mounted read-only if true, read-write otherwise
+                                  (false or unspecified). Defaults to false.
                                 type: boolean
                               subPath:
+                                description: Path within the volume from which the container's
+                                  volume should be mounted. Defaults to "" (volume's
+                                  root).
                                 type: string
                               subPathExpr:
+                                description: Expanded path within the volume from which
+                                  the container's volume should be mounted. Behaves
+                                  similarly to SubPath but environment variable references
+                                  $(VAR_NAME) are expanded using the container's environment.
+                                  Defaults to "" (volume's root). SubPathExpr and SubPath
+                                  are mutually exclusive.
                                 type: string
                             required:
                               - mountPath
@@ -424,20 +696,46 @@ spec:
                       type: object
                   type: object
                 autoScalingPolicy:
+                  description: AutoScalingPolicy defines how BookKeeperCluster will
+                    be scaled up/down with given metrics and threshold
                   properties:
                     behavior:
+                      description: Behavior configures the scaling behavior of the target
+                        in both Up and Down directions (scaleUp and scaleDown fields
+                        respectively). If not set, the default HPAScalingRules for scale
+                        up and scale down are used.
                       properties:
                         scaleDown:
+                          description: scaleDown is scaling policy for scaling Down.
+                            If not set, the default value is to allow to scale down
+                            to minReplicas pods, with a 300 second stabilization window
+                            (i.e., the highest recommendation for the last 300sec is
+                            used).
                           properties:
                             policies:
+                              description: policies is a list of potential scaling polices
+                                which can be used during scaling. At least one policy
+                                must be specified, otherwise the HPAScalingRules will
+                                be discarded as invalid
                               items:
+                                description: HPAScalingPolicy is a single policy which
+                                  must hold true for a specified past interval.
                                 properties:
                                   periodSeconds:
+                                    description: PeriodSeconds specifies the window
+                                      of time for which the policy should hold true.
+                                      PeriodSeconds must be greater than zero and less
+                                      than or equal to 1800 (30 min).
                                     format: int32
                                     type: integer
                                   type:
+                                    description: Type is used to specify the scaling
+                                      policy.
                                     type: string
                                   value:
+                                    description: Value contains the amount of change
+                                      which is permitted by the policy. It must be greater
+                                      than zero
                                     format: int32
                                     type: integer
                                 required:
@@ -447,22 +745,52 @@ spec:
                                 type: object
                               type: array
                             selectPolicy:
+                              description: selectPolicy is used to specify which policy
+                                should be used. If not set, the default value MaxPolicySelect
+                                is used.
                               type: string
                             stabilizationWindowSeconds:
+                              description: 'StabilizationWindowSeconds is the number
+                              of seconds for which past recommendations should be
+                              considered while scaling up or scaling down. StabilizationWindowSeconds
+                              must be greater than or equal to zero and less than
+                              or equal to 3600 (one hour). If not set, use the default
+                              values: - For scale up: 0 (i.e. no stabilization is
+                              done). - For scale down: 300 (i.e. the stabilization
+                              window is 300 seconds long).'
                               format: int32
                               type: integer
                           type: object
                         scaleUp:
+                          description: 'scaleUp is scaling policy for scaling Up. If
+                          not set, the default value is the higher of:   * increase
+                          no more than 4 pods per 60 seconds   * double the number
+                          of pods per 60 seconds No stabilization is used.'
                           properties:
                             policies:
+                              description: policies is a list of potential scaling polices
+                                which can be used during scaling. At least one policy
+                                must be specified, otherwise the HPAScalingRules will
+                                be discarded as invalid
                               items:
+                                description: HPAScalingPolicy is a single policy which
+                                  must hold true for a specified past interval.
                                 properties:
                                   periodSeconds:
+                                    description: PeriodSeconds specifies the window
+                                      of time for which the policy should hold true.
+                                      PeriodSeconds must be greater than zero and less
+                                      than or equal to 1800 (30 min).
                                     format: int32
                                     type: integer
                                   type:
+                                    description: Type is used to specify the scaling
+                                      policy.
                                     type: string
                                   value:
+                                    description: Value contains the amount of change
+                                      which is permitted by the policy. It must be greater
+                                      than zero
                                     format: int32
                                     type: integer
                                 required:
@@ -472,8 +800,19 @@ spec:
                                 type: object
                               type: array
                             selectPolicy:
+                              description: selectPolicy is used to specify which policy
+                                should be used. If not set, the default value MaxPolicySelect
+                                is used.
                               type: string
                             stabilizationWindowSeconds:
+                              description: 'StabilizationWindowSeconds is the number
+                              of seconds for which past recommendations should be
+                              considered while scaling up or scaling down. StabilizationWindowSeconds
+                              must be greater than or equal to zero and less than
+                              or equal to 3600 (one hour). If not set, use the default
+                              values: - For scale up: 0 (i.e. no stabilization is
+                              done). - For scale down: 300 (i.e. the stabilization
+                              window is 300 seconds long).'
                               format: int32
                               type: integer
                           type: object
@@ -482,24 +821,64 @@ spec:
                       format: int32
                       type: integer
                     metrics:
+                      description: 'Metrics contains the specifications for which to
+                      use to calculate the desired replica count (the maximum replica
+                      count across all metrics will be used). More info: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling'
                       items:
+                        description: MetricSpec specifies how to scale based on a single
+                          metric (only `type` and one other matching field should be
+                          set at once).
                         properties:
                           external:
+                            description: external refers to a global metric that is
+                              not associated with any Kubernetes object. It allows autoscaling
+                              based on information coming from components running outside
+                              of cluster (for example length of queue in cloud messaging
+                              service, or QPS from loadbalancer running outside of cluster).
                             properties:
                               metric:
+                                description: metric identifies the target metric by
+                                  name and selector
                                 properties:
                                   name:
+                                    description: name is the name of the given metric
                                     type: string
                                   selector:
+                                    description: selector is the string-encoded form
+                                      of a standard kubernetes label selector for the
+                                      given metric When set, it is passed as an additional
+                                      parameter to the metrics server for more specific
+                                      metrics scoping. When unset, just the metricName
+                                      will be used to gather metrics.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -511,28 +890,49 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                 required:
                                   - name
                                 type: object
                               target:
+                                description: target specifies the target value for the
+                                  given metric
                                 properties:
                                   averageUtilization:
+                                    description: averageUtilization is the target value
+                                      of the average of the resource metric across all
+                                      relevant pods, represented as a percentage of
+                                      the requested value of the resource for the pods.
+                                      Currently only valid for Resource metric source
+                                      type
                                     format: int32
                                     type: integer
                                   averageValue:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: averageValue is the target value of
+                                      the average of the metric across all relevant
+                                      pods (as a quantity)
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type:
+                                    description: type represents whether the metric
+                                      type is Utilization, Value, or AverageValue
                                     type: string
                                   value:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: value is the target value of the metric
+                                      (as a quantity).
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 required:
@@ -543,33 +943,70 @@ spec:
                               - target
                             type: object
                           object:
+                            description: object refers to a metric describing a single
+                              kubernetes object (for example, hits-per-second on an
+                              Ingress object).
                             properties:
                               describedObject:
+                                description: CrossVersionObjectReference contains enough
+                                  information to let you identify the referred resource.
                                 properties:
                                   apiVersion:
+                                    description: API version of the referent
                                     type: string
                                   kind:
+                                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
                                     type: string
                                   name:
+                                    description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                                     type: string
                                 required:
                                   - kind
                                   - name
                                 type: object
                               metric:
+                                description: metric identifies the target metric by
+                                  name and selector
                                 properties:
                                   name:
+                                    description: name is the name of the given metric
                                     type: string
                                   selector:
+                                    description: selector is the string-encoded form
+                                      of a standard kubernetes label selector for the
+                                      given metric When set, it is passed as an additional
+                                      parameter to the metrics server for more specific
+                                      metrics scoping. When unset, just the metricName
+                                      will be used to gather metrics.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -581,28 +1018,49 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                 required:
                                   - name
                                 type: object
                               target:
+                                description: target specifies the target value for the
+                                  given metric
                                 properties:
                                   averageUtilization:
+                                    description: averageUtilization is the target value
+                                      of the average of the resource metric across all
+                                      relevant pods, represented as a percentage of
+                                      the requested value of the resource for the pods.
+                                      Currently only valid for Resource metric source
+                                      type
                                     format: int32
                                     type: integer
                                   averageValue:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: averageValue is the target value of
+                                      the average of the metric across all relevant
+                                      pods (as a quantity)
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type:
+                                    description: type represents whether the metric
+                                      type is Utilization, Value, or AverageValue
                                     type: string
                                   value:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: value is the target value of the metric
+                                      (as a quantity).
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 required:
@@ -614,21 +1072,54 @@ spec:
                               - target
                             type: object
                           pods:
+                            description: pods refers to a metric describing each pod
+                              in the current scale target (for example, transactions-processed-per-second).  The
+                              values will be averaged together before being compared
+                              to the target value.
                             properties:
                               metric:
+                                description: metric identifies the target metric by
+                                  name and selector
                                 properties:
                                   name:
+                                    description: name is the name of the given metric
                                     type: string
                                   selector:
+                                    description: selector is the string-encoded form
+                                      of a standard kubernetes label selector for the
+                                      given metric When set, it is passed as an additional
+                                      parameter to the metrics server for more specific
+                                      metrics scoping. When unset, just the metricName
+                                      will be used to gather metrics.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -640,28 +1131,49 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                 required:
                                   - name
                                 type: object
                               target:
+                                description: target specifies the target value for the
+                                  given metric
                                 properties:
                                   averageUtilization:
+                                    description: averageUtilization is the target value
+                                      of the average of the resource metric across all
+                                      relevant pods, represented as a percentage of
+                                      the requested value of the resource for the pods.
+                                      Currently only valid for Resource metric source
+                                      type
                                     format: int32
                                     type: integer
                                   averageValue:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: averageValue is the target value of
+                                      the average of the metric across all relevant
+                                      pods (as a quantity)
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type:
+                                    description: type represents whether the metric
+                                      type is Utilization, Value, or AverageValue
                                     type: string
                                   value:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: value is the target value of the metric
+                                      (as a quantity).
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 required:
@@ -672,26 +1184,48 @@ spec:
                               - target
                             type: object
                           resource:
+                            description: resource refers to a resource metric (such
+                              as those specified in requests and limits) known to Kubernetes
+                              describing each pod in the current scale target (e.g.
+                              CPU or memory). Such metrics are built in to Kubernetes,
+                              and have special scaling options on top of those available
+                              to normal per-pod metrics using the "pods" source.
                             properties:
                               name:
+                                description: name is the name of the resource in question.
                                 type: string
                               target:
+                                description: target specifies the target value for the
+                                  given metric
                                 properties:
                                   averageUtilization:
+                                    description: averageUtilization is the target value
+                                      of the average of the resource metric across all
+                                      relevant pods, represented as a percentage of
+                                      the requested value of the resource for the pods.
+                                      Currently only valid for Resource metric source
+                                      type
                                     format: int32
                                     type: integer
                                   averageValue:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: averageValue is the target value of
+                                      the average of the metric across all relevant
+                                      pods (as a quantity)
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type:
+                                    description: type represents whether the metric
+                                      type is Utilization, Value, or AverageValue
                                     type: string
                                   value:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: value is the target value of the metric
+                                      (as a quantity).
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 required:
@@ -702,6 +1236,9 @@ spec:
                               - target
                             type: object
                           type:
+                            description: type is the type of metric source.  It should
+                              be one of "Object", "Pods" or "Resource", each mapping
+                              to a matching field in the object.
                             type: string
                         required:
                           - type
@@ -714,59 +1251,103 @@ spec:
                     - maxReplicas
                   type: object
                 bkMetadataServiceUri:
+                  description: BkMetadataServiceURI defines the metadata service uri
+                    that bookkeeper is used for loading corresponding metadata driver
+                    and resolving its metadata service location.
                   type: string
                 cleanUpPolicy:
+                  description: CleanUpPolicy defines the behavior when the object is
+                    being deleted
                   type: string
                 config:
+                  description: Config defines configurations for brokers
                   properties:
                     advertisedDomain:
+                      description: AdvertisedDomain defines a root domain of the services
+                        to advertise to the outside world.
                       type: string
                     clusterName:
+                      description: ClusterName defines name of the Pulsar cluster.
                       type: string
                     custom:
                       additionalProperties:
                         type: string
+                      description: Custom allows to customize broker configurations
+                        directly.
+                      nullable: true
                       type: object
                     function:
+                      description: FunctionConfig defines function worker configurations
                       properties:
                         custom:
                           additionalProperties:
                             type: string
+                          description: Custom allows to custom functions worker's configuration
+                            and will be written to the ConfigMap for `changeConfig`
+                          nullable: true
                           type: object
                         customWorkerConfig:
+                          description: CustomWorkerConfig allows customizing function
+                            workers config. The value should be a yaml with the configurations
+                            the user want to override
                           type: string
                         enabled:
+                          description: Enabled defines whether to enable function in
+                            the cluster
                           type: boolean
                         functionRunnerImages:
+                          description: Function runner images
                           properties:
                             go:
+                              description: Image of Go function runner.
                               type: string
                             java:
+                              description: Image of Java function runner.
                               type: string
                             python:
+                              description: Image of Python function runner.
                               type: string
                           type: object
                         labels:
                           additionalProperties:
                             type: string
+                          description: Labels defines custom labels for function pods
+                          nullable: true
                           type: object
                         mesh:
+                          description: Mesh defines configurations used in function
+                            mesh
                           properties:
                             builtinConnectorsRef:
+                              description: BuiltinConnectorsRef defines the reference
+                                to the ConfigMap that contains a list of builtin-connector
+                                definitions
                               properties:
                                 name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind,
+                                  uid?'
                                   type: string
                               type: object
                             functionEnabled:
+                              description: FunctionEnabled defines whether to enable
+                                function APIs
                               type: boolean
                             sinkEnabled:
+                              description: SinkEnabled defines whether to enable sink
+                                APIs
                               type: boolean
                             sourceEnabled:
+                              description: SourceEnabled defines whether to enable source
+                                APIs
                               type: boolean
                             uploadEnabled:
+                              description: UploadEnabled defines whether to enable user
+                                code upload in APIs
                               type: boolean
                           type: object
                         resourceRequirements:
+                          description: ResourceRequirements describes the resource requirements
                           properties:
                             max:
                               additionalProperties:
@@ -775,6 +1356,8 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
+                              description: Max describes maximum compute resource could
+                                request for each replica
                               type: object
                             min:
                               additionalProperties:
@@ -783,100 +1366,207 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
+                              description: Min describes minimal compute resource should
+                                request for each replica
                               type: object
                           type: object
                         serviceAccountName:
+                          description: The name of the service account to run functions
+                            and connectors.
                           type: string
                         type:
+                          description: Type defines the type of function worker service
+                            to run functions/sources/sinks Function-mesh worker service
+                            is used if the value of type is FunctionMesh, otherwise
+                            the builtin worker service is used
                           type: string
                       type: object
                     protocolHandlers:
+                      description: ProtocolHandlers defines the configuration of protocol
+                        handlers
                       properties:
                         aop:
+                          description: AoP configurations
                           properties:
                             enabled:
+                              description: Enabled defines whether to enable AoP
                               type: boolean
                             proxyEnabled:
+                              description: Whether to start AMQP proxy.
                               type: boolean
                           type: object
                         kop:
+                          description: KoP defines KoP configurations
                           properties:
                             enabled:
+                              description: Enabled defines whether to enable KoP
                               type: boolean
                             tls:
+                              description: TLS defines the TLS configuration on the
+                                broker.
                               properties:
                                 certSecretName:
+                                  description: CertSecretName defines the name of the
+                                    secret that contains the certificate to use the
+                                    value should be name of the secret that contains
+                                    a valid certificate to use in the proxy
                                   type: string
                                 enabled:
+                                  description: Enabled determines whether to enable
+                                    TLS in proxies TODO move other TLS related fields
+                                    here
                                   type: boolean
                                 passwordSecretRef:
+                                  description: PasswordSecretRef is a reference to a
+                                    key in a Secret resource containing the password
+                                    used to encrypt the keystore.
                                   properties:
                                     key:
+                                      description: The key of the entry in the Secret
+                                        resource's `data` field to be used. Some instances
+                                        of this field may be defaulted, in others it
+                                        may be required.
                                       type: string
                                     name:
+                                      description: 'Name of the resource being referred
+                                      to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                       type: string
                                   required:
                                     - name
                                   type: object
                                 trustCertsEnabled:
+                                  description: TrustCertsEnabled defines whether to
+                                    enable trust store
                                   type: boolean
                               type: object
                           type: object
                         mop:
+                          description: MoP configurations
                           properties:
                             authenticationEnabled:
+                              description: AuthenticationEnabled defines whether to
+                                enable MoP authentication.
                               type: boolean
                             authenticationMethods:
+                              description: AuthenticationMethods defines which authentication
+                                method to use, only supports token now
                               type: string
                             authorizationEnabled:
+                              description: AuthorizationEnabled defines whether to enable
+                                MoP authorization.
                               type: boolean
                             enabled:
+                              description: Enabled defines whether to enable MoP
                               type: boolean
                             proxyEnabled:
+                              description: ProxyEnabled defines whether to enable MoP
+                                proxy.
                               type: boolean
                           type: object
                       type: object
                     serviceURLGenerationPolicy:
                       default: NameUIDPrefix
+                      description: ServiceURLGenerationPolicy defines how the service
+                        url should be generated
                       type: string
                     transactionEnabled:
+                      description: TransactionEnabled defines whether transaction support
+                        is enabled in the brokers
                       type: boolean
                     usePodIPAsAdvertisedAddress:
+                      description: UsePodIPAsAdvertisedAddress use pod ip as advertise
+                        address.
                       type: boolean
                   type: object
                 configs:
                   additionalProperties:
                     type: string
+                  description: 'Configs defines custom configurations for brokers Deprecated:
+                  use Config instead'
+                  nullable: true
                   type: object
                 configurationStoreServers:
+                  description: ConfigurationStoreServers defines the address of the
+                    configuration store
                   type: string
                 dnsNames:
+                  description: A list of service urls this pulsar broker advertise
                   items:
                     type: string
+                  nullable: true
                   type: array
                 image:
+                  description: Image is the container image used to run pulsar broker
+                    pods. default is apachepulsar/pulsar:latest
                   type: string
                 imagePullPolicy:
+                  description: Image pull policy, one of Always, Never, IfNotPresent,
+                    default to Always.
                   type: string
                 initJobPod:
+                  description: InitJobPod defines the policy for creating a pod for
+                    init job
                   properties:
                     affinity:
+                      description: Affinity specifies the scheduling constraints of
+                        a pod
                       properties:
                         nodeAffinity:
+                          description: Describes node affinity scheduling rules for
+                            the pod.
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node matches the corresponding matchExpressions;
+                                the node(s) with the highest sum are the most preferred.
                               items:
+                                description: An empty preferred scheduling term matches
+                                  all objects with implicit weight 0 (i.e. it's a no-op).
+                                  A null preferred scheduling term matches no objects
+                                  (i.e. is also a no-op).
                                 properties:
                                   preference:
+                                    description: A node selector term, associated with
+                                      the corresponding weight.
                                     properties:
                                       matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
                                         items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -886,13 +1576,35 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
                                         items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -903,6 +1615,8 @@ spec:
                                         type: array
                                     type: object
                                   weight:
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -911,18 +1625,53 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by
+                                this field are not met at scheduling time, the pod will
+                                not be scheduled onto the node. If the affinity requirements
+                                specified by this field cease to be met at some point
+                                during pod execution (e.g. due to an update), the system
+                                may or may not try to eventually evict the pod from
+                                its node.
                               properties:
                                 nodeSelectorTerms:
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
                                   items:
+                                    description: A null or empty node selector term
+                                      matches no objects. The requirements of them are
+                                      ANDed. The TopologySelectorTerm type implements
+                                      a subset of the NodeSelectorTerm.
                                     properties:
                                       matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
                                         items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -932,13 +1681,35 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
                                         items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -954,22 +1725,65 @@ spec:
                               type: object
                           type: object
                         podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g.
+                            co-locate this pod in the same node, zone, etc. as some
+                            other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the corresponding
+                                podAffinityTerm; the node(s) with the highest sum are
+                                the most preferred.
                               items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
                                 properties:
                                   podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
                                     properties:
                                       labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -981,18 +1795,37 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the
+                                          pods matching the labelSelector in the specified
+                                          namespaces, where co-located is defined as
+                                          running on a node whose value of the label
+                                          with key topologyKey matches that of any node
+                                          on which any of the selected pods is running.
+                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -1001,18 +1834,56 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by
+                                this field are not met at scheduling time, the pod will
+                                not be scheduled onto the node. If the affinity requirements
+                                specified by this field cease to be met at some point
+                                during pod execution (e.g. due to a pod label update),
+                                the system may or may not try to eventually evict the
+                                pod from its node. When there are multiple elements,
+                                the lists of nodes corresponding to each podAffinityTerm
+                                are intersected, i.e. all terms must be satisfied.
                               items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or not
+                                  co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any node
+                                  on which a pod of the set of pods is running
                                 properties:
                                   labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -1024,13 +1895,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -1038,22 +1925,65 @@ spec:
                               type: array
                           type: object
                         podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules
+                            (e.g. avoid putting this pod in the same node, zone, etc.
+                            as some other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the anti-affinity expressions
+                                specified by this field, but it may choose a node that
+                                violates one or more of the expressions. The node that
+                                is most preferred is the one with the greatest sum of
+                                weights, i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                anti-affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the corresponding
+                                podAffinityTerm; the node(s) with the highest sum are
+                                the most preferred.
                               items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
                                 properties:
                                   podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
                                     properties:
                                       labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -1065,18 +1995,37 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the
+                                          pods matching the labelSelector in the specified
+                                          namespaces, where co-located is defined as
+                                          running on a node whose value of the label
+                                          with key topologyKey matches that of any node
+                                          on which any of the selected pods is running.
+                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -1085,18 +2034,56 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the anti-affinity requirements specified
+                                by this field are not met at scheduling time, the pod
+                                will not be scheduled onto the node. If the anti-affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod
+                                label update), the system may or may not try to eventually
+                                evict the pod from its node. When there are multiple
+                                elements, the lists of nodes corresponding to each podAffinityTerm
+                                are intersected, i.e. all terms must be satisfied.
                               items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or not
+                                  co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any node
+                                  on which a pod of the set of pods is running
                                 properties:
                                   labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -1108,13 +2095,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -1125,78 +2128,151 @@ spec:
                     annotations:
                       additionalProperties:
                         type: string
+                      description: Annotations specifies the annotations to attach to
+                        pods the operator creates
                       type: object
                     debug:
+                      description: Debug defines a switch enable debug
                       type: boolean
                     imagePullSecrets:
+                      description: ImagePullSecrets is an optional list of references
+                        to secrets in the same namespace to use for pulling any of the
+                        images used by this PodSpec.
                       items:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same namespace.
                         properties:
                           name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       type: array
                     initContainers:
+                      description: InitContainers defines init containers of the pod.
+                        A typical use case could be using an init container to download
+                        a remote jar to a local path.
                       items:
+                        description: A single application container that you want to
+                          run within a pod. The Container API from the core group is
+                          not used directly to avoid unneeded fields and reduce the
+                          size of the CRD. New fields could be added as needed.
                         properties:
                           args:
+                            description: Arguments to the entrypoint.
                             items:
                               type: string
                             type: array
                           command:
+                            description: Entrypoint array. Not executed within a shell.
                             items:
                               type: string
                             type: array
                           env:
+                            description: List of environment variables to set in the
+                              container.
                             items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
                               properties:
                                 name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previous defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  The $(VAR_NAME) syntax can be escaped with a double
+                                  $$, ie: $$(VAR_NAME). Escaped references will never
+                                  be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
                                   type: string
                                 valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
+                                          description: The key to select.
                                           type: string
                                         name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
                                           type: boolean
                                       required:
                                         - key
                                       type: object
                                     fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
                                       properties:
                                         apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
+                                          description: Path of the field to select in
+                                            the specified API version.
                                           type: string
                                       required:
                                         - fieldPath
                                       type: object
                                     resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
                                       properties:
                                         containerName:
+                                          description: 'Container name: required for
+                                          volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                             - type: integer
                                             - type: string
+                                          description: Specifies the output format of
+                                            the exposed resources, defaults to "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
+                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                         - resource
                                       type: object
                                     secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
                                       properties:
                                         key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret or
+                                            its key must be defined
                                           type: boolean
                                       required:
                                         - key
@@ -1207,52 +2283,99 @@ spec:
                               type: object
                             type: array
                           envFrom:
+                            description: List of sources to populate environment variables
+                              in the container.
                             items:
+                              description: EnvFromSource represents the source of a
+                                set of ConfigMaps
                               properties:
                                 configMapRef:
+                                  description: The ConfigMap to select from
                                   properties:
                                     name:
+                                      description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                       type: string
                                     optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
                                       type: boolean
                                   type: object
                                 prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
+                                  description: The Secret to select from
                                   properties:
                                     name:
+                                      description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                       type: string
                                     optional:
+                                      description: Specify whether the Secret must be
+                                        defined
                                       type: boolean
                                   type: object
                               type: object
                             type: array
                           image:
+                            description: Docker image name.
                             type: string
                           imagePullPolicy:
+                            description: Image pull policy.
                             type: string
                           livenessProbe:
+                            description: Periodic probe of container liveness.
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1260,66 +2383,120 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           name:
+                            description: Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
                             type: string
                           readinessProbe:
+                            description: 'Periodic probe of container service readiness.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1327,43 +2504,70 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           resources:
+                            description: Compute Resources required by this container.
                             properties:
                               limits:
                                 additionalProperties:
@@ -1372,6 +2576,8 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -1380,30 +2586,61 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                             type: object
                           startupProbe:
+                            description: StartupProbe indicates that the Pod has successfully
+                              initialized.
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1411,56 +2648,103 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           volumeMounts:
+                            description: Pod volumes to mount into the container's filesystem.
                             items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
                               properties:
                                 mountPath:
+                                  description: Path within the container at which the
+                                    volume should be mounted.  Must not contain ':'.
                                   type: string
                                 mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and the
+                                    other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
+                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to false.
                                   type: boolean
                                 subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults to
+                                    "" (volume's root).
                                   type: string
                                 subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the container's
+                                    environment. Defaults to "" (volume's root). SubPathExpr
+                                    and SubPath are mutually exclusive.
                                   type: string
                               required:
                                 - mountPath
@@ -1468,12 +2752,15 @@ spec:
                               type: object
                             type: array
                           workingDir:
+                            description: Container's working directory.
                             type: string
                         required:
                           - name
                         type: object
                       type: array
                     jvmOptions:
+                      description: JvmOptions defines the Jvm options passed to the
+                        proxy
                       properties:
                         extraOptions:
                           items:
@@ -1495,12 +2782,19 @@ spec:
                     labels:
                       additionalProperties:
                         type: string
+                      description: Labels specifies the labels to attach to pod the
+                        operator creates for the cluster.
                       type: object
                     nodeSelector:
                       additionalProperties:
                         type: string
+                      description: NodeSelector specifies a map of key-value pairs.
+                        For a pod to be eligible to run on a node, the node must have
+                        each of the indicated key-value pairs as labels.
                       type: object
                     resources:
+                      description: Resources specifies the resource requirements of
+                        containers to run in the pod
                       properties:
                         limits:
                           additionalProperties:
@@ -1509,6 +2803,8 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
@@ -1517,9 +2813,15 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
                     secretRefs:
+                      description: SecretRefs defines how to mount required secrets
+                        into containers
                       items:
                         properties:
                           mountPath:
@@ -1532,51 +2834,120 @@ spec:
                         type: object
                       type: array
                     securityContext:
+                      description: 'SecurityContext specifies the security context for
+                      the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
                       properties:
                         fsGroup:
+                          description: "A special supplemental group that applies to
+                          all containers in a pod. Some volume types allow the Kubelet
+                          to change the ownership of that volume to be owned by the
+                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
+                          bit is set (new files created in the volume will be owned
+                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
+                          \n If unset, the Kubelet will not modify the ownership and
+                          permissions of any volume."
                           format: int64
                           type: integer
                         fsGroupChangePolicy:
+                          description: 'fsGroupChangePolicy defines behavior of changing
+                          ownership and permission of the volume before being exposed
+                          inside Pod. This field will only apply to volume types which
+                          support fsGroup based ownership(and permissions). It will
+                          have no effect on ephemeral volume types such as: secret,
+                          configmaps and emptydir. Valid values are "OnRootMismatch"
+                          and "Always". If not specified defaults to "Always".'
                           type: string
                         runAsGroup:
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container.
                           format: int64
                           type: integer
                         runAsNonRoot:
+                          description: Indicates that the container must run as a non-root
+                            user. If true, the Kubelet will validate the image at runtime
+                            to ensure that it does not run as UID 0 (root) and fail
+                            to start the container if it does. If unset or false, no
+                            such validation will be performed. May also be set in SecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
                           type: boolean
                         runAsUser:
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata if
+                            unspecified. May also be set in SecurityContext.  If set
+                            in both SecurityContext and PodSecurityContext, the value
+                            specified in SecurityContext takes precedence for that container.
                           format: int64
                           type: integer
                         seLinuxOptions:
+                          description: The SELinux context to be applied to all containers.
+                            If unspecified, the container runtime will allocate a random
+                            SELinux context for each container.  May also be set in
+                            SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence
+                            for that container.
                           properties:
                             level:
+                              description: Level is SELinux level label that applies
+                                to the container.
                               type: string
                             role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
                               type: string
                             type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
                               type: string
                             user:
+                              description: User is a SELinux user label that applies
+                                to the container.
                               type: string
                           type: object
                         seccompProfile:
+                          description: The seccomp options to use by the containers
+                            in this pod.
                           properties:
                             localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used. The profile must
+                                be preconfigured on the node to work. Must be a descending
+                                path, relative to the kubelet's configured seccomp profile
+                                location. Must only be set if type is "Localhost".
                               type: string
                             type:
+                              description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a
+                              profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile
+                              should be used. Unconfined - no profile should be applied."
                               type: string
                           required:
                             - type
                           type: object
                         supplementalGroups:
+                          description: A list of groups applied to the first process
+                            run in each container, in addition to the container's primary
+                            GID.  If unspecified, no groups will be added to any container.
                           items:
                             format: int64
                             type: integer
                           type: array
                         sysctls:
+                          description: Sysctls hold a list of namespaced sysctls used
+                            for the pod. Pods with unsupported sysctls (by the container
+                            runtime) might fail to launch.
                           items:
+                            description: Sysctl defines a kernel parameter to be set
                             properties:
                               name:
+                                description: Name of a property to set
                                 type: string
                               value:
+                                description: Value of a property to set
                                 type: string
                             required:
                               - name
@@ -1584,79 +2955,160 @@ spec:
                             type: object
                           type: array
                         windowsOptions:
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options within a container's
+                            SecurityContext will be used. If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
                           properties:
                             gmsaCredentialSpec:
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field.
                               type: string
                             gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
                               type: string
                             runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set in
+                                PodSecurityContext. If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
                               type: string
                           type: object
                       type: object
                     serviceAccountName:
+                      description: ServiceAccountName is the name of the ServiceAccount
+                        to use to run pods.
                       type: string
                     sidecars:
+                      description: Sidecars defines sidecar containers running alongside
+                        with the main function container in the pod.
                       items:
+                        description: A single application container that you want to
+                          run within a pod. The Container API from the core group is
+                          not used directly to avoid unneeded fields and reduce the
+                          size of the CRD. New fields could be added as needed.
                         properties:
                           args:
+                            description: Arguments to the entrypoint.
                             items:
                               type: string
                             type: array
                           command:
+                            description: Entrypoint array. Not executed within a shell.
                             items:
                               type: string
                             type: array
                           env:
+                            description: List of environment variables to set in the
+                              container.
                             items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
                               properties:
                                 name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previous defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  The $(VAR_NAME) syntax can be escaped with a double
+                                  $$, ie: $$(VAR_NAME). Escaped references will never
+                                  be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
                                   type: string
                                 valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
+                                          description: The key to select.
                                           type: string
                                         name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
                                           type: boolean
                                       required:
                                         - key
                                       type: object
                                     fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
                                       properties:
                                         apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
+                                          description: Path of the field to select in
+                                            the specified API version.
                                           type: string
                                       required:
                                         - fieldPath
                                       type: object
                                     resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
                                       properties:
                                         containerName:
+                                          description: 'Container name: required for
+                                          volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                             - type: integer
                                             - type: string
+                                          description: Specifies the output format of
+                                            the exposed resources, defaults to "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
+                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                         - resource
                                       type: object
                                     secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
                                       properties:
                                         key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret or
+                                            its key must be defined
                                           type: boolean
                                       required:
                                         - key
@@ -1667,52 +3119,99 @@ spec:
                               type: object
                             type: array
                           envFrom:
+                            description: List of sources to populate environment variables
+                              in the container.
                             items:
+                              description: EnvFromSource represents the source of a
+                                set of ConfigMaps
                               properties:
                                 configMapRef:
+                                  description: The ConfigMap to select from
                                   properties:
                                     name:
+                                      description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                       type: string
                                     optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
                                       type: boolean
                                   type: object
                                 prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
+                                  description: The Secret to select from
                                   properties:
                                     name:
+                                      description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                       type: string
                                     optional:
+                                      description: Specify whether the Secret must be
+                                        defined
                                       type: boolean
                                   type: object
                               type: object
                             type: array
                           image:
+                            description: Docker image name.
                             type: string
                           imagePullPolicy:
+                            description: Image pull policy.
                             type: string
                           livenessProbe:
+                            description: Periodic probe of container liveness.
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1720,66 +3219,120 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           name:
+                            description: Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
                             type: string
                           readinessProbe:
+                            description: 'Periodic probe of container service readiness.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1787,43 +3340,70 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           resources:
+                            description: Compute Resources required by this container.
                             properties:
                               limits:
                                 additionalProperties:
@@ -1832,6 +3412,8 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -1840,30 +3422,61 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                             type: object
                           startupProbe:
+                            description: StartupProbe indicates that the Pod has successfully
+                              initialized.
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1871,56 +3484,103 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           volumeMounts:
+                            description: Pod volumes to mount into the container's filesystem.
                             items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
                               properties:
                                 mountPath:
+                                  description: Path within the container at which the
+                                    volume should be mounted.  Must not contain ':'.
                                   type: string
                                 mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and the
+                                    other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
+                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to false.
                                   type: boolean
                                 subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults to
+                                    "" (volume's root).
                                   type: string
                                 subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the container's
+                                    environment. Defaults to "" (volume's root). SubPathExpr
+                                    and SubPath are mutually exclusive.
                                   type: string
                               required:
                                 - mountPath
@@ -1928,81 +3588,158 @@ spec:
                               type: object
                             type: array
                           workingDir:
+                            description: Container's working directory.
                             type: string
                         required:
                           - name
                         type: object
                       type: array
                     terminationGracePeriodSeconds:
+                      description: TerminationGracePeriodSeconds is the amount of time
+                        that kubernetes will give for a pod before terminating it.
                       format: int64
                       type: integer
                     tolerations:
+                      description: Tolerations specifies the tolerations of a Pod
                       items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
                         properties:
                           effect:
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified, allowed
+                              values are NoSchedule, PreferNoSchedule and NoExecute.
                             type: string
                           key:
+                            description: Key is the taint key that the toleration applies
+                              to. Empty means match all taint keys. If the key is empty,
+                              operator must be Exists; this combination means to match
+                              all values and all keys.
                             type: string
                           operator:
+                            description: Operator represents a key's relationship to
+                              the value. Valid operators are Exists and Equal. Defaults
+                              to Equal. Exists is equivalent to wildcard for value,
+                              so that a pod can tolerate all taints of a particular
+                              category.
                             type: string
                           tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the taint
+                              forever (do not evict). Zero and negative values will
+                              be treated as 0 (evict immediately) by the system.
                             format: int64
                             type: integer
                           value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
                             type: string
                         type: object
                       type: array
                     vars:
+                      description: Vars specifies the environment variables of a Pod
                       items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
                         properties:
                           name:
+                            description: Name of the environment variable. Must be a
+                              C_IDENTIFIER.
                             type: string
                           value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
                             type: string
                           valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
                                 properties:
                                   key:
+                                    description: The key to select.
                                     type: string
                                   name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                     type: string
                                   optional:
+                                    description: Specify whether the ConfigMap or its
+                                      key must be defined
                                     type: boolean
                                 required:
                                   - key
                                 type: object
                               fieldRef:
+                                description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
                                 properties:
                                   apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
                                     type: string
                                 required:
                                   - fieldPath
                                 type: object
                               resourceFieldRef:
+                                description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
                                 properties:
                                   containerName:
+                                    description: 'Container name: required for volumes,
+                                    optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
+                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                   - resource
                                 type: object
                               secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
                                 properties:
                                   key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
                                     type: string
                                   name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                     type: string
                                   optional:
+                                    description: Specify whether the Secret or its key
+                                      must be defined
                                     type: boolean
                                 required:
                                   - key
@@ -2013,22 +3750,66 @@ spec:
                         type: object
                       type: array
                     volumes:
+                      description: Volumes defines extra volumes of the pod.
                       items:
+                        description: Volume represents a named volume in a pod that
+                          may be accessed by any container in the pod. The Volume API
+                          from the core group is not used directly to avoid unneeded
+                          fields defined in `VolumeSource` and reduce the size of the
+                          CRD. New fields in VolumeSource could be added as needed.
                         properties:
                           configMap:
+                            description: ConfigMap represents a configMap that should
+                              populate this volume
                             properties:
                               defaultMode:
+                                description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0
+                                and 511. YAML accepts both octal and decimal values,
+                                JSON requires decimal values for mode bits. Defaults
+                                to 0644. Directories within the path are not affected
+                                by this setting. This might be in conflict with other
+                                options that affect the file mode, like fsGroup, and
+                                the result can be other mode bits set.'
                                 format: int32
                                 type: integer
                               items:
+                                description: If unspecified, each key-value pair in
+                                  the Data field of the referenced ConfigMap will be
+                                  projected into the volume as a file whose name is
+                                  the key and content is the value. If specified, the
+                                  listed keys will be projected into the specified paths,
+                                  and unlisted keys will not be present. If a key is
+                                  specified which is not present in the ConfigMap, the
+                                  volume setup will error unless it is marked optional.
+                                  Paths must be relative and may not contain the '..'
+                                  path or start with '..'.
                                 items:
+                                  description: Maps a string key to a path within a
+                                    volume.
                                   properties:
                                     key:
+                                      description: The key to project.
                                       type: string
                                     mode:
+                                      description: 'Optional: mode bits used to set
+                                      permissions on this file. Must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
                                       format: int32
                                       type: integer
                                     path:
+                                      description: The relative path of the file to
+                                        map the key to. May not be an absolute path.
+                                        May not contain the path element '..'. May not
+                                        start with the string '..'.
                                       type: string
                                   required:
                                     - key
@@ -2036,26 +3817,70 @@ spec:
                                   type: object
                                 type: array
                               name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
+                                description: Specify whether the ConfigMap or its keys
+                                  must be defined
                                 type: boolean
                             type: object
                           name:
+                            description: 'Volume''s name. Must be a DNS_LABEL and unique
+                            within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
                           secret:
+                            description: Secret represents a secret that should populate
+                              this volume.
                             properties:
                               defaultMode:
+                                description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0
+                                and 511. YAML accepts both octal and decimal values,
+                                JSON requires decimal values for mode bits. Defaults
+                                to 0644. Directories within the path are not affected
+                                by this setting. This might be in conflict with other
+                                options that affect the file mode, like fsGroup, and
+                                the result can be other mode bits set.'
                                 format: int32
                                 type: integer
                               items:
+                                description: If unspecified, each key-value pair in
+                                  the Data field of the referenced Secret will be projected
+                                  into the volume as a file whose name is the key and
+                                  content is the value. If specified, the listed keys
+                                  will be projected into the specified paths, and unlisted
+                                  keys will not be present. If a key is specified which
+                                  is not present in the Secret, the volume setup will
+                                  error unless it is marked optional. Paths must be
+                                  relative and may not contain the '..' path or start
+                                  with '..'.
                                 items:
+                                  description: Maps a string key to a path within a
+                                    volume.
                                   properties:
                                     key:
+                                      description: The key to project.
                                       type: string
                                     mode:
+                                      description: 'Optional: mode bits used to set
+                                      permissions on this file. Must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
                                       format: int32
                                       type: integer
                                     path:
+                                      description: The relative path of the file to
+                                        map the key to. May not be an absolute path.
+                                        May not contain the path element '..'. May not
+                                        start with the string '..'.
                                       type: string
                                   required:
                                     - key
@@ -2063,8 +3888,12 @@ spec:
                                   type: object
                                 type: array
                               optional:
+                                description: Specify whether the Secret or its keys
+                                  must be defined
                                 type: boolean
                               secretName:
+                                description: 'Name of the secret in the pod''s namespace
+                                to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                 type: string
                             type: object
                         required:
@@ -2073,55 +3902,89 @@ spec:
                       type: array
                   type: object
                 initialized:
+                  description: Initialized determines whether to create the job to initialize
+                    the cluster metadata.
                   type: boolean
                 interceptors:
+                  description: Interceptors defines a list of interceptors to enable
                   items:
                     properties:
                       configs:
                         additionalProperties:
                           type: string
+                        description: Configs defines configs for the interceptor
+                        nullable: true
                         type: object
                       mountedConfigs:
+                        description: MountedConfigs defines configs whose value should
+                          be put in a dedicated file
                         items:
+                          description: The operator generates config files based on
+                            the spec automatically
                           properties:
                             configName:
+                              description: ConfigName defines the name of the config
                               type: string
                             fileName:
+                              description: FileName defines the name of the file used
+                                to store the value. Defaults to the ConfigName.
                               type: string
                             value:
+                              description: Value defines the value of the config
                               type: string
                           required:
                             - configName
                             - value
                           type: object
+                        nullable: true
                         type: array
                       name:
+                        description: Name defines the name of the interceptor
                         type: string
                     required:
                       - name
                     type: object
+                  nullable: true
                   type: array
                 istio:
+                  description: Istio defines the configurations for istio
                   properties:
                     enabled:
+                      description: Enabled defines whether to enable Istio
                       type: boolean
                     gateway:
+                      description: Gateway defines the gateway configuration The operator
+                        could either create a gateway automatically or use an existing
+                        one
                       properties:
                         create:
+                          description: Create defines whether to create a gateway
                           type: boolean
                         gateways:
+                          description: Gateways defines a list of existing gateways
                           items:
                             type: string
+                          nullable: true
                           type: array
                         selector:
                           additionalProperties:
                             type: string
+                          description: Selector defines the selector for the gateway
+                            to create
+                          nullable: true
                           type: object
                         tls:
                           properties:
                             certSecretName:
+                              description: CertSecretName defines the name of the secret
+                                that contains the certificate to use. The value should
+                                be name of the secret in the gateway workload namespace.
+                                Required in SIMPLE mode; not used in PASSTHROUGH mode.
                               type: string
                             mode:
+                              description: 'Optional: Indicates whether connections
+                              to this port should be secured using TLS. The value
+                              of this field determines how TLS is enforced.'
                               type: string
                           type: object
                       type: object
@@ -2129,26 +3992,73 @@ spec:
                 labels:
                   additionalProperties:
                     type: string
+                  description: Labels specifies the labels to attach to the stateful
+                    set created by operator for pulsar broker
+                  nullable: true
                   type: object
                 pod:
+                  description: Pod defines the policy for creating a broker pod
                   properties:
                     affinity:
+                      description: Affinity specifies the scheduling constraints of
+                        a pod
                       properties:
                         nodeAffinity:
+                          description: Describes node affinity scheduling rules for
+                            the pod.
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node matches the corresponding matchExpressions;
+                                the node(s) with the highest sum are the most preferred.
                               items:
+                                description: An empty preferred scheduling term matches
+                                  all objects with implicit weight 0 (i.e. it's a no-op).
+                                  A null preferred scheduling term matches no objects
+                                  (i.e. is also a no-op).
                                 properties:
                                   preference:
+                                    description: A node selector term, associated with
+                                      the corresponding weight.
                                     properties:
                                       matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
                                         items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2158,13 +4068,35 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
                                         items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2175,6 +4107,8 @@ spec:
                                         type: array
                                     type: object
                                   weight:
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -2183,18 +4117,53 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by
+                                this field are not met at scheduling time, the pod will
+                                not be scheduled onto the node. If the affinity requirements
+                                specified by this field cease to be met at some point
+                                during pod execution (e.g. due to an update), the system
+                                may or may not try to eventually evict the pod from
+                                its node.
                               properties:
                                 nodeSelectorTerms:
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
                                   items:
+                                    description: A null or empty node selector term
+                                      matches no objects. The requirements of them are
+                                      ANDed. The TopologySelectorTerm type implements
+                                      a subset of the NodeSelectorTerm.
                                     properties:
                                       matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
                                         items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2204,13 +4173,35 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
                                         items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2226,22 +4217,65 @@ spec:
                               type: object
                           type: object
                         podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g.
+                            co-locate this pod in the same node, zone, etc. as some
+                            other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the corresponding
+                                podAffinityTerm; the node(s) with the highest sum are
+                                the most preferred.
                               items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
                                 properties:
                                   podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
                                     properties:
                                       labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -2253,18 +4287,37 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the
+                                          pods matching the labelSelector in the specified
+                                          namespaces, where co-located is defined as
+                                          running on a node whose value of the label
+                                          with key topologyKey matches that of any node
+                                          on which any of the selected pods is running.
+                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -2273,18 +4326,56 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by
+                                this field are not met at scheduling time, the pod will
+                                not be scheduled onto the node. If the affinity requirements
+                                specified by this field cease to be met at some point
+                                during pod execution (e.g. due to a pod label update),
+                                the system may or may not try to eventually evict the
+                                pod from its node. When there are multiple elements,
+                                the lists of nodes corresponding to each podAffinityTerm
+                                are intersected, i.e. all terms must be satisfied.
                               items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or not
+                                  co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any node
+                                  on which a pod of the set of pods is running
                                 properties:
                                   labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2296,13 +4387,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -2310,22 +4417,65 @@ spec:
                               type: array
                           type: object
                         podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules
+                            (e.g. avoid putting this pod in the same node, zone, etc.
+                            as some other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the anti-affinity expressions
+                                specified by this field, but it may choose a node that
+                                violates one or more of the expressions. The node that
+                                is most preferred is the one with the greatest sum of
+                                weights, i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                anti-affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the corresponding
+                                podAffinityTerm; the node(s) with the highest sum are
+                                the most preferred.
                               items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
                                 properties:
                                   podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
                                     properties:
                                       labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -2337,18 +4487,37 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the
+                                          pods matching the labelSelector in the specified
+                                          namespaces, where co-located is defined as
+                                          running on a node whose value of the label
+                                          with key topologyKey matches that of any node
+                                          on which any of the selected pods is running.
+                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -2357,18 +4526,56 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the anti-affinity requirements specified
+                                by this field are not met at scheduling time, the pod
+                                will not be scheduled onto the node. If the anti-affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod
+                                label update), the system may or may not try to eventually
+                                evict the pod from its node. When there are multiple
+                                elements, the lists of nodes corresponding to each podAffinityTerm
+                                are intersected, i.e. all terms must be satisfied.
                               items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or not
+                                  co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any node
+                                  on which a pod of the set of pods is running
                                 properties:
                                   labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2380,13 +4587,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -2397,78 +4620,151 @@ spec:
                     annotations:
                       additionalProperties:
                         type: string
+                      description: Annotations specifies the annotations to attach to
+                        pods the operator creates
                       type: object
                     debug:
+                      description: Debug defines a switch enable debug
                       type: boolean
                     imagePullSecrets:
+                      description: ImagePullSecrets is an optional list of references
+                        to secrets in the same namespace to use for pulling any of the
+                        images used by this PodSpec.
                       items:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same namespace.
                         properties:
                           name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       type: array
                     initContainers:
+                      description: InitContainers defines init containers of the pod.
+                        A typical use case could be using an init container to download
+                        a remote jar to a local path.
                       items:
+                        description: A single application container that you want to
+                          run within a pod. The Container API from the core group is
+                          not used directly to avoid unneeded fields and reduce the
+                          size of the CRD. New fields could be added as needed.
                         properties:
                           args:
+                            description: Arguments to the entrypoint.
                             items:
                               type: string
                             type: array
                           command:
+                            description: Entrypoint array. Not executed within a shell.
                             items:
                               type: string
                             type: array
                           env:
+                            description: List of environment variables to set in the
+                              container.
                             items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
                               properties:
                                 name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previous defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  The $(VAR_NAME) syntax can be escaped with a double
+                                  $$, ie: $$(VAR_NAME). Escaped references will never
+                                  be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
                                   type: string
                                 valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
+                                          description: The key to select.
                                           type: string
                                         name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
                                           type: boolean
                                       required:
                                         - key
                                       type: object
                                     fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
                                       properties:
                                         apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
+                                          description: Path of the field to select in
+                                            the specified API version.
                                           type: string
                                       required:
                                         - fieldPath
                                       type: object
                                     resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
                                       properties:
                                         containerName:
+                                          description: 'Container name: required for
+                                          volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                             - type: integer
                                             - type: string
+                                          description: Specifies the output format of
+                                            the exposed resources, defaults to "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
+                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                         - resource
                                       type: object
                                     secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
                                       properties:
                                         key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret or
+                                            its key must be defined
                                           type: boolean
                                       required:
                                         - key
@@ -2479,52 +4775,99 @@ spec:
                               type: object
                             type: array
                           envFrom:
+                            description: List of sources to populate environment variables
+                              in the container.
                             items:
+                              description: EnvFromSource represents the source of a
+                                set of ConfigMaps
                               properties:
                                 configMapRef:
+                                  description: The ConfigMap to select from
                                   properties:
                                     name:
+                                      description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                       type: string
                                     optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
                                       type: boolean
                                   type: object
                                 prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
+                                  description: The Secret to select from
                                   properties:
                                     name:
+                                      description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                       type: string
                                     optional:
+                                      description: Specify whether the Secret must be
+                                        defined
                                       type: boolean
                                   type: object
                               type: object
                             type: array
                           image:
+                            description: Docker image name.
                             type: string
                           imagePullPolicy:
+                            description: Image pull policy.
                             type: string
                           livenessProbe:
+                            description: Periodic probe of container liveness.
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -2532,66 +4875,120 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           name:
+                            description: Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
                             type: string
                           readinessProbe:
+                            description: 'Periodic probe of container service readiness.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -2599,43 +4996,70 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           resources:
+                            description: Compute Resources required by this container.
                             properties:
                               limits:
                                 additionalProperties:
@@ -2644,6 +5068,8 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -2652,30 +5078,61 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                             type: object
                           startupProbe:
+                            description: StartupProbe indicates that the Pod has successfully
+                              initialized.
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -2683,56 +5140,103 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           volumeMounts:
+                            description: Pod volumes to mount into the container's filesystem.
                             items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
                               properties:
                                 mountPath:
+                                  description: Path within the container at which the
+                                    volume should be mounted.  Must not contain ':'.
                                   type: string
                                 mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and the
+                                    other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
+                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to false.
                                   type: boolean
                                 subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults to
+                                    "" (volume's root).
                                   type: string
                                 subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the container's
+                                    environment. Defaults to "" (volume's root). SubPathExpr
+                                    and SubPath are mutually exclusive.
                                   type: string
                               required:
                                 - mountPath
@@ -2740,12 +5244,15 @@ spec:
                               type: object
                             type: array
                           workingDir:
+                            description: Container's working directory.
                             type: string
                         required:
                           - name
                         type: object
                       type: array
                     jvmOptions:
+                      description: JvmOptions defines the Jvm options passed to the
+                        proxy
                       properties:
                         extraOptions:
                           items:
@@ -2767,12 +5274,19 @@ spec:
                     labels:
                       additionalProperties:
                         type: string
+                      description: Labels specifies the labels to attach to pod the
+                        operator creates for the cluster.
                       type: object
                     nodeSelector:
                       additionalProperties:
                         type: string
+                      description: NodeSelector specifies a map of key-value pairs.
+                        For a pod to be eligible to run on a node, the node must have
+                        each of the indicated key-value pairs as labels.
                       type: object
                     resources:
+                      description: Resources specifies the resource requirements of
+                        containers to run in the pod
                       properties:
                         limits:
                           additionalProperties:
@@ -2781,6 +5295,8 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
@@ -2789,9 +5305,15 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
                     secretRefs:
+                      description: SecretRefs defines how to mount required secrets
+                        into containers
                       items:
                         properties:
                           mountPath:
@@ -2804,51 +5326,120 @@ spec:
                         type: object
                       type: array
                     securityContext:
+                      description: 'SecurityContext specifies the security context for
+                      the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
                       properties:
                         fsGroup:
+                          description: "A special supplemental group that applies to
+                          all containers in a pod. Some volume types allow the Kubelet
+                          to change the ownership of that volume to be owned by the
+                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
+                          bit is set (new files created in the volume will be owned
+                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
+                          \n If unset, the Kubelet will not modify the ownership and
+                          permissions of any volume."
                           format: int64
                           type: integer
                         fsGroupChangePolicy:
+                          description: 'fsGroupChangePolicy defines behavior of changing
+                          ownership and permission of the volume before being exposed
+                          inside Pod. This field will only apply to volume types which
+                          support fsGroup based ownership(and permissions). It will
+                          have no effect on ephemeral volume types such as: secret,
+                          configmaps and emptydir. Valid values are "OnRootMismatch"
+                          and "Always". If not specified defaults to "Always".'
                           type: string
                         runAsGroup:
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container.
                           format: int64
                           type: integer
                         runAsNonRoot:
+                          description: Indicates that the container must run as a non-root
+                            user. If true, the Kubelet will validate the image at runtime
+                            to ensure that it does not run as UID 0 (root) and fail
+                            to start the container if it does. If unset or false, no
+                            such validation will be performed. May also be set in SecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
                           type: boolean
                         runAsUser:
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata if
+                            unspecified. May also be set in SecurityContext.  If set
+                            in both SecurityContext and PodSecurityContext, the value
+                            specified in SecurityContext takes precedence for that container.
                           format: int64
                           type: integer
                         seLinuxOptions:
+                          description: The SELinux context to be applied to all containers.
+                            If unspecified, the container runtime will allocate a random
+                            SELinux context for each container.  May also be set in
+                            SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence
+                            for that container.
                           properties:
                             level:
+                              description: Level is SELinux level label that applies
+                                to the container.
                               type: string
                             role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
                               type: string
                             type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
                               type: string
                             user:
+                              description: User is a SELinux user label that applies
+                                to the container.
                               type: string
                           type: object
                         seccompProfile:
+                          description: The seccomp options to use by the containers
+                            in this pod.
                           properties:
                             localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used. The profile must
+                                be preconfigured on the node to work. Must be a descending
+                                path, relative to the kubelet's configured seccomp profile
+                                location. Must only be set if type is "Localhost".
                               type: string
                             type:
+                              description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a
+                              profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile
+                              should be used. Unconfined - no profile should be applied."
                               type: string
                           required:
                             - type
                           type: object
                         supplementalGroups:
+                          description: A list of groups applied to the first process
+                            run in each container, in addition to the container's primary
+                            GID.  If unspecified, no groups will be added to any container.
                           items:
                             format: int64
                             type: integer
                           type: array
                         sysctls:
+                          description: Sysctls hold a list of namespaced sysctls used
+                            for the pod. Pods with unsupported sysctls (by the container
+                            runtime) might fail to launch.
                           items:
+                            description: Sysctl defines a kernel parameter to be set
                             properties:
                               name:
+                                description: Name of a property to set
                                 type: string
                               value:
+                                description: Value of a property to set
                                 type: string
                             required:
                               - name
@@ -2856,79 +5447,160 @@ spec:
                             type: object
                           type: array
                         windowsOptions:
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options within a container's
+                            SecurityContext will be used. If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
                           properties:
                             gmsaCredentialSpec:
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field.
                               type: string
                             gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
                               type: string
                             runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set in
+                                PodSecurityContext. If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
                               type: string
                           type: object
                       type: object
                     serviceAccountName:
+                      description: ServiceAccountName is the name of the ServiceAccount
+                        to use to run pods.
                       type: string
                     sidecars:
+                      description: Sidecars defines sidecar containers running alongside
+                        with the main function container in the pod.
                       items:
+                        description: A single application container that you want to
+                          run within a pod. The Container API from the core group is
+                          not used directly to avoid unneeded fields and reduce the
+                          size of the CRD. New fields could be added as needed.
                         properties:
                           args:
+                            description: Arguments to the entrypoint.
                             items:
                               type: string
                             type: array
                           command:
+                            description: Entrypoint array. Not executed within a shell.
                             items:
                               type: string
                             type: array
                           env:
+                            description: List of environment variables to set in the
+                              container.
                             items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
                               properties:
                                 name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previous defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  The $(VAR_NAME) syntax can be escaped with a double
+                                  $$, ie: $$(VAR_NAME). Escaped references will never
+                                  be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
                                   type: string
                                 valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
+                                          description: The key to select.
                                           type: string
                                         name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
                                           type: boolean
                                       required:
                                         - key
                                       type: object
                                     fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
                                       properties:
                                         apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
+                                          description: Path of the field to select in
+                                            the specified API version.
                                           type: string
                                       required:
                                         - fieldPath
                                       type: object
                                     resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
                                       properties:
                                         containerName:
+                                          description: 'Container name: required for
+                                          volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                             - type: integer
                                             - type: string
+                                          description: Specifies the output format of
+                                            the exposed resources, defaults to "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
+                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                         - resource
                                       type: object
                                     secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
                                       properties:
                                         key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret or
+                                            its key must be defined
                                           type: boolean
                                       required:
                                         - key
@@ -2939,52 +5611,99 @@ spec:
                               type: object
                             type: array
                           envFrom:
+                            description: List of sources to populate environment variables
+                              in the container.
                             items:
+                              description: EnvFromSource represents the source of a
+                                set of ConfigMaps
                               properties:
                                 configMapRef:
+                                  description: The ConfigMap to select from
                                   properties:
                                     name:
+                                      description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                       type: string
                                     optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
                                       type: boolean
                                   type: object
                                 prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
+                                  description: The Secret to select from
                                   properties:
                                     name:
+                                      description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                       type: string
                                     optional:
+                                      description: Specify whether the Secret must be
+                                        defined
                                       type: boolean
                                   type: object
                               type: object
                             type: array
                           image:
+                            description: Docker image name.
                             type: string
                           imagePullPolicy:
+                            description: Image pull policy.
                             type: string
                           livenessProbe:
+                            description: Periodic probe of container liveness.
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -2992,66 +5711,120 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           name:
+                            description: Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
                             type: string
                           readinessProbe:
+                            description: 'Periodic probe of container service readiness.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -3059,43 +5832,70 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           resources:
+                            description: Compute Resources required by this container.
                             properties:
                               limits:
                                 additionalProperties:
@@ -3104,6 +5904,8 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -3112,30 +5914,61 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                             type: object
                           startupProbe:
+                            description: StartupProbe indicates that the Pod has successfully
+                              initialized.
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -3143,56 +5976,103 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           volumeMounts:
+                            description: Pod volumes to mount into the container's filesystem.
                             items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
                               properties:
                                 mountPath:
+                                  description: Path within the container at which the
+                                    volume should be mounted.  Must not contain ':'.
                                   type: string
                                 mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and the
+                                    other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
+                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to false.
                                   type: boolean
                                 subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults to
+                                    "" (volume's root).
                                   type: string
                                 subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the container's
+                                    environment. Defaults to "" (volume's root). SubPathExpr
+                                    and SubPath are mutually exclusive.
                                   type: string
                               required:
                                 - mountPath
@@ -3200,81 +6080,158 @@ spec:
                               type: object
                             type: array
                           workingDir:
+                            description: Container's working directory.
                             type: string
                         required:
                           - name
                         type: object
                       type: array
                     terminationGracePeriodSeconds:
+                      description: TerminationGracePeriodSeconds is the amount of time
+                        that kubernetes will give for a pod before terminating it.
                       format: int64
                       type: integer
                     tolerations:
+                      description: Tolerations specifies the tolerations of a Pod
                       items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
                         properties:
                           effect:
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified, allowed
+                              values are NoSchedule, PreferNoSchedule and NoExecute.
                             type: string
                           key:
+                            description: Key is the taint key that the toleration applies
+                              to. Empty means match all taint keys. If the key is empty,
+                              operator must be Exists; this combination means to match
+                              all values and all keys.
                             type: string
                           operator:
+                            description: Operator represents a key's relationship to
+                              the value. Valid operators are Exists and Equal. Defaults
+                              to Equal. Exists is equivalent to wildcard for value,
+                              so that a pod can tolerate all taints of a particular
+                              category.
                             type: string
                           tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the taint
+                              forever (do not evict). Zero and negative values will
+                              be treated as 0 (evict immediately) by the system.
                             format: int64
                             type: integer
                           value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
                             type: string
                         type: object
                       type: array
                     vars:
+                      description: Vars specifies the environment variables of a Pod
                       items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
                         properties:
                           name:
+                            description: Name of the environment variable. Must be a
+                              C_IDENTIFIER.
                             type: string
                           value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
                             type: string
                           valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
                                 properties:
                                   key:
+                                    description: The key to select.
                                     type: string
                                   name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                     type: string
                                   optional:
+                                    description: Specify whether the ConfigMap or its
+                                      key must be defined
                                     type: boolean
                                 required:
                                   - key
                                 type: object
                               fieldRef:
+                                description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
                                 properties:
                                   apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
                                     type: string
                                 required:
                                   - fieldPath
                                 type: object
                               resourceFieldRef:
+                                description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
                                 properties:
                                   containerName:
+                                    description: 'Container name: required for volumes,
+                                    optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
+                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                   - resource
                                 type: object
                               secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
                                 properties:
                                   key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
                                     type: string
                                   name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                     type: string
                                   optional:
+                                    description: Specify whether the Secret or its key
+                                      must be defined
                                     type: boolean
                                 required:
                                   - key
@@ -3285,22 +6242,66 @@ spec:
                         type: object
                       type: array
                     volumes:
+                      description: Volumes defines extra volumes of the pod.
                       items:
+                        description: Volume represents a named volume in a pod that
+                          may be accessed by any container in the pod. The Volume API
+                          from the core group is not used directly to avoid unneeded
+                          fields defined in `VolumeSource` and reduce the size of the
+                          CRD. New fields in VolumeSource could be added as needed.
                         properties:
                           configMap:
+                            description: ConfigMap represents a configMap that should
+                              populate this volume
                             properties:
                               defaultMode:
+                                description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0
+                                and 511. YAML accepts both octal and decimal values,
+                                JSON requires decimal values for mode bits. Defaults
+                                to 0644. Directories within the path are not affected
+                                by this setting. This might be in conflict with other
+                                options that affect the file mode, like fsGroup, and
+                                the result can be other mode bits set.'
                                 format: int32
                                 type: integer
                               items:
+                                description: If unspecified, each key-value pair in
+                                  the Data field of the referenced ConfigMap will be
+                                  projected into the volume as a file whose name is
+                                  the key and content is the value. If specified, the
+                                  listed keys will be projected into the specified paths,
+                                  and unlisted keys will not be present. If a key is
+                                  specified which is not present in the ConfigMap, the
+                                  volume setup will error unless it is marked optional.
+                                  Paths must be relative and may not contain the '..'
+                                  path or start with '..'.
                                 items:
+                                  description: Maps a string key to a path within a
+                                    volume.
                                   properties:
                                     key:
+                                      description: The key to project.
                                       type: string
                                     mode:
+                                      description: 'Optional: mode bits used to set
+                                      permissions on this file. Must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
                                       format: int32
                                       type: integer
                                     path:
+                                      description: The relative path of the file to
+                                        map the key to. May not be an absolute path.
+                                        May not contain the path element '..'. May not
+                                        start with the string '..'.
                                       type: string
                                   required:
                                     - key
@@ -3308,26 +6309,70 @@ spec:
                                   type: object
                                 type: array
                               name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
+                                description: Specify whether the ConfigMap or its keys
+                                  must be defined
                                 type: boolean
                             type: object
                           name:
+                            description: 'Volume''s name. Must be a DNS_LABEL and unique
+                            within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
                           secret:
+                            description: Secret represents a secret that should populate
+                              this volume.
                             properties:
                               defaultMode:
+                                description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0
+                                and 511. YAML accepts both octal and decimal values,
+                                JSON requires decimal values for mode bits. Defaults
+                                to 0644. Directories within the path are not affected
+                                by this setting. This might be in conflict with other
+                                options that affect the file mode, like fsGroup, and
+                                the result can be other mode bits set.'
                                 format: int32
                                 type: integer
                               items:
+                                description: If unspecified, each key-value pair in
+                                  the Data field of the referenced Secret will be projected
+                                  into the volume as a file whose name is the key and
+                                  content is the value. If specified, the listed keys
+                                  will be projected into the specified paths, and unlisted
+                                  keys will not be present. If a key is specified which
+                                  is not present in the Secret, the volume setup will
+                                  error unless it is marked optional. Paths must be
+                                  relative and may not contain the '..' path or start
+                                  with '..'.
                                 items:
+                                  description: Maps a string key to a path within a
+                                    volume.
                                   properties:
                                     key:
+                                      description: The key to project.
                                       type: string
                                     mode:
+                                      description: 'Optional: mode bits used to set
+                                      permissions on this file. Must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
                                       format: int32
                                       type: integer
                                     path:
+                                      description: The relative path of the file to
+                                        map the key to. May not be an absolute path.
+                                        May not contain the path element '..'. May not
+                                        start with the string '..'.
                                       type: string
                                   required:
                                     - key
@@ -3335,8 +6380,12 @@ spec:
                                   type: object
                                 type: array
                               optional:
+                                description: Specify whether the Secret or its keys
+                                  must be defined
                                 type: boolean
                               secretName:
+                                description: 'Name of the secret in the pod''s namespace
+                                to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                 type: string
                             type: object
                         required:
@@ -3345,19 +6394,26 @@ spec:
                       type: array
                   type: object
                 replicas:
+                  description: Replicas is the expected size of the pulsar broker
                   format: int32
                   type: integer
                 zkServers:
+                  description: Zookeeper server list
                   type: string
               required:
                 - zkServers
               type: object
             status:
+              description: PulsarBrokerStatus defines the observed state of PulsarBroker
               properties:
                 conditions:
                   additionalProperties:
+                    description: The `Status` of a given `Condition` and the `Action`
+                      needed to reach the `Status`
                     properties:
                       action:
+                        description: The action needed to advance components to ready
+                          status
                         type: string
                       condition:
                         type: string
@@ -3368,16 +6424,25 @@ spec:
                       - condition
                       - status
                     type: object
+                  description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of Broker Important: Run "make" to regenerate code after modifying
+                  this file'
                   type: object
                 labelSelector:
+                  description: Label selector for scaling
                   type: string
                 observedGeneration:
+                  description: ObservedGeneration is the most recent generation observed
+                    for this cluster. It corresponds to the metadata generation, which
+                    is updated on mutation by the API Server.
                   format: int64
                   type: integer
                 readyReplicas:
+                  description: ReadyReplicas is the number of ready servers in the cluster
                   format: int32
                   type: integer
                 replicas:
+                  description: Replicas is the number of servers in the cluster
                   format: int32
                   type: integer
                 serviceEndpoints:
@@ -3398,6 +6463,8 @@ spec:
                       type: object
                   type: object
                 updatedReplicas:
+                  description: UpdatedReplicas is the number of servers that has been
+                    updated to the latest configuration
                   format: int32
                   type: integer
               required:

--- a/charts/pulsar-operator/crds/pulsar.streamnative.io_pulsarproxies.yaml
+++ b/charts/pulsar-operator/crds/pulsar.streamnative.io_pulsarproxies.yaml
@@ -40,176 +40,296 @@ spec:
       name: v1alpha1
       schema:
         openAPIV3Schema:
+          description: PulsarProxy is the Schema for the pulsarproxies API
           properties:
             apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
             spec:
+              description: PulsarProxySpec defines the desired state of PulsarProxy
               properties:
                 apiObjects:
+                  description: APIObjects allows precise control over how components
+                    (services, statefulset and so on) should be managed
                   properties:
                     externalService:
+                      description: ExternalService defines the Pulsar Proxy external
+                        service resource template.
                       properties:
                         exposeSSLPort:
+                          description: ExposeSSLPort will be used to export SSL service
+                            port even when proxy tls is disabled, it's useful when we
+                            want to terminate tls at external load balancer and forward
+                            plain text request to proxy If it is true, the service port
+                            will be 443, 6651 otherwise, the service port will be 8080,
+                            6650
                           type: boolean
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         ports:
+                          description: Ports will be used to replace existing port or
+                            create new port The default non tls service port is 6650,
+                            8080 when the type is NodePort, if you want to to expose
+                            proxy port 6650 and 8080 to a specific node port
                           items:
+                            description: ServicePort contains information on service's
+                              port.
                             properties:
                               name:
+                                description: The name of this port within the service.
                                 type: string
                               nodePort:
+                                description: The port on each node on which this service
+                                  is exposed when type is NodePort
                                 format: int32
                                 type: integer
                               port:
+                                description: The port that will be exposed by this service.
                                 format: int32
                                 type: integer
                               targetPort:
+                                description: Number or name of the port to access on
+                                  the pods targeted by the service. When add new service
+                                  port, it shouldn't be empty
                                 format: int32
                                 type: integer
                             type: object
                           type: array
                         type:
+                          description: Type indicates the external service type, LoadBalancer,
+                            NodePort, ClusterIP default is LoadBalancer for backward
+                            compatibility
                           type: string
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     headlessService:
+                      description: HeadlessService defines the Pulsar Proxy headless
+                        service resource template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     hpa:
+                      description: HPA defines the horizontalPodAutoscaler resource
+                        template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     pdb:
+                      description: PDB defines the PodDisruptionBudget resource template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     proxyConfigMap:
+                      description: ProxyConfigMap defines the Pulsar proxy ConfigMap
+                        resource template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     statefulSet:
+                      description: StatefulSet defines the StatefulSet resource template
+                        for broker.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          the name, labels, annotations of the object. More info:
+                          https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                         volumeClaimTemplates:
+                          description: VolumeClaimTemplates is a list of claims that
+                            pods are allowed to reference. If a non-empty list is specified,
+                            the original values in the desired STS will be replaced.
                           items:
+                            description: PersistentVolumeClaim is a user's request for
+                              and claim to a persistent volume
                             properties:
                               apiVersion:
+                                description: 'APIVersion defines the versioned schema
+                                of this representation of an object. Servers should
+                                convert recognized schemas to the latest internal
+                                value, and may reject unrecognized values. More info:
+                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                                 type: string
                               kind:
+                                description: 'Kind is a string value representing the
+                                REST resource this object represents. Servers may
+                                infer this from the endpoint the client submits requests
+                                to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                 type: string
                               metadata:
+                                description: 'Standard object''s metadata. More info:
+                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                                 properties:
                                   annotations:
                                     additionalProperties:
@@ -229,24 +349,55 @@ spec:
                                     type: string
                                 type: object
                               spec:
+                                description: 'Spec defines the desired characteristics
+                                of a volume requested by a pod author. More info:
+                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                 properties:
                                   accessModes:
+                                    description: 'AccessModes contains the desired access
+                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                     items:
                                       type: string
                                     type: array
                                   dataSource:
+                                    description: 'This field can be used to specify
+                                    either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                                    - Beta) * An existing PVC (PersistentVolumeClaim)
+                                    * An existing custom resource/object that implements
+                                    data population (Alpha) In order to use VolumeSnapshot
+                                    object types, the appropriate feature gate must
+                                    be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
+                                    If the provisioner or an external controller can
+                                    support the specified data source, it will create
+                                    a new volume based on the contents of the specified
+                                    data source. If the specified data source is not
+                                    supported, the volume will not be created and
+                                    the failure will be reported as an event. In the
+                                    future, we plan to support more data source types
+                                    and the behavior of the provisioner may change.'
                                     properties:
                                       apiGroup:
+                                        description: APIGroup is the group for the resource
+                                          being referenced. If APIGroup is not specified,
+                                          the specified Kind must be in the core API
+                                          group. For any other third-party types, APIGroup
+                                          is required.
                                         type: string
                                       kind:
+                                        description: Kind is the type of resource being
+                                          referenced
                                         type: string
                                       name:
+                                        description: Name is the name of resource being
+                                          referenced
                                         type: string
                                     required:
                                       - kind
                                       - name
                                     type: object
                                   resources:
+                                    description: 'Resources represents the minimum resources
+                                    the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -255,6 +406,8 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum amount
+                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -263,18 +416,46 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum
+                                        amount of compute resources required. If Requests
+                                        is omitted for a container, it defaults to
+                                        Limits if that is explicitly specified, otherwise
+                                        to an implementation-defined value. More info:
+                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   selector:
+                                    description: A label query over volumes to consider
+                                      for binding.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -286,18 +467,37 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   storageClassName:
+                                    description: 'Name of the StorageClass required
+                                    by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                     type: string
                                   volumeMode:
+                                    description: volumeMode defines what type of volume
+                                      is required by the claim. Value of Filesystem
+                                      is implied when not included in claim spec.
                                     type: string
                                   volumeName:
+                                    description: VolumeName is the binding reference
+                                      to the PersistentVolume backing this claim.
                                     type: string
                                 type: object
                               status:
+                                description: 'Status represents the current information/status
+                                of a persistent volume claim. Read-only. More info:
+                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                 properties:
                                   accessModes:
+                                    description: 'AccessModes contains the actual access
+                                    modes the volume backing the PVC has. More info:
+                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                     items:
                                       type: string
                                     type: array
@@ -308,23 +508,43 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: Represents the actual resources of
+                                      the underlying volume.
                                     type: object
                                   conditions:
+                                    description: Current Condition of persistent volume
+                                      claim. If underlying persistent volume is being
+                                      resized then the Condition will be set to 'ResizeStarted'.
                                     items:
+                                      description: PersistentVolumeClaimCondition contails
+                                        details about state of pvc
                                       properties:
                                         lastProbeTime:
+                                          description: Last time we probed the condition.
                                           format: date-time
                                           type: string
                                         lastTransitionTime:
+                                          description: Last time the condition transitioned
+                                            from one status to another.
                                           format: date-time
                                           type: string
                                         message:
+                                          description: Human-readable message indicating
+                                            details about last transition.
                                           type: string
                                         reason:
+                                          description: Unique, this should be a short,
+                                            machine understandable string that gives
+                                            the reason for condition's last transition.
+                                            If it reports "ResizeStarted" that means
+                                            the underlying persistent volume is being
+                                            resized.
                                           type: string
                                         status:
                                           type: string
                                         type:
+                                          description: PersistentVolumeClaimConditionType
+                                            is a valid value of PersistentVolumeClaimCondition.Type
                                           type: string
                                       required:
                                         - status
@@ -332,24 +552,50 @@ spec:
                                       type: object
                                     type: array
                                   phase:
+                                    description: Phase represents the current phase
+                                      of PersistentVolumeClaim.
                                     type: string
                                 type: object
                             type: object
                           type: array
                         volumeMounts:
+                          description: VolumeMounts is a list of volumes to mount into
+                            the container's filesystem. If a non-empty list is specified,
+                            the original values of the main container in the desired
+                            STS will be replaced.
                           items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
                             properties:
                               mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
                                 type: string
                               mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
                                 type: string
                               name:
+                                description: This must match the Name of a Volume.
                                 type: string
                               readOnly:
+                                description: Mounted read-only if true, read-write otherwise
+                                  (false or unspecified). Defaults to false.
                                 type: boolean
                               subPath:
+                                description: Path within the volume from which the container's
+                                  volume should be mounted. Defaults to "" (volume's
+                                  root).
                                 type: string
                               subPathExpr:
+                                description: Expanded path within the volume from which
+                                  the container's volume should be mounted. Behaves
+                                  similarly to SubPath but environment variable references
+                                  $(VAR_NAME) are expanded using the container's environment.
+                                  Defaults to "" (volume's root). SubPathExpr and SubPath
+                                  are mutually exclusive.
                                 type: string
                             required:
                               - mountPath
@@ -358,43 +604,81 @@ spec:
                           type: array
                       type: object
                     websocketConfigMap:
+                      description: WebSocketConfigMap defines the Pulsar WebSocket ConfigMap
+                        resource template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                   type: object
                 autoScalingPolicy:
+                  description: AutoScalingPolicy defines how BookKeeperCluster will
+                    be scaled up/down with given metrics and threshold
                   properties:
                     behavior:
+                      description: Behavior configures the scaling behavior of the target
+                        in both Up and Down directions (scaleUp and scaleDown fields
+                        respectively). If not set, the default HPAScalingRules for scale
+                        up and scale down are used.
                       properties:
                         scaleDown:
+                          description: scaleDown is scaling policy for scaling Down.
+                            If not set, the default value is to allow to scale down
+                            to minReplicas pods, with a 300 second stabilization window
+                            (i.e., the highest recommendation for the last 300sec is
+                            used).
                           properties:
                             policies:
+                              description: policies is a list of potential scaling polices
+                                which can be used during scaling. At least one policy
+                                must be specified, otherwise the HPAScalingRules will
+                                be discarded as invalid
                               items:
+                                description: HPAScalingPolicy is a single policy which
+                                  must hold true for a specified past interval.
                                 properties:
                                   periodSeconds:
+                                    description: PeriodSeconds specifies the window
+                                      of time for which the policy should hold true.
+                                      PeriodSeconds must be greater than zero and less
+                                      than or equal to 1800 (30 min).
                                     format: int32
                                     type: integer
                                   type:
+                                    description: Type is used to specify the scaling
+                                      policy.
                                     type: string
                                   value:
+                                    description: Value contains the amount of change
+                                      which is permitted by the policy. It must be greater
+                                      than zero
                                     format: int32
                                     type: integer
                                 required:
@@ -404,22 +688,52 @@ spec:
                                 type: object
                               type: array
                             selectPolicy:
+                              description: selectPolicy is used to specify which policy
+                                should be used. If not set, the default value MaxPolicySelect
+                                is used.
                               type: string
                             stabilizationWindowSeconds:
+                              description: 'StabilizationWindowSeconds is the number
+                              of seconds for which past recommendations should be
+                              considered while scaling up or scaling down. StabilizationWindowSeconds
+                              must be greater than or equal to zero and less than
+                              or equal to 3600 (one hour). If not set, use the default
+                              values: - For scale up: 0 (i.e. no stabilization is
+                              done). - For scale down: 300 (i.e. the stabilization
+                              window is 300 seconds long).'
                               format: int32
                               type: integer
                           type: object
                         scaleUp:
+                          description: 'scaleUp is scaling policy for scaling Up. If
+                          not set, the default value is the higher of:   * increase
+                          no more than 4 pods per 60 seconds   * double the number
+                          of pods per 60 seconds No stabilization is used.'
                           properties:
                             policies:
+                              description: policies is a list of potential scaling polices
+                                which can be used during scaling. At least one policy
+                                must be specified, otherwise the HPAScalingRules will
+                                be discarded as invalid
                               items:
+                                description: HPAScalingPolicy is a single policy which
+                                  must hold true for a specified past interval.
                                 properties:
                                   periodSeconds:
+                                    description: PeriodSeconds specifies the window
+                                      of time for which the policy should hold true.
+                                      PeriodSeconds must be greater than zero and less
+                                      than or equal to 1800 (30 min).
                                     format: int32
                                     type: integer
                                   type:
+                                    description: Type is used to specify the scaling
+                                      policy.
                                     type: string
                                   value:
+                                    description: Value contains the amount of change
+                                      which is permitted by the policy. It must be greater
+                                      than zero
                                     format: int32
                                     type: integer
                                 required:
@@ -429,8 +743,19 @@ spec:
                                 type: object
                               type: array
                             selectPolicy:
+                              description: selectPolicy is used to specify which policy
+                                should be used. If not set, the default value MaxPolicySelect
+                                is used.
                               type: string
                             stabilizationWindowSeconds:
+                              description: 'StabilizationWindowSeconds is the number
+                              of seconds for which past recommendations should be
+                              considered while scaling up or scaling down. StabilizationWindowSeconds
+                              must be greater than or equal to zero and less than
+                              or equal to 3600 (one hour). If not set, use the default
+                              values: - For scale up: 0 (i.e. no stabilization is
+                              done). - For scale down: 300 (i.e. the stabilization
+                              window is 300 seconds long).'
                               format: int32
                               type: integer
                           type: object
@@ -439,24 +764,64 @@ spec:
                       format: int32
                       type: integer
                     metrics:
+                      description: 'Metrics contains the specifications for which to
+                      use to calculate the desired replica count (the maximum replica
+                      count across all metrics will be used). More info: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling'
                       items:
+                        description: MetricSpec specifies how to scale based on a single
+                          metric (only `type` and one other matching field should be
+                          set at once).
                         properties:
                           external:
+                            description: external refers to a global metric that is
+                              not associated with any Kubernetes object. It allows autoscaling
+                              based on information coming from components running outside
+                              of cluster (for example length of queue in cloud messaging
+                              service, or QPS from loadbalancer running outside of cluster).
                             properties:
                               metric:
+                                description: metric identifies the target metric by
+                                  name and selector
                                 properties:
                                   name:
+                                    description: name is the name of the given metric
                                     type: string
                                   selector:
+                                    description: selector is the string-encoded form
+                                      of a standard kubernetes label selector for the
+                                      given metric When set, it is passed as an additional
+                                      parameter to the metrics server for more specific
+                                      metrics scoping. When unset, just the metricName
+                                      will be used to gather metrics.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -468,28 +833,49 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                 required:
                                   - name
                                 type: object
                               target:
+                                description: target specifies the target value for the
+                                  given metric
                                 properties:
                                   averageUtilization:
+                                    description: averageUtilization is the target value
+                                      of the average of the resource metric across all
+                                      relevant pods, represented as a percentage of
+                                      the requested value of the resource for the pods.
+                                      Currently only valid for Resource metric source
+                                      type
                                     format: int32
                                     type: integer
                                   averageValue:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: averageValue is the target value of
+                                      the average of the metric across all relevant
+                                      pods (as a quantity)
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type:
+                                    description: type represents whether the metric
+                                      type is Utilization, Value, or AverageValue
                                     type: string
                                   value:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: value is the target value of the metric
+                                      (as a quantity).
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 required:
@@ -500,33 +886,70 @@ spec:
                               - target
                             type: object
                           object:
+                            description: object refers to a metric describing a single
+                              kubernetes object (for example, hits-per-second on an
+                              Ingress object).
                             properties:
                               describedObject:
+                                description: CrossVersionObjectReference contains enough
+                                  information to let you identify the referred resource.
                                 properties:
                                   apiVersion:
+                                    description: API version of the referent
                                     type: string
                                   kind:
+                                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
                                     type: string
                                   name:
+                                    description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                                     type: string
                                 required:
                                   - kind
                                   - name
                                 type: object
                               metric:
+                                description: metric identifies the target metric by
+                                  name and selector
                                 properties:
                                   name:
+                                    description: name is the name of the given metric
                                     type: string
                                   selector:
+                                    description: selector is the string-encoded form
+                                      of a standard kubernetes label selector for the
+                                      given metric When set, it is passed as an additional
+                                      parameter to the metrics server for more specific
+                                      metrics scoping. When unset, just the metricName
+                                      will be used to gather metrics.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -538,28 +961,49 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                 required:
                                   - name
                                 type: object
                               target:
+                                description: target specifies the target value for the
+                                  given metric
                                 properties:
                                   averageUtilization:
+                                    description: averageUtilization is the target value
+                                      of the average of the resource metric across all
+                                      relevant pods, represented as a percentage of
+                                      the requested value of the resource for the pods.
+                                      Currently only valid for Resource metric source
+                                      type
                                     format: int32
                                     type: integer
                                   averageValue:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: averageValue is the target value of
+                                      the average of the metric across all relevant
+                                      pods (as a quantity)
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type:
+                                    description: type represents whether the metric
+                                      type is Utilization, Value, or AverageValue
                                     type: string
                                   value:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: value is the target value of the metric
+                                      (as a quantity).
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 required:
@@ -571,21 +1015,54 @@ spec:
                               - target
                             type: object
                           pods:
+                            description: pods refers to a metric describing each pod
+                              in the current scale target (for example, transactions-processed-per-second).  The
+                              values will be averaged together before being compared
+                              to the target value.
                             properties:
                               metric:
+                                description: metric identifies the target metric by
+                                  name and selector
                                 properties:
                                   name:
+                                    description: name is the name of the given metric
                                     type: string
                                   selector:
+                                    description: selector is the string-encoded form
+                                      of a standard kubernetes label selector for the
+                                      given metric When set, it is passed as an additional
+                                      parameter to the metrics server for more specific
+                                      metrics scoping. When unset, just the metricName
+                                      will be used to gather metrics.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -597,28 +1074,49 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                 required:
                                   - name
                                 type: object
                               target:
+                                description: target specifies the target value for the
+                                  given metric
                                 properties:
                                   averageUtilization:
+                                    description: averageUtilization is the target value
+                                      of the average of the resource metric across all
+                                      relevant pods, represented as a percentage of
+                                      the requested value of the resource for the pods.
+                                      Currently only valid for Resource metric source
+                                      type
                                     format: int32
                                     type: integer
                                   averageValue:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: averageValue is the target value of
+                                      the average of the metric across all relevant
+                                      pods (as a quantity)
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type:
+                                    description: type represents whether the metric
+                                      type is Utilization, Value, or AverageValue
                                     type: string
                                   value:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: value is the target value of the metric
+                                      (as a quantity).
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 required:
@@ -629,26 +1127,48 @@ spec:
                               - target
                             type: object
                           resource:
+                            description: resource refers to a resource metric (such
+                              as those specified in requests and limits) known to Kubernetes
+                              describing each pod in the current scale target (e.g.
+                              CPU or memory). Such metrics are built in to Kubernetes,
+                              and have special scaling options on top of those available
+                              to normal per-pod metrics using the "pods" source.
                             properties:
                               name:
+                                description: name is the name of the resource in question.
                                 type: string
                               target:
+                                description: target specifies the target value for the
+                                  given metric
                                 properties:
                                   averageUtilization:
+                                    description: averageUtilization is the target value
+                                      of the average of the resource metric across all
+                                      relevant pods, represented as a percentage of
+                                      the requested value of the resource for the pods.
+                                      Currently only valid for Resource metric source
+                                      type
                                     format: int32
                                     type: integer
                                   averageValue:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: averageValue is the target value of
+                                      the average of the metric across all relevant
+                                      pods (as a quantity)
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type:
+                                    description: type represents whether the metric
+                                      type is Utilization, Value, or AverageValue
                                     type: string
                                   value:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: value is the target value of the metric
+                                      (as a quantity).
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 required:
@@ -659,6 +1179,9 @@ spec:
                               - target
                             type: object
                           type:
+                            description: type is the type of metric source.  It should
+                              be one of "Object", "Pods" or "Resource", each mapping
+                              to a matching field in the object.
                             type: string
                         required:
                           - type
@@ -671,49 +1194,92 @@ spec:
                     - maxReplicas
                   type: object
                 brokerAddress:
+                  description: The address of the broker
                   type: string
                 certSecretName:
+                  description: CertSecretName defines the name of the secret that contains
+                    the certificate to use in the proxy if the value is not set, then
+                    the operator create an certificate automatically if the value is
+                    set to be an empty string, then the proxy will not use a certificate
+                    otherwise the value should be name of the secret that contains a
+                    valid certificate to use in the proxy
                   type: string
                 config:
+                  description: Config defines configurations for proxies
                   properties:
                     clusterName:
+                      description: ClusterName defines name of the Pulsar cluster.
                       type: string
                     custom:
                       additionalProperties:
                         type: string
+                      description: Custom allows to customize broker configurations
+                        directly.
+                      nullable: true
                       type: object
                     prometheusPlugin:
+                      description: PrometheusPlugin defines the configuration of the
+                        Prometheus servlet plugin which could be used to query the Prometheus
+                        cluster deployed alongside the proxy cluster.
                       properties:
                         host:
+                          description: Host defines the host of the Prometheus service
                           type: string
                       type: object
                     tls:
+                      description: TLS defines the configuration of TLS in proxies
                       properties:
                         certSecretName:
+                          description: CertSecretName defines the name of the secret
+                            that contains the certificate to use the value should be
+                            name of the secret that contains a valid certificate to
+                            use in the proxy
                           type: string
                         enabled:
+                          description: Enabled determines whether to enable TLS in proxies
+                            TODO move other TLS related fields here
                           type: boolean
                         trustCertsEnabled:
+                          description: TrustCertsEnabled defines whether to enable trust
+                            store
                           type: boolean
                       type: object
                     usePodIPAsAdvertisedAddress:
+                      description: UsePodIPAsAdvertisedAddress use pod ip as advertise
+                        address.
                       type: boolean
                   type: object
                 configs:
                   additionalProperties:
                     type: string
+                  description: Configs defines custom configurations for proxies
+                  nullable: true
                   type: object
                 configurationStoreServers:
+                  description: ConfigurationStoreServers defines the configuration store
+                    servers address
                   type: string
                 dnsNames:
+                  description: A list of service urls this pulsar proxy advertise
                   items:
                     type: string
                   type: array
                 image:
+                  description: Image is the container image used to run pulsar proxy
+                    pods. default is apachepulsar/pulsar:latest
                   type: string
                 imagePullPolicy:
+                  description: Image pull policy, one of Always, Never, IfNotPresent,
+                    default to Always.
                   type: string
                 issuerRef:
+                  description: IssuerRef is a reference to the issuer for the TLS endpoint.  If
+                    the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                    with the given name in the same namespace as the PulsarProxy will
+                    be used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                    with the provided name will be used. The 'name' field in this stanza
+                    is required at all times. The group field refers to the API group
+                    of the issuer which defaults to 'cert-manager.io' if empty.
                   properties:
                     group:
                       type: string
@@ -725,33 +1291,82 @@ spec:
                     - name
                   type: object
                 istio:
+                  description: Istio defines the configurations for istio
                   properties:
                     enabled:
+                      description: Enabled defines whether to enable Istio
                       type: boolean
                   type: object
                 labels:
                   additionalProperties:
                     type: string
+                  description: Labels specifies the labels to attach to the stateful
+                    set created by operator for pulsar proxy
+                  nullable: true
                   type: object
                 pod:
+                  description: Pod defines the policy for creating a proxy pod
                   properties:
                     affinity:
+                      description: Affinity specifies the scheduling constraints of
+                        a pod
                       properties:
                         nodeAffinity:
+                          description: Describes node affinity scheduling rules for
+                            the pod.
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node matches the corresponding matchExpressions;
+                                the node(s) with the highest sum are the most preferred.
                               items:
+                                description: An empty preferred scheduling term matches
+                                  all objects with implicit weight 0 (i.e. it's a no-op).
+                                  A null preferred scheduling term matches no objects
+                                  (i.e. is also a no-op).
                                 properties:
                                   preference:
+                                    description: A node selector term, associated with
+                                      the corresponding weight.
                                     properties:
                                       matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
                                         items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -761,13 +1376,35 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
                                         items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -778,6 +1415,8 @@ spec:
                                         type: array
                                     type: object
                                   weight:
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -786,18 +1425,53 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by
+                                this field are not met at scheduling time, the pod will
+                                not be scheduled onto the node. If the affinity requirements
+                                specified by this field cease to be met at some point
+                                during pod execution (e.g. due to an update), the system
+                                may or may not try to eventually evict the pod from
+                                its node.
                               properties:
                                 nodeSelectorTerms:
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
                                   items:
+                                    description: A null or empty node selector term
+                                      matches no objects. The requirements of them are
+                                      ANDed. The TopologySelectorTerm type implements
+                                      a subset of the NodeSelectorTerm.
                                     properties:
                                       matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
                                         items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -807,13 +1481,35 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
                                         items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -829,22 +1525,65 @@ spec:
                               type: object
                           type: object
                         podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g.
+                            co-locate this pod in the same node, zone, etc. as some
+                            other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the corresponding
+                                podAffinityTerm; the node(s) with the highest sum are
+                                the most preferred.
                               items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
                                 properties:
                                   podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
                                     properties:
                                       labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -856,18 +1595,37 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the
+                                          pods matching the labelSelector in the specified
+                                          namespaces, where co-located is defined as
+                                          running on a node whose value of the label
+                                          with key topologyKey matches that of any node
+                                          on which any of the selected pods is running.
+                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -876,18 +1634,56 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by
+                                this field are not met at scheduling time, the pod will
+                                not be scheduled onto the node. If the affinity requirements
+                                specified by this field cease to be met at some point
+                                during pod execution (e.g. due to a pod label update),
+                                the system may or may not try to eventually evict the
+                                pod from its node. When there are multiple elements,
+                                the lists of nodes corresponding to each podAffinityTerm
+                                are intersected, i.e. all terms must be satisfied.
                               items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or not
+                                  co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any node
+                                  on which a pod of the set of pods is running
                                 properties:
                                   labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -899,13 +1695,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -913,22 +1725,65 @@ spec:
                               type: array
                           type: object
                         podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules
+                            (e.g. avoid putting this pod in the same node, zone, etc.
+                            as some other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the anti-affinity expressions
+                                specified by this field, but it may choose a node that
+                                violates one or more of the expressions. The node that
+                                is most preferred is the one with the greatest sum of
+                                weights, i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                anti-affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the corresponding
+                                podAffinityTerm; the node(s) with the highest sum are
+                                the most preferred.
                               items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
                                 properties:
                                   podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
                                     properties:
                                       labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -940,18 +1795,37 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the
+                                          pods matching the labelSelector in the specified
+                                          namespaces, where co-located is defined as
+                                          running on a node whose value of the label
+                                          with key topologyKey matches that of any node
+                                          on which any of the selected pods is running.
+                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -960,18 +1834,56 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the anti-affinity requirements specified
+                                by this field are not met at scheduling time, the pod
+                                will not be scheduled onto the node. If the anti-affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod
+                                label update), the system may or may not try to eventually
+                                evict the pod from its node. When there are multiple
+                                elements, the lists of nodes corresponding to each podAffinityTerm
+                                are intersected, i.e. all terms must be satisfied.
                               items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or not
+                                  co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any node
+                                  on which a pod of the set of pods is running
                                 properties:
                                   labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -983,13 +1895,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -1000,78 +1928,151 @@ spec:
                     annotations:
                       additionalProperties:
                         type: string
+                      description: Annotations specifies the annotations to attach to
+                        pods the operator creates
                       type: object
                     debug:
+                      description: Debug defines a switch enable debug
                       type: boolean
                     imagePullSecrets:
+                      description: ImagePullSecrets is an optional list of references
+                        to secrets in the same namespace to use for pulling any of the
+                        images used by this PodSpec.
                       items:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same namespace.
                         properties:
                           name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       type: array
                     initContainers:
+                      description: InitContainers defines init containers of the pod.
+                        A typical use case could be using an init container to download
+                        a remote jar to a local path.
                       items:
+                        description: A single application container that you want to
+                          run within a pod. The Container API from the core group is
+                          not used directly to avoid unneeded fields and reduce the
+                          size of the CRD. New fields could be added as needed.
                         properties:
                           args:
+                            description: Arguments to the entrypoint.
                             items:
                               type: string
                             type: array
                           command:
+                            description: Entrypoint array. Not executed within a shell.
                             items:
                               type: string
                             type: array
                           env:
+                            description: List of environment variables to set in the
+                              container.
                             items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
                               properties:
                                 name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previous defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  The $(VAR_NAME) syntax can be escaped with a double
+                                  $$, ie: $$(VAR_NAME). Escaped references will never
+                                  be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
                                   type: string
                                 valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
+                                          description: The key to select.
                                           type: string
                                         name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
                                           type: boolean
                                       required:
                                         - key
                                       type: object
                                     fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
                                       properties:
                                         apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
+                                          description: Path of the field to select in
+                                            the specified API version.
                                           type: string
                                       required:
                                         - fieldPath
                                       type: object
                                     resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
                                       properties:
                                         containerName:
+                                          description: 'Container name: required for
+                                          volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                             - type: integer
                                             - type: string
+                                          description: Specifies the output format of
+                                            the exposed resources, defaults to "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
+                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                         - resource
                                       type: object
                                     secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
                                       properties:
                                         key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret or
+                                            its key must be defined
                                           type: boolean
                                       required:
                                         - key
@@ -1082,52 +2083,99 @@ spec:
                               type: object
                             type: array
                           envFrom:
+                            description: List of sources to populate environment variables
+                              in the container.
                             items:
+                              description: EnvFromSource represents the source of a
+                                set of ConfigMaps
                               properties:
                                 configMapRef:
+                                  description: The ConfigMap to select from
                                   properties:
                                     name:
+                                      description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                       type: string
                                     optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
                                       type: boolean
                                   type: object
                                 prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
+                                  description: The Secret to select from
                                   properties:
                                     name:
+                                      description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                       type: string
                                     optional:
+                                      description: Specify whether the Secret must be
+                                        defined
                                       type: boolean
                                   type: object
                               type: object
                             type: array
                           image:
+                            description: Docker image name.
                             type: string
                           imagePullPolicy:
+                            description: Image pull policy.
                             type: string
                           livenessProbe:
+                            description: Periodic probe of container liveness.
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1135,66 +2183,120 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           name:
+                            description: Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
                             type: string
                           readinessProbe:
+                            description: 'Periodic probe of container service readiness.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1202,43 +2304,70 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           resources:
+                            description: Compute Resources required by this container.
                             properties:
                               limits:
                                 additionalProperties:
@@ -1247,6 +2376,8 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -1255,30 +2386,61 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                             type: object
                           startupProbe:
+                            description: StartupProbe indicates that the Pod has successfully
+                              initialized.
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1286,56 +2448,103 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           volumeMounts:
+                            description: Pod volumes to mount into the container's filesystem.
                             items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
                               properties:
                                 mountPath:
+                                  description: Path within the container at which the
+                                    volume should be mounted.  Must not contain ':'.
                                   type: string
                                 mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and the
+                                    other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
+                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to false.
                                   type: boolean
                                 subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults to
+                                    "" (volume's root).
                                   type: string
                                 subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the container's
+                                    environment. Defaults to "" (volume's root). SubPathExpr
+                                    and SubPath are mutually exclusive.
                                   type: string
                               required:
                                 - mountPath
@@ -1343,12 +2552,15 @@ spec:
                               type: object
                             type: array
                           workingDir:
+                            description: Container's working directory.
                             type: string
                         required:
                           - name
                         type: object
                       type: array
                     jvmOptions:
+                      description: JvmOptions defines the Jvm options passed to the
+                        proxy
                       properties:
                         extraOptions:
                           items:
@@ -1370,12 +2582,19 @@ spec:
                     labels:
                       additionalProperties:
                         type: string
+                      description: Labels specifies the labels to attach to pod the
+                        operator creates for the cluster.
                       type: object
                     nodeSelector:
                       additionalProperties:
                         type: string
+                      description: NodeSelector specifies a map of key-value pairs.
+                        For a pod to be eligible to run on a node, the node must have
+                        each of the indicated key-value pairs as labels.
                       type: object
                     resources:
+                      description: Resources specifies the resource requirements of
+                        containers to run in the pod
                       properties:
                         limits:
                           additionalProperties:
@@ -1384,6 +2603,8 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
@@ -1392,9 +2613,15 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
                     secretRefs:
+                      description: SecretRefs defines how to mount required secrets
+                        into containers
                       items:
                         properties:
                           mountPath:
@@ -1407,51 +2634,120 @@ spec:
                         type: object
                       type: array
                     securityContext:
+                      description: 'SecurityContext specifies the security context for
+                      the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
                       properties:
                         fsGroup:
+                          description: "A special supplemental group that applies to
+                          all containers in a pod. Some volume types allow the Kubelet
+                          to change the ownership of that volume to be owned by the
+                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
+                          bit is set (new files created in the volume will be owned
+                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
+                          \n If unset, the Kubelet will not modify the ownership and
+                          permissions of any volume."
                           format: int64
                           type: integer
                         fsGroupChangePolicy:
+                          description: 'fsGroupChangePolicy defines behavior of changing
+                          ownership and permission of the volume before being exposed
+                          inside Pod. This field will only apply to volume types which
+                          support fsGroup based ownership(and permissions). It will
+                          have no effect on ephemeral volume types such as: secret,
+                          configmaps and emptydir. Valid values are "OnRootMismatch"
+                          and "Always". If not specified defaults to "Always".'
                           type: string
                         runAsGroup:
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container.
                           format: int64
                           type: integer
                         runAsNonRoot:
+                          description: Indicates that the container must run as a non-root
+                            user. If true, the Kubelet will validate the image at runtime
+                            to ensure that it does not run as UID 0 (root) and fail
+                            to start the container if it does. If unset or false, no
+                            such validation will be performed. May also be set in SecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
                           type: boolean
                         runAsUser:
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata if
+                            unspecified. May also be set in SecurityContext.  If set
+                            in both SecurityContext and PodSecurityContext, the value
+                            specified in SecurityContext takes precedence for that container.
                           format: int64
                           type: integer
                         seLinuxOptions:
+                          description: The SELinux context to be applied to all containers.
+                            If unspecified, the container runtime will allocate a random
+                            SELinux context for each container.  May also be set in
+                            SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence
+                            for that container.
                           properties:
                             level:
+                              description: Level is SELinux level label that applies
+                                to the container.
                               type: string
                             role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
                               type: string
                             type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
                               type: string
                             user:
+                              description: User is a SELinux user label that applies
+                                to the container.
                               type: string
                           type: object
                         seccompProfile:
+                          description: The seccomp options to use by the containers
+                            in this pod.
                           properties:
                             localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used. The profile must
+                                be preconfigured on the node to work. Must be a descending
+                                path, relative to the kubelet's configured seccomp profile
+                                location. Must only be set if type is "Localhost".
                               type: string
                             type:
+                              description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a
+                              profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile
+                              should be used. Unconfined - no profile should be applied."
                               type: string
                           required:
                             - type
                           type: object
                         supplementalGroups:
+                          description: A list of groups applied to the first process
+                            run in each container, in addition to the container's primary
+                            GID.  If unspecified, no groups will be added to any container.
                           items:
                             format: int64
                             type: integer
                           type: array
                         sysctls:
+                          description: Sysctls hold a list of namespaced sysctls used
+                            for the pod. Pods with unsupported sysctls (by the container
+                            runtime) might fail to launch.
                           items:
+                            description: Sysctl defines a kernel parameter to be set
                             properties:
                               name:
+                                description: Name of a property to set
                                 type: string
                               value:
+                                description: Value of a property to set
                                 type: string
                             required:
                               - name
@@ -1459,79 +2755,160 @@ spec:
                             type: object
                           type: array
                         windowsOptions:
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options within a container's
+                            SecurityContext will be used. If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
                           properties:
                             gmsaCredentialSpec:
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field.
                               type: string
                             gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
                               type: string
                             runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set in
+                                PodSecurityContext. If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
                               type: string
                           type: object
                       type: object
                     serviceAccountName:
+                      description: ServiceAccountName is the name of the ServiceAccount
+                        to use to run pods.
                       type: string
                     sidecars:
+                      description: Sidecars defines sidecar containers running alongside
+                        with the main function container in the pod.
                       items:
+                        description: A single application container that you want to
+                          run within a pod. The Container API from the core group is
+                          not used directly to avoid unneeded fields and reduce the
+                          size of the CRD. New fields could be added as needed.
                         properties:
                           args:
+                            description: Arguments to the entrypoint.
                             items:
                               type: string
                             type: array
                           command:
+                            description: Entrypoint array. Not executed within a shell.
                             items:
                               type: string
                             type: array
                           env:
+                            description: List of environment variables to set in the
+                              container.
                             items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
                               properties:
                                 name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previous defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  The $(VAR_NAME) syntax can be escaped with a double
+                                  $$, ie: $$(VAR_NAME). Escaped references will never
+                                  be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
                                   type: string
                                 valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
+                                          description: The key to select.
                                           type: string
                                         name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
                                           type: boolean
                                       required:
                                         - key
                                       type: object
                                     fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
                                       properties:
                                         apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
+                                          description: Path of the field to select in
+                                            the specified API version.
                                           type: string
                                       required:
                                         - fieldPath
                                       type: object
                                     resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
                                       properties:
                                         containerName:
+                                          description: 'Container name: required for
+                                          volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                             - type: integer
                                             - type: string
+                                          description: Specifies the output format of
+                                            the exposed resources, defaults to "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
+                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                         - resource
                                       type: object
                                     secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
                                       properties:
                                         key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret or
+                                            its key must be defined
                                           type: boolean
                                       required:
                                         - key
@@ -1542,52 +2919,99 @@ spec:
                               type: object
                             type: array
                           envFrom:
+                            description: List of sources to populate environment variables
+                              in the container.
                             items:
+                              description: EnvFromSource represents the source of a
+                                set of ConfigMaps
                               properties:
                                 configMapRef:
+                                  description: The ConfigMap to select from
                                   properties:
                                     name:
+                                      description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                       type: string
                                     optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
                                       type: boolean
                                   type: object
                                 prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
+                                  description: The Secret to select from
                                   properties:
                                     name:
+                                      description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                       type: string
                                     optional:
+                                      description: Specify whether the Secret must be
+                                        defined
                                       type: boolean
                                   type: object
                               type: object
                             type: array
                           image:
+                            description: Docker image name.
                             type: string
                           imagePullPolicy:
+                            description: Image pull policy.
                             type: string
                           livenessProbe:
+                            description: Periodic probe of container liveness.
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1595,66 +3019,120 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           name:
+                            description: Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
                             type: string
                           readinessProbe:
+                            description: 'Periodic probe of container service readiness.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1662,43 +3140,70 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           resources:
+                            description: Compute Resources required by this container.
                             properties:
                               limits:
                                 additionalProperties:
@@ -1707,6 +3212,8 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -1715,30 +3222,61 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                             type: object
                           startupProbe:
+                            description: StartupProbe indicates that the Pod has successfully
+                              initialized.
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1746,56 +3284,103 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           volumeMounts:
+                            description: Pod volumes to mount into the container's filesystem.
                             items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
                               properties:
                                 mountPath:
+                                  description: Path within the container at which the
+                                    volume should be mounted.  Must not contain ':'.
                                   type: string
                                 mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and the
+                                    other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
+                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to false.
                                   type: boolean
                                 subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults to
+                                    "" (volume's root).
                                   type: string
                                 subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the container's
+                                    environment. Defaults to "" (volume's root). SubPathExpr
+                                    and SubPath are mutually exclusive.
                                   type: string
                               required:
                                 - mountPath
@@ -1803,81 +3388,158 @@ spec:
                               type: object
                             type: array
                           workingDir:
+                            description: Container's working directory.
                             type: string
                         required:
                           - name
                         type: object
                       type: array
                     terminationGracePeriodSeconds:
+                      description: TerminationGracePeriodSeconds is the amount of time
+                        that kubernetes will give for a pod before terminating it.
                       format: int64
                       type: integer
                     tolerations:
+                      description: Tolerations specifies the tolerations of a Pod
                       items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
                         properties:
                           effect:
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified, allowed
+                              values are NoSchedule, PreferNoSchedule and NoExecute.
                             type: string
                           key:
+                            description: Key is the taint key that the toleration applies
+                              to. Empty means match all taint keys. If the key is empty,
+                              operator must be Exists; this combination means to match
+                              all values and all keys.
                             type: string
                           operator:
+                            description: Operator represents a key's relationship to
+                              the value. Valid operators are Exists and Equal. Defaults
+                              to Equal. Exists is equivalent to wildcard for value,
+                              so that a pod can tolerate all taints of a particular
+                              category.
                             type: string
                           tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the taint
+                              forever (do not evict). Zero and negative values will
+                              be treated as 0 (evict immediately) by the system.
                             format: int64
                             type: integer
                           value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
                             type: string
                         type: object
                       type: array
                     vars:
+                      description: Vars specifies the environment variables of a Pod
                       items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
                         properties:
                           name:
+                            description: Name of the environment variable. Must be a
+                              C_IDENTIFIER.
                             type: string
                           value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
                             type: string
                           valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
                                 properties:
                                   key:
+                                    description: The key to select.
                                     type: string
                                   name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                     type: string
                                   optional:
+                                    description: Specify whether the ConfigMap or its
+                                      key must be defined
                                     type: boolean
                                 required:
                                   - key
                                 type: object
                               fieldRef:
+                                description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
                                 properties:
                                   apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
                                     type: string
                                 required:
                                   - fieldPath
                                 type: object
                               resourceFieldRef:
+                                description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
                                 properties:
                                   containerName:
+                                    description: 'Container name: required for volumes,
+                                    optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
+                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                   - resource
                                 type: object
                               secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
                                 properties:
                                   key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
                                     type: string
                                   name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                     type: string
                                   optional:
+                                    description: Specify whether the Secret or its key
+                                      must be defined
                                     type: boolean
                                 required:
                                   - key
@@ -1888,22 +3550,66 @@ spec:
                         type: object
                       type: array
                     volumes:
+                      description: Volumes defines extra volumes of the pod.
                       items:
+                        description: Volume represents a named volume in a pod that
+                          may be accessed by any container in the pod. The Volume API
+                          from the core group is not used directly to avoid unneeded
+                          fields defined in `VolumeSource` and reduce the size of the
+                          CRD. New fields in VolumeSource could be added as needed.
                         properties:
                           configMap:
+                            description: ConfigMap represents a configMap that should
+                              populate this volume
                             properties:
                               defaultMode:
+                                description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0
+                                and 511. YAML accepts both octal and decimal values,
+                                JSON requires decimal values for mode bits. Defaults
+                                to 0644. Directories within the path are not affected
+                                by this setting. This might be in conflict with other
+                                options that affect the file mode, like fsGroup, and
+                                the result can be other mode bits set.'
                                 format: int32
                                 type: integer
                               items:
+                                description: If unspecified, each key-value pair in
+                                  the Data field of the referenced ConfigMap will be
+                                  projected into the volume as a file whose name is
+                                  the key and content is the value. If specified, the
+                                  listed keys will be projected into the specified paths,
+                                  and unlisted keys will not be present. If a key is
+                                  specified which is not present in the ConfigMap, the
+                                  volume setup will error unless it is marked optional.
+                                  Paths must be relative and may not contain the '..'
+                                  path or start with '..'.
                                 items:
+                                  description: Maps a string key to a path within a
+                                    volume.
                                   properties:
                                     key:
+                                      description: The key to project.
                                       type: string
                                     mode:
+                                      description: 'Optional: mode bits used to set
+                                      permissions on this file. Must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
                                       format: int32
                                       type: integer
                                     path:
+                                      description: The relative path of the file to
+                                        map the key to. May not be an absolute path.
+                                        May not contain the path element '..'. May not
+                                        start with the string '..'.
                                       type: string
                                   required:
                                     - key
@@ -1911,26 +3617,70 @@ spec:
                                   type: object
                                 type: array
                               name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
+                                description: Specify whether the ConfigMap or its keys
+                                  must be defined
                                 type: boolean
                             type: object
                           name:
+                            description: 'Volume''s name. Must be a DNS_LABEL and unique
+                            within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
                           secret:
+                            description: Secret represents a secret that should populate
+                              this volume.
                             properties:
                               defaultMode:
+                                description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0
+                                and 511. YAML accepts both octal and decimal values,
+                                JSON requires decimal values for mode bits. Defaults
+                                to 0644. Directories within the path are not affected
+                                by this setting. This might be in conflict with other
+                                options that affect the file mode, like fsGroup, and
+                                the result can be other mode bits set.'
                                 format: int32
                                 type: integer
                               items:
+                                description: If unspecified, each key-value pair in
+                                  the Data field of the referenced Secret will be projected
+                                  into the volume as a file whose name is the key and
+                                  content is the value. If specified, the listed keys
+                                  will be projected into the specified paths, and unlisted
+                                  keys will not be present. If a key is specified which
+                                  is not present in the Secret, the volume setup will
+                                  error unless it is marked optional. Paths must be
+                                  relative and may not contain the '..' path or start
+                                  with '..'.
                                 items:
+                                  description: Maps a string key to a path within a
+                                    volume.
                                   properties:
                                     key:
+                                      description: The key to project.
                                       type: string
                                     mode:
+                                      description: 'Optional: mode bits used to set
+                                      permissions on this file. Must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
                                       format: int32
                                       type: integer
                                     path:
+                                      description: The relative path of the file to
+                                        map the key to. May not be an absolute path.
+                                        May not contain the path element '..'. May not
+                                        start with the string '..'.
                                       type: string
                                   required:
                                     - key
@@ -1938,8 +3688,12 @@ spec:
                                   type: object
                                 type: array
                               optional:
+                                description: Specify whether the Secret or its keys
+                                  must be defined
                                 type: boolean
                               secretName:
+                                description: 'Name of the secret in the pod''s namespace
+                                to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                 type: string
                             type: object
                         required:
@@ -1948,9 +3702,12 @@ spec:
                       type: array
                   type: object
                 replicas:
+                  description: Replicas is the expected size of the pulsar proxy
                   format: int32
                   type: integer
                 webSocketServiceEnabled:
+                  description: WebSocketServiceEnabled defines whether WebSocket will
+                    be enabled
                   type: boolean
               required:
                 - brokerAddress
@@ -1958,11 +3715,16 @@ spec:
                 - issuerRef
               type: object
             status:
+              description: PulsarProxyStatus defines the observed state of PulsarProxy
               properties:
                 conditions:
                   additionalProperties:
+                    description: The `Status` of a given `Condition` and the `Action`
+                      needed to reach the `Status`
                     properties:
                       action:
+                        description: The action needed to advance components to ready
+                          status
                         type: string
                       condition:
                         type: string
@@ -1973,19 +3735,30 @@ spec:
                       - condition
                       - status
                     type: object
+                  description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file'
                   type: object
                 labelSelector:
+                  description: Label selector for scaling
                   type: string
                 observedGeneration:
+                  description: ObservedGeneration is the most recent generation observed
+                    for this cluster. It corresponds to the metadata generation, which
+                    is updated on mutation by the API Server.
                   format: int64
                   type: integer
                 readyReplicas:
+                  description: ReadyReplicas is the number of ready servers in the cluster
                   format: int32
                   type: integer
                 replicas:
+                  description: Replicas is the number of servers in the cluster
                   format: int32
                   type: integer
                 updatedReplicas:
+                  description: UpdatedReplicas is the number of servers that has been
+                    updated to the latest configuration
                   format: int32
                   type: integer
               required:

--- a/charts/pulsar-operator/crds/zookeeper.streamnative.io_zookeeperclusters.yaml
+++ b/charts/pulsar-operator/crds/zookeeper.streamnative.io_zookeeperclusters.yaml
@@ -36,44 +36,75 @@ spec:
       name: v1alpha1
       schema:
         openAPIV3Schema:
+          description: ZooKeeperCluster is the Schema for the zookeeperclusters API
           properties:
             apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
             kind:
+              description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
               type: object
             spec:
+              description: ZooKeeperClusterSpec defines the desired state of ZooKeeperCluster
               properties:
                 advancedOptions:
+                  description: AdvancedOptions contains advancedOptions for additional
+                    customization the pod
                   properties:
                     customStartupCommand:
+                      description: CustomStartupCommand defines a custom command to
+                        use for starting up
                       type: string
                     staticServerList:
+                      description: StaticServerList defines a list of static servers
+                        to be used in the zookeeper config. this overrides the default
+                        generated list of servers
                       properties:
                         servers:
+                          description: Servers is the list of zookeeper servers used
                           items:
                             properties:
                               clientAddress:
+                                description: ClientAddress is the address to bind for
+                                  client connections, defaults to `0.0.0.0`
                                 type: string
                               id:
+                                description: ID is the id of this server
                                 type: integer
                               listeners:
+                                description: Listeners is an array of listeners, must
+                                  have at least one listener
                                 items:
                                   properties:
                                     electionPort:
+                                      description: ElectionPort is the port for connecting
+                                        to leader, defaults to 3888
                                       type: integer
                                     followerPort:
+                                      description: FollowerPort is the port for connecting
+                                        to leader, defaults to 2888
                                       type: integer
                                     hostname:
+                                      description: Hostname is the name of the listener
                                       type: string
                                     role:
+                                      description: Role is the type of node this is,
+                                        options are participant or observer, defaults
+                                        to participant
                                       type: string
                                   required:
                                     - hostname
                                   type: object
                                 type: array
                               port:
+                                description: ClientPort is the port to bind for client
+                                  connections, defaults to `2181`
                                 type: integer
                             required:
                               - id
@@ -85,124 +116,201 @@ spec:
                       type: object
                   type: object
                 apiObjects:
+                  description: APIObjects allows precise control over how components
+                    (services, statefulset and so on) should be managed
                   properties:
                     clientService:
+                      description: ClientService defines the Zookeeper Client Service
+                        resource template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     configMap:
+                      description: ConfigMap defines the configmap resource template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     headlessService:
+                      description: HeadlessService defines the Zookeeper Headless Service
+                        resource template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     pdb:
+                      description: PDB defines the podDisruptionBudget resource template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          name, labels, annotations of the object. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                       type: object
                     statefulSet:
+                      description: StatefulSet defines the Zookeeper Cluster Statefulset
+                        resource template.
                       properties:
                         managed:
+                          description: Managed config if this object should be managed
+                            by controller
                           type: boolean
                         metadata:
+                          description: 'Standard object''s metadata used to customize
+                          the name, labels, annotations of the object. More info:
+                          https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
+                              description: Annotations of the resource.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
+                              description: Labels of the resource.
                               type: object
                             name:
+                              description: Name of the resource within a namespace.
+                                It must be unique.
                               type: string
                           type: object
                         updatePolicy:
+                          description: UpdatePolicy defines which field to update.
                           items:
+                            description: UpdateMode defines how to update resource.
                             type: string
                           type: array
                         volumeClaimTemplates:
+                          description: VolumeClaimTemplates is a list of claims that
+                            pods are allowed to reference. If a non-empty list is specified,
+                            the original values in the desired STS will be replaced.
                           items:
+                            description: PersistentVolumeClaim is a user's request for
+                              and claim to a persistent volume
                             properties:
                               apiVersion:
+                                description: 'APIVersion defines the versioned schema
+                                of this representation of an object. Servers should
+                                convert recognized schemas to the latest internal
+                                value, and may reject unrecognized values. More info:
+                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                                 type: string
                               kind:
+                                description: 'Kind is a string value representing the
+                                REST resource this object represents. Servers may
+                                infer this from the endpoint the client submits requests
+                                to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                                 type: string
                               metadata:
+                                description: 'Standard object''s metadata. More info:
+                                https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                                 properties:
                                   annotations:
                                     additionalProperties:
@@ -222,24 +330,55 @@ spec:
                                     type: string
                                 type: object
                               spec:
+                                description: 'Spec defines the desired characteristics
+                                of a volume requested by a pod author. More info:
+                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                 properties:
                                   accessModes:
+                                    description: 'AccessModes contains the desired access
+                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                     items:
                                       type: string
                                     type: array
                                   dataSource:
+                                    description: 'This field can be used to specify
+                                    either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                                    - Beta) * An existing PVC (PersistentVolumeClaim)
+                                    * An existing custom resource/object that implements
+                                    data population (Alpha) In order to use VolumeSnapshot
+                                    object types, the appropriate feature gate must
+                                    be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
+                                    If the provisioner or an external controller can
+                                    support the specified data source, it will create
+                                    a new volume based on the contents of the specified
+                                    data source. If the specified data source is not
+                                    supported, the volume will not be created and
+                                    the failure will be reported as an event. In the
+                                    future, we plan to support more data source types
+                                    and the behavior of the provisioner may change.'
                                     properties:
                                       apiGroup:
+                                        description: APIGroup is the group for the resource
+                                          being referenced. If APIGroup is not specified,
+                                          the specified Kind must be in the core API
+                                          group. For any other third-party types, APIGroup
+                                          is required.
                                         type: string
                                       kind:
+                                        description: Kind is the type of resource being
+                                          referenced
                                         type: string
                                       name:
+                                        description: Name is the name of resource being
+                                          referenced
                                         type: string
                                     required:
                                       - kind
                                       - name
                                     type: object
                                   resources:
+                                    description: 'Resources represents the minimum resources
+                                    the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -248,6 +387,8 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
+                                        description: 'Limits describes the maximum amount
+                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -256,18 +397,46 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
+                                        description: 'Requests describes the minimum
+                                        amount of compute resources required. If Requests
+                                        is omitted for a container, it defaults to
+                                        Limits if that is explicitly specified, otherwise
+                                        to an implementation-defined value. More info:
+                                        https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   selector:
+                                    description: A label query over volumes to consider
+                                      for binding.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -279,18 +448,37 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   storageClassName:
+                                    description: 'Name of the StorageClass required
+                                    by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                                     type: string
                                   volumeMode:
+                                    description: volumeMode defines what type of volume
+                                      is required by the claim. Value of Filesystem
+                                      is implied when not included in claim spec.
                                     type: string
                                   volumeName:
+                                    description: VolumeName is the binding reference
+                                      to the PersistentVolume backing this claim.
                                     type: string
                                 type: object
                               status:
+                                description: 'Status represents the current information/status
+                                of a persistent volume claim. Read-only. More info:
+                                https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                 properties:
                                   accessModes:
+                                    description: 'AccessModes contains the actual access
+                                    modes the volume backing the PVC has. More info:
+                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                                     items:
                                       type: string
                                     type: array
@@ -301,23 +489,43 @@ spec:
                                         - type: string
                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                       x-kubernetes-int-or-string: true
+                                    description: Represents the actual resources of
+                                      the underlying volume.
                                     type: object
                                   conditions:
+                                    description: Current Condition of persistent volume
+                                      claim. If underlying persistent volume is being
+                                      resized then the Condition will be set to 'ResizeStarted'.
                                     items:
+                                      description: PersistentVolumeClaimCondition contails
+                                        details about state of pvc
                                       properties:
                                         lastProbeTime:
+                                          description: Last time we probed the condition.
                                           format: date-time
                                           type: string
                                         lastTransitionTime:
+                                          description: Last time the condition transitioned
+                                            from one status to another.
                                           format: date-time
                                           type: string
                                         message:
+                                          description: Human-readable message indicating
+                                            details about last transition.
                                           type: string
                                         reason:
+                                          description: Unique, this should be a short,
+                                            machine understandable string that gives
+                                            the reason for condition's last transition.
+                                            If it reports "ResizeStarted" that means
+                                            the underlying persistent volume is being
+                                            resized.
                                           type: string
                                         status:
                                           type: string
                                         type:
+                                          description: PersistentVolumeClaimConditionType
+                                            is a valid value of PersistentVolumeClaimCondition.Type
                                           type: string
                                       required:
                                         - status
@@ -325,24 +533,50 @@ spec:
                                       type: object
                                     type: array
                                   phase:
+                                    description: Phase represents the current phase
+                                      of PersistentVolumeClaim.
                                     type: string
                                 type: object
                             type: object
                           type: array
                         volumeMounts:
+                          description: VolumeMounts is a list of volumes to mount into
+                            the container's filesystem. If a non-empty list is specified,
+                            the original values of the main container in the desired
+                            STS will be replaced.
                           items:
+                            description: VolumeMount describes a mounting of a Volume
+                              within a container.
                             properties:
                               mountPath:
+                                description: Path within the container at which the
+                                  volume should be mounted.  Must not contain ':'.
                                 type: string
                               mountPropagation:
+                                description: mountPropagation determines how mounts
+                                  are propagated from the host to container and the
+                                  other way around. When not set, MountPropagationNone
+                                  is used. This field is beta in 1.10.
                                 type: string
                               name:
+                                description: This must match the Name of a Volume.
                                 type: string
                               readOnly:
+                                description: Mounted read-only if true, read-write otherwise
+                                  (false or unspecified). Defaults to false.
                                 type: boolean
                               subPath:
+                                description: Path within the volume from which the container's
+                                  volume should be mounted. Defaults to "" (volume's
+                                  root).
                                 type: string
                               subPathExpr:
+                                description: Expanded path within the volume from which
+                                  the container's volume should be mounted. Behaves
+                                  similarly to SubPath but environment variable references
+                                  $(VAR_NAME) are expanded using the container's environment.
+                                  Defaults to "" (volume's root). SubPathExpr and SubPath
+                                  are mutually exclusive.
                                 type: string
                             required:
                               - mountPath
@@ -352,76 +586,151 @@ spec:
                       type: object
                   type: object
                 conf:
+                  description: 'Conf defines the zookeeper configuration. It will be
+                  used for generating the configuration file used by zookeeper process.
+                  Deprecated: use `config`'
                   properties:
                     custom:
                       additionalProperties:
                         type: string
+                      description: Custom accepts other configurations
+                      nullable: true
                       type: object
                     globalOutstandingLimit:
+                      description: "GlobalOutstandingLimit limits the number of queued
+                      outstanding requests \n The default value is 100000"
                       type: integer
                     initLimit:
+                      description: "InitLimit is the number of ticks that the initial
+                      synchronization phase can take. \n The default value is 10."
                       type: integer
                     maxClientCnxns:
+                      description: "MaxClientCnxns limits the maximum number of client
+                      connections. \n The default value is 1000"
                       type: integer
                     serverCnxnFactory:
+                      description: "ServerCnxnFactory is the ServerCnxnFactory implementation.
+                      \n The default value is org.apache.zookeeper.server.NettyServerCnxnFactory"
                       type: string
                     snapCount:
+                      description: "SnapCount is the number of transactions recorded
+                      in the transaction log before a snapshot can be taken. \n The
+                      default value is 1000000"
                       type: integer
                     syncLimit:
+                      description: "SyncLimit is the number of ticks that can pass between
+                      sending a request and getting an acknowledgement \n The default
+                      value is 5."
                       type: integer
                     tickTime:
+                      description: "TickTime is the number of milliseconds of each tick.
+                      A tick is the basic time unit used by ZooKeeper, as measured
+                      in milliseconds \n The default value is 2000."
                       type: integer
                   type: object
                 config:
+                  description: Config defines the zookeeper configuration
                   properties:
                     custom:
                       additionalProperties:
                         type: string
+                      description: Custom accepts other configurations
+                      nullable: true
                       type: object
                     globalOutstandingLimit:
+                      description: "GlobalOutstandingLimit limits the number of queued
+                      outstanding requests \n The default value is 100000"
                       type: integer
                     initLimit:
+                      description: "InitLimit is the number of ticks that the initial
+                      synchronization phase can take. \n The default value is 10."
                       type: integer
                     maxClientCnxns:
+                      description: "MaxClientCnxns limits the maximum number of client
+                      connections. \n The default value is 1000"
                       type: integer
                     serverCnxnFactory:
+                      description: "ServerCnxnFactory is the ServerCnxnFactory implementation.
+                      \n The default value is org.apache.zookeeper.server.NettyServerCnxnFactory"
                       type: string
                     snapCount:
+                      description: "SnapCount is the number of transactions recorded
+                      in the transaction log before a snapshot can be taken. \n The
+                      default value is 1000000"
                       type: integer
                     syncLimit:
+                      description: "SyncLimit is the number of ticks that can pass between
+                      sending a request and getting an acknowledgement \n The default
+                      value is 5."
                       type: integer
                     tickTime:
+                      description: "TickTime is the number of milliseconds of each tick.
+                      A tick is the basic time unit used by ZooKeeper, as measured
+                      in milliseconds \n The default value is 2000."
                       type: integer
                   type: object
                 image:
+                  description: Image is the container image used to run zookeeper pods.
+                    default is apachepulsar/pulsar:latest
                   type: string
                 imagePullPolicy:
+                  description: Image pull policy, one of Always, Never, IfNotPresent,
+                    default to Always.
                   type: string
                 labels:
                   additionalProperties:
                     type: string
+                  description: Labels specifies the labels to attach to the stateful
+                    set the operator creates for the zookeeper cluster.
+                  nullable: true
                   type: object
                 persistence:
+                  description: Persistence defines the persistent volume used for the
+                    zookeeper pod
                   properties:
                     data:
+                      description: Data is the spec to define the data PVC for the container
                       properties:
                         accessModes:
+                          description: 'AccessModes contains the desired access modes
+                          the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                           items:
                             type: string
                           type: array
                         dataSource:
+                          description: 'This field can be used to specify either: *
+                          An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                          - Beta) * An existing PVC (PersistentVolumeClaim) * An existing
+                          custom resource/object that implements data population (Alpha)
+                          In order to use VolumeSnapshot object types, the appropriate
+                          feature gate must be enabled (VolumeSnapshotDataSource or
+                          AnyVolumeDataSource) If the provisioner or an external controller
+                          can support the specified data source, it will create a
+                          new volume based on the contents of the specified data source.
+                          If the specified data source is not supported, the volume
+                          will not be created and the failure will be reported as
+                          an event. In the future, we plan to support more data source
+                          types and the behavior of the provisioner may change.'
                           properties:
                             apiGroup:
+                              description: APIGroup is the group for the resource being
+                                referenced. If APIGroup is not specified, the specified
+                                Kind must be in the core API group. For any other third-party
+                                types, APIGroup is required.
                               type: string
                             kind:
+                              description: Kind is the type of resource being referenced
                               type: string
                             name:
+                              description: Name is the name of resource being referenced
                               type: string
                           required:
                             - kind
                             - name
                           type: object
                         resources:
+                          description: 'Resources represents the minimum resources the
+                          volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                           properties:
                             limits:
                               additionalProperties:
@@ -430,6 +739,8 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                               type: object
                             requests:
                               additionalProperties:
@@ -438,18 +749,40 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                               type: object
                           type: object
                         selector:
+                          description: A label query over volumes to consider for binding.
                           properties:
                             matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
                               items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
                                 properties:
                                   key:
+                                    description: key is the label key that the selector
+                                      applies to.
                                     type: string
                                   operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In, NotIn,
+                                      Exists and DoesNotExist.
                                     type: string
                                   values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists or
+                                      DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
                                     items:
                                       type: string
                                     type: array
@@ -461,34 +794,71 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field is
+                                "key", the operator is "In", and the values array contains
+                                only "value". The requirements are ANDed.
                               type: object
                           type: object
                         storageClassName:
+                          description: 'Name of the StorageClass required by the claim.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                           type: string
                         volumeMode:
+                          description: volumeMode defines what type of volume is required
+                            by the claim. Value of Filesystem is implied when not included
+                            in claim spec.
                           type: string
                         volumeName:
+                          description: VolumeName is the binding reference to the PersistentVolume
+                            backing this claim.
                           type: string
                       type: object
                     dataLog:
+                      description: DataLog is the spec to define the data-log PVC for
+                        the container
                       properties:
                         accessModes:
+                          description: 'AccessModes contains the desired access modes
+                          the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
                           items:
                             type: string
                           type: array
                         dataSource:
+                          description: 'This field can be used to specify either: *
+                          An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                          - Beta) * An existing PVC (PersistentVolumeClaim) * An existing
+                          custom resource/object that implements data population (Alpha)
+                          In order to use VolumeSnapshot object types, the appropriate
+                          feature gate must be enabled (VolumeSnapshotDataSource or
+                          AnyVolumeDataSource) If the provisioner or an external controller
+                          can support the specified data source, it will create a
+                          new volume based on the contents of the specified data source.
+                          If the specified data source is not supported, the volume
+                          will not be created and the failure will be reported as
+                          an event. In the future, we plan to support more data source
+                          types and the behavior of the provisioner may change.'
                           properties:
                             apiGroup:
+                              description: APIGroup is the group for the resource being
+                                referenced. If APIGroup is not specified, the specified
+                                Kind must be in the core API group. For any other third-party
+                                types, APIGroup is required.
                               type: string
                             kind:
+                              description: Kind is the type of resource being referenced
                               type: string
                             name:
+                              description: Name is the name of resource being referenced
                               type: string
                           required:
                             - kind
                             - name
                           type: object
                         resources:
+                          description: 'Resources represents the minimum resources the
+                          volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
                           properties:
                             limits:
                               additionalProperties:
@@ -497,6 +867,8 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute
+                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                               type: object
                             requests:
                               additionalProperties:
@@ -505,18 +877,40 @@ spec:
                                   - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of
+                              compute resources required. If Requests is omitted for
+                              a container, it defaults to Limits if that is explicitly
+                              specified, otherwise to an implementation-defined value.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                               type: object
                           type: object
                         selector:
+                          description: A label query over volumes to consider for binding.
                           properties:
                             matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
                               items:
+                                description: A label selector requirement is a selector
+                                  that contains values, a key, and an operator that
+                                  relates the key and values.
                                 properties:
                                   key:
+                                    description: key is the label key that the selector
+                                      applies to.
                                     type: string
                                   operator:
+                                    description: operator represents a key's relationship
+                                      to a set of values. Valid operators are In, NotIn,
+                                      Exists and DoesNotExist.
                                     type: string
                                   values:
+                                    description: values is an array of string values.
+                                      If the operator is In or NotIn, the values array
+                                      must be non-empty. If the operator is Exists or
+                                      DoesNotExist, the values array must be empty.
+                                      This array is replaced during a strategic merge
+                                      patch.
                                     items:
                                       type: string
                                     type: array
@@ -528,37 +922,95 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
+                              description: matchLabels is a map of {key,value} pairs.
+                                A single {key,value} in the matchLabels map is equivalent
+                                to an element of matchExpressions, whose key field is
+                                "key", the operator is "In", and the values array contains
+                                only "value". The requirements are ANDed.
                               type: object
                           type: object
                         storageClassName:
+                          description: 'Name of the StorageClass required by the claim.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
                           type: string
                         volumeMode:
+                          description: volumeMode defines what type of volume is required
+                            by the claim. Value of Filesystem is implied when not included
+                            in claim spec.
                           type: string
                         volumeName:
+                          description: VolumeName is the binding reference to the PersistentVolume
+                            backing this claim.
                           type: string
                       type: object
                     reclaimPolicy:
+                      description: VolumeReclaimPolicy defines how to reclaim PV.
                       type: string
                   type: object
                 pod:
+                  description: Pod defines the policy for creating a zookeeper pod for
+                    the cluster
                   properties:
                     affinity:
+                      description: Affinity specifies the scheduling constraints of
+                        a pod
                       properties:
                         nodeAffinity:
+                          description: Describes node affinity scheduling rules for
+                            the pod.
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node matches the corresponding matchExpressions;
+                                the node(s) with the highest sum are the most preferred.
                               items:
+                                description: An empty preferred scheduling term matches
+                                  all objects with implicit weight 0 (i.e. it's a no-op).
+                                  A null preferred scheduling term matches no objects
+                                  (i.e. is also a no-op).
                                 properties:
                                   preference:
+                                    description: A node selector term, associated with
+                                      the corresponding weight.
                                     properties:
                                       matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
                                         items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -568,13 +1020,35 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
                                         items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -585,6 +1059,8 @@ spec:
                                         type: array
                                     type: object
                                   weight:
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -593,18 +1069,53 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by
+                                this field are not met at scheduling time, the pod will
+                                not be scheduled onto the node. If the affinity requirements
+                                specified by this field cease to be met at some point
+                                during pod execution (e.g. due to an update), the system
+                                may or may not try to eventually evict the pod from
+                                its node.
                               properties:
                                 nodeSelectorTerms:
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
                                   items:
+                                    description: A null or empty node selector term
+                                      matches no objects. The requirements of them are
+                                      ANDed. The TopologySelectorTerm type implements
+                                      a subset of the NodeSelectorTerm.
                                     properties:
                                       matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
                                         items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -614,13 +1125,35 @@ spec:
                                           type: object
                                         type: array
                                       matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
                                         items:
+                                          description: A node selector requirement is
+                                            a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: The label key that the selector
+                                                applies to.
                                               type: string
                                             operator:
+                                              description: Represents a key's relationship
+                                                to a set of values. Valid operators
+                                                are In, NotIn, Exists, DoesNotExist.
+                                                Gt, and Lt.
                                               type: string
                                             values:
+                                              description: An array of string values.
+                                                If the operator is In or NotIn, the
+                                                values array must be non-empty. If the
+                                                operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the
+                                                operator is Gt or Lt, the values array
+                                                must have a single element, which will
+                                                be interpreted as an integer. This array
+                                                is replaced during a strategic merge
+                                                patch.
                                               items:
                                                 type: string
                                               type: array
@@ -636,22 +1169,65 @@ spec:
                               type: object
                           type: object
                         podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g.
+                            co-locate this pod in the same node, zone, etc. as some
+                            other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the affinity expressions specified
+                                by this field, but it may choose a node that violates
+                                one or more of the expressions. The node that is most
+                                preferred is the one with the greatest sum of weights,
+                                i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the corresponding
+                                podAffinityTerm; the node(s) with the highest sum are
+                                the most preferred.
                               items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
                                 properties:
                                   podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
                                     properties:
                                       labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -663,18 +1239,37 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the
+                                          pods matching the labelSelector in the specified
+                                          namespaces, where co-located is defined as
+                                          running on a node whose value of the label
+                                          with key topologyKey matches that of any node
+                                          on which any of the selected pods is running.
+                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -683,18 +1278,56 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the affinity requirements specified by
+                                this field are not met at scheduling time, the pod will
+                                not be scheduled onto the node. If the affinity requirements
+                                specified by this field cease to be met at some point
+                                during pod execution (e.g. due to a pod label update),
+                                the system may or may not try to eventually evict the
+                                pod from its node. When there are multiple elements,
+                                the lists of nodes corresponding to each podAffinityTerm
+                                are intersected, i.e. all terms must be satisfied.
                               items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or not
+                                  co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any node
+                                  on which a pod of the set of pods is running
                                 properties:
                                   labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -706,13 +1339,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -720,22 +1369,65 @@ spec:
                               type: array
                           type: object
                         podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules
+                            (e.g. avoid putting this pod in the same node, zone, etc.
+                            as some other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
+                              description: The scheduler will prefer to schedule pods
+                                to nodes that satisfy the anti-affinity expressions
+                                specified by this field, but it may choose a node that
+                                violates one or more of the expressions. The node that
+                                is most preferred is the one with the greatest sum of
+                                weights, i.e. for each node that meets all of the scheduling
+                                requirements (resource request, requiredDuringScheduling
+                                anti-affinity expressions, etc.), compute a sum by iterating
+                                through the elements of this field and adding "weight"
+                                to the sum if the node has pods which matches the corresponding
+                                podAffinityTerm; the node(s) with the highest sum are
+                                the most preferred.
                               items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
                                 properties:
                                   podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
                                     properties:
                                       labelSelector:
+                                        description: A label query over a set of resources,
+                                          in this case pods.
                                         properties:
                                           matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
                                             items:
+                                              description: A label selector requirement
+                                                is a selector that contains values,
+                                                a key, and an operator that relates
+                                                the key and values.
                                               properties:
                                                 key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
                                                   type: string
                                                 operator:
+                                                  description: operator represents a
+                                                    key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists
+                                                    and DoesNotExist.
                                                   type: string
                                                 values:
+                                                  description: values is an array of
+                                                    string values. If the operator is
+                                                    In or NotIn, the values array must
+                                                    be non-empty. If the operator is
+                                                    Exists or DoesNotExist, the values
+                                                    array must be empty. This array
+                                                    is replaced during a strategic merge
+                                                    patch.
                                                   items:
                                                     type: string
                                                   type: array
@@ -747,18 +1439,37 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
+                                            description: matchLabels is a map of {key,value}
+                                              pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions,
+                                              whose key field is "key", the operator
+                                              is "In", and the values array contains
+                                              only "value". The requirements are ANDed.
                                             type: object
                                         type: object
                                       namespaces:
+                                        description: namespaces specifies which namespaces
+                                          the labelSelector applies to (matches against);
+                                          null or empty list means "this pod's namespace"
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
+                                        description: This pod should be co-located (affinity)
+                                          or not co-located (anti-affinity) with the
+                                          pods matching the labelSelector in the specified
+                                          namespaces, where co-located is defined as
+                                          running on a node whose value of the label
+                                          with key topologyKey matches that of any node
+                                          on which any of the selected pods is running.
+                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                       - topologyKey
                                     type: object
                                   weight:
+                                    description: weight associated with matching the
+                                      corresponding podAffinityTerm, in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -767,18 +1478,56 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
+                              description: If the anti-affinity requirements specified
+                                by this field are not met at scheduling time, the pod
+                                will not be scheduled onto the node. If the anti-affinity
+                                requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod
+                                label update), the system may or may not try to eventually
+                                evict the pod from its node. When there are multiple
+                                elements, the lists of nodes corresponding to each podAffinityTerm
+                                are intersected, i.e. all terms must be satisfied.
                               items:
+                                description: Defines a set of pods (namely those matching
+                                  the labelSelector relative to the given namespace(s))
+                                  that this pod should be co-located (affinity) or not
+                                  co-located (anti-affinity) with, where co-located
+                                  is defined as running on a node whose value of the
+                                  label with key <topologyKey> matches that of any node
+                                  on which a pod of the set of pods is running
                                 properties:
                                   labelSelector:
+                                    description: A label query over a set of resources,
+                                      in this case pods.
                                     properties:
                                       matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
                                         items:
+                                          description: A label selector requirement
+                                            is a selector that contains values, a key,
+                                            and an operator that relates the key and
+                                            values.
                                           properties:
                                             key:
+                                              description: key is the label key that
+                                                the selector applies to.
                                               type: string
                                             operator:
+                                              description: operator represents a key's
+                                                relationship to a set of values. Valid
+                                                operators are In, NotIn, Exists and
+                                                DoesNotExist.
                                               type: string
                                             values:
+                                              description: values is an array of string
+                                                values. If the operator is In or NotIn,
+                                                the values array must be non-empty.
+                                                If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This
+                                                array is replaced during a strategic
+                                                merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -790,13 +1539,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
+                                        description: matchLabels is a map of {key,value}
+                                          pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions,
+                                          whose key field is "key", the operator is
+                                          "In", and the values array contains only "value".
+                                          The requirements are ANDed.
                                         type: object
                                     type: object
                                   namespaces:
+                                    description: namespaces specifies which namespaces
+                                      the labelSelector applies to (matches against);
+                                      null or empty list means "this pod's namespace"
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
+                                    description: This pod should be co-located (affinity)
+                                      or not co-located (anti-affinity) with the pods
+                                      matching the labelSelector in the specified namespaces,
+                                      where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey
+                                      matches that of any node on which any of the selected
+                                      pods is running. Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
@@ -807,78 +1572,151 @@ spec:
                     annotations:
                       additionalProperties:
                         type: string
+                      description: Annotations specifies the annotations to attach to
+                        pods the operator creates
                       type: object
                     debug:
+                      description: Debug defines a switch enable debug
                       type: boolean
                     imagePullSecrets:
+                      description: ImagePullSecrets is an optional list of references
+                        to secrets in the same namespace to use for pulling any of the
+                        images used by this PodSpec.
                       items:
+                        description: LocalObjectReference contains enough information
+                          to let you locate the referenced object inside the same namespace.
                         properties:
                           name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
                       type: array
                     initContainers:
+                      description: InitContainers defines init containers of the pod.
+                        A typical use case could be using an init container to download
+                        a remote jar to a local path.
                       items:
+                        description: A single application container that you want to
+                          run within a pod. The Container API from the core group is
+                          not used directly to avoid unneeded fields and reduce the
+                          size of the CRD. New fields could be added as needed.
                         properties:
                           args:
+                            description: Arguments to the entrypoint.
                             items:
                               type: string
                             type: array
                           command:
+                            description: Entrypoint array. Not executed within a shell.
                             items:
                               type: string
                             type: array
                           env:
+                            description: List of environment variables to set in the
+                              container.
                             items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
                               properties:
                                 name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previous defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  The $(VAR_NAME) syntax can be escaped with a double
+                                  $$, ie: $$(VAR_NAME). Escaped references will never
+                                  be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
                                   type: string
                                 valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
+                                          description: The key to select.
                                           type: string
                                         name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
                                           type: boolean
                                       required:
                                         - key
                                       type: object
                                     fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
                                       properties:
                                         apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
+                                          description: Path of the field to select in
+                                            the specified API version.
                                           type: string
                                       required:
                                         - fieldPath
                                       type: object
                                     resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
                                       properties:
                                         containerName:
+                                          description: 'Container name: required for
+                                          volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                             - type: integer
                                             - type: string
+                                          description: Specifies the output format of
+                                            the exposed resources, defaults to "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
+                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                         - resource
                                       type: object
                                     secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
                                       properties:
                                         key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret or
+                                            its key must be defined
                                           type: boolean
                                       required:
                                         - key
@@ -889,52 +1727,99 @@ spec:
                               type: object
                             type: array
                           envFrom:
+                            description: List of sources to populate environment variables
+                              in the container.
                             items:
+                              description: EnvFromSource represents the source of a
+                                set of ConfigMaps
                               properties:
                                 configMapRef:
+                                  description: The ConfigMap to select from
                                   properties:
                                     name:
+                                      description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                       type: string
                                     optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
                                       type: boolean
                                   type: object
                                 prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
+                                  description: The Secret to select from
                                   properties:
                                     name:
+                                      description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                       type: string
                                     optional:
+                                      description: Specify whether the Secret must be
+                                        defined
                                       type: boolean
                                   type: object
                               type: object
                             type: array
                           image:
+                            description: Docker image name.
                             type: string
                           imagePullPolicy:
+                            description: Image pull policy.
                             type: string
                           livenessProbe:
+                            description: Periodic probe of container liveness.
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -942,66 +1827,120 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           name:
+                            description: Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
                             type: string
                           readinessProbe:
+                            description: 'Periodic probe of container service readiness.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1009,43 +1948,70 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           resources:
+                            description: Compute Resources required by this container.
                             properties:
                               limits:
                                 additionalProperties:
@@ -1054,6 +2020,8 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -1062,30 +2030,61 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                             type: object
                           startupProbe:
+                            description: StartupProbe indicates that the Pod has successfully
+                              initialized.
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1093,56 +2092,103 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           volumeMounts:
+                            description: Pod volumes to mount into the container's filesystem.
                             items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
                               properties:
                                 mountPath:
+                                  description: Path within the container at which the
+                                    volume should be mounted.  Must not contain ':'.
                                   type: string
                                 mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and the
+                                    other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
+                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to false.
                                   type: boolean
                                 subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults to
+                                    "" (volume's root).
                                   type: string
                                 subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the container's
+                                    environment. Defaults to "" (volume's root). SubPathExpr
+                                    and SubPath are mutually exclusive.
                                   type: string
                               required:
                                 - mountPath
@@ -1150,12 +2196,15 @@ spec:
                               type: object
                             type: array
                           workingDir:
+                            description: Container's working directory.
                             type: string
                         required:
                           - name
                         type: object
                       type: array
                     jvmOptions:
+                      description: JvmOptions defines the Jvm options passed to the
+                        proxy
                       properties:
                         extraOptions:
                           items:
@@ -1177,12 +2226,19 @@ spec:
                     labels:
                       additionalProperties:
                         type: string
+                      description: Labels specifies the labels to attach to pod the
+                        operator creates for the cluster.
                       type: object
                     nodeSelector:
                       additionalProperties:
                         type: string
+                      description: NodeSelector specifies a map of key-value pairs.
+                        For a pod to be eligible to run on a node, the node must have
+                        each of the indicated key-value pairs as labels.
                       type: object
                     resources:
+                      description: Resources specifies the resource requirements of
+                        containers to run in the pod
                       properties:
                         limits:
                           additionalProperties:
@@ -1191,6 +2247,8 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                         requests:
                           additionalProperties:
@@ -1199,9 +2257,15 @@ spec:
                               - type: string
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                           type: object
                       type: object
                     secretRefs:
+                      description: SecretRefs defines how to mount required secrets
+                        into containers
                       items:
                         properties:
                           mountPath:
@@ -1214,51 +2278,120 @@ spec:
                         type: object
                       type: array
                     securityContext:
+                      description: 'SecurityContext specifies the security context for
+                      the entire pod More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context'
                       properties:
                         fsGroup:
+                          description: "A special supplemental group that applies to
+                          all containers in a pod. Some volume types allow the Kubelet
+                          to change the ownership of that volume to be owned by the
+                          pod: \n 1. The owning GID will be the FSGroup 2. The setgid
+                          bit is set (new files created in the volume will be owned
+                          by FSGroup) 3. The permission bits are OR'd with rw-rw----
+                          \n If unset, the Kubelet will not modify the ownership and
+                          permissions of any volume."
                           format: int64
                           type: integer
                         fsGroupChangePolicy:
+                          description: 'fsGroupChangePolicy defines behavior of changing
+                          ownership and permission of the volume before being exposed
+                          inside Pod. This field will only apply to volume types which
+                          support fsGroup based ownership(and permissions). It will
+                          have no effect on ephemeral volume types such as: secret,
+                          configmaps and emptydir. Valid values are "OnRootMismatch"
+                          and "Always". If not specified defaults to "Always".'
                           type: string
                         runAsGroup:
+                          description: The GID to run the entrypoint of the container
+                            process. Uses runtime default if unset. May also be set
+                            in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container.
                           format: int64
                           type: integer
                         runAsNonRoot:
+                          description: Indicates that the container must run as a non-root
+                            user. If true, the Kubelet will validate the image at runtime
+                            to ensure that it does not run as UID 0 (root) and fail
+                            to start the container if it does. If unset or false, no
+                            such validation will be performed. May also be set in SecurityContext.  If
+                            set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
                           type: boolean
                         runAsUser:
+                          description: The UID to run the entrypoint of the container
+                            process. Defaults to user specified in image metadata if
+                            unspecified. May also be set in SecurityContext.  If set
+                            in both SecurityContext and PodSecurityContext, the value
+                            specified in SecurityContext takes precedence for that container.
                           format: int64
                           type: integer
                         seLinuxOptions:
+                          description: The SELinux context to be applied to all containers.
+                            If unspecified, the container runtime will allocate a random
+                            SELinux context for each container.  May also be set in
+                            SecurityContext.  If set in both SecurityContext and PodSecurityContext,
+                            the value specified in SecurityContext takes precedence
+                            for that container.
                           properties:
                             level:
+                              description: Level is SELinux level label that applies
+                                to the container.
                               type: string
                             role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
                               type: string
                             type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
                               type: string
                             user:
+                              description: User is a SELinux user label that applies
+                                to the container.
                               type: string
                           type: object
                         seccompProfile:
+                          description: The seccomp options to use by the containers
+                            in this pod.
                           properties:
                             localhostProfile:
+                              description: localhostProfile indicates a profile defined
+                                in a file on the node should be used. The profile must
+                                be preconfigured on the node to work. Must be a descending
+                                path, relative to the kubelet's configured seccomp profile
+                                location. Must only be set if type is "Localhost".
                               type: string
                             type:
+                              description: "type indicates which kind of seccomp profile
+                              will be applied. Valid options are: \n Localhost - a
+                              profile defined in a file on the node should be used.
+                              RuntimeDefault - the container runtime default profile
+                              should be used. Unconfined - no profile should be applied."
                               type: string
                           required:
                             - type
                           type: object
                         supplementalGroups:
+                          description: A list of groups applied to the first process
+                            run in each container, in addition to the container's primary
+                            GID.  If unspecified, no groups will be added to any container.
                           items:
                             format: int64
                             type: integer
                           type: array
                         sysctls:
+                          description: Sysctls hold a list of namespaced sysctls used
+                            for the pod. Pods with unsupported sysctls (by the container
+                            runtime) might fail to launch.
                           items:
+                            description: Sysctl defines a kernel parameter to be set
                             properties:
                               name:
+                                description: Name of a property to set
                                 type: string
                               value:
+                                description: Value of a property to set
                                 type: string
                             required:
                               - name
@@ -1266,79 +2399,160 @@ spec:
                             type: object
                           type: array
                         windowsOptions:
+                          description: The Windows specific settings applied to all
+                            containers. If unspecified, the options within a container's
+                            SecurityContext will be used. If set in both SecurityContext
+                            and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence.
                           properties:
                             gmsaCredentialSpec:
+                              description: GMSACredentialSpec is where the GMSA admission
+                                webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                                inlines the contents of the GMSA credential spec named
+                                by the GMSACredentialSpecName field.
                               type: string
                             gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
                               type: string
                             runAsUserName:
+                              description: The UserName in Windows to run the entrypoint
+                                of the container process. Defaults to the user specified
+                                in image metadata if unspecified. May also be set in
+                                PodSecurityContext. If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext
+                                takes precedence.
                               type: string
                           type: object
                       type: object
                     serviceAccountName:
+                      description: ServiceAccountName is the name of the ServiceAccount
+                        to use to run pods.
                       type: string
                     sidecars:
+                      description: Sidecars defines sidecar containers running alongside
+                        with the main function container in the pod.
                       items:
+                        description: A single application container that you want to
+                          run within a pod. The Container API from the core group is
+                          not used directly to avoid unneeded fields and reduce the
+                          size of the CRD. New fields could be added as needed.
                         properties:
                           args:
+                            description: Arguments to the entrypoint.
                             items:
                               type: string
                             type: array
                           command:
+                            description: Entrypoint array. Not executed within a shell.
                             items:
                               type: string
                             type: array
                           env:
+                            description: List of environment variables to set in the
+                              container.
                             items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
                               properties:
                                 name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
                                   type: string
                                 value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                  expanded using the previous defined environment
+                                  variables in the container and any service environment
+                                  variables. If a variable cannot be resolved, the
+                                  reference in the input string will be unchanged.
+                                  The $(VAR_NAME) syntax can be escaped with a double
+                                  $$, ie: $$(VAR_NAME). Escaped references will never
+                                  be expanded, regardless of whether the variable
+                                  exists or not. Defaults to "".'
                                   type: string
                                 valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
                                   properties:
                                     configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
                                       properties:
                                         key:
+                                          description: The key to select.
                                           type: string
                                         name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
                                           type: boolean
                                       required:
                                         - key
                                       type: object
                                     fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                      spec.serviceAccountName, status.hostIP, status.podIP,
+                                      status.podIPs.'
                                       properties:
                                         apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
                                           type: string
                                         fieldPath:
+                                          description: Path of the field to select in
+                                            the specified API version.
                                           type: string
                                       required:
                                         - fieldPath
                                       type: object
                                     resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                      only resources limits and requests (limits.cpu,
+                                      limits.memory, limits.ephemeral-storage, requests.cpu,
+                                      requests.memory and requests.ephemeral-storage)
+                                      are currently supported.'
                                       properties:
                                         containerName:
+                                          description: 'Container name: required for
+                                          volumes, optional for env vars'
                                           type: string
                                         divisor:
                                           anyOf:
                                             - type: integer
                                             - type: string
+                                          description: Specifies the output format of
+                                            the exposed resources, defaults to "1"
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
                                         resource:
+                                          description: 'Required: resource to select'
                                           type: string
                                       required:
                                         - resource
                                       type: object
                                     secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
                                       properties:
                                         key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
                                           type: string
                                         name:
+                                          description: 'Name of the referent. More info:
+                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion,
+                                          kind, uid?'
                                           type: string
                                         optional:
+                                          description: Specify whether the Secret or
+                                            its key must be defined
                                           type: boolean
                                       required:
                                         - key
@@ -1349,52 +2563,99 @@ spec:
                               type: object
                             type: array
                           envFrom:
+                            description: List of sources to populate environment variables
+                              in the container.
                             items:
+                              description: EnvFromSource represents the source of a
+                                set of ConfigMaps
                               properties:
                                 configMapRef:
+                                  description: The ConfigMap to select from
                                   properties:
                                     name:
+                                      description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                       type: string
                                     optional:
+                                      description: Specify whether the ConfigMap must
+                                        be defined
                                       type: boolean
                                   type: object
                                 prefix:
+                                  description: An optional identifier to prepend to
+                                    each key in the ConfigMap. Must be a C_IDENTIFIER.
                                   type: string
                                 secretRef:
+                                  description: The Secret to select from
                                   properties:
                                     name:
+                                      description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
                                       type: string
                                     optional:
+                                      description: Specify whether the Secret must be
+                                        defined
                                       type: boolean
                                   type: object
                               type: object
                             type: array
                           image:
+                            description: Docker image name.
                             type: string
                           imagePullPolicy:
+                            description: Image pull policy.
                             type: string
                           livenessProbe:
+                            description: Periodic probe of container liveness.
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1402,66 +2663,120 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           name:
+                            description: Name of the container specified as a DNS_LABEL.
+                              Each container in a pod must have a unique name (DNS_LABEL).
                             type: string
                           readinessProbe:
+                            description: 'Periodic probe of container service readiness.
+                            More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1469,43 +2784,70 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           resources:
+                            description: Compute Resources required by this container.
                             properties:
                               limits:
                                 additionalProperties:
@@ -1514,6 +2856,8 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount of
+                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                               requests:
                                 additionalProperties:
@@ -1522,30 +2866,61 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                of compute resources required. If Requests is omitted
+                                for a container, it defaults to Limits if that is
+                                explicitly specified, otherwise to an implementation-defined
+                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                 type: object
                             type: object
                           startupProbe:
+                            description: StartupProbe indicates that the Pod has successfully
+                              initialized.
                             properties:
                               exec:
+                                description: One and only one of the following should
+                                  be specified. Exec specifies the action to take.
                                 properties:
                                   command:
+                                    description: Command is the command line to execute
+                                      inside the container, the working directory for
+                                      the command  is root ('/') in the container's
+                                      filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions
+                                      ('|', etc) won't work. To use a shell, you need
+                                      to explicitly call out to that shell. Exit status
+                                      of 0 is treated as live/healthy and non-zero is
+                                      unhealthy.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               failureThreshold:
+                                description: Minimum consecutive failures for the probe
+                                  to be considered failed after having succeeded. Defaults
+                                  to 3. Minimum value is 1.
                                 format: int32
                                 type: integer
                               httpGet:
+                                description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
+                                    description: Host name to connect to, defaults to
+                                      the pod IP. You probably want to set "Host" in
+                                      httpHeaders instead.
                                     type: string
                                   httpHeaders:
+                                    description: Custom headers to set in the request.
+                                      HTTP allows repeated headers.
                                     items:
+                                      description: HTTPHeader describes a custom header
+                                        to be used in HTTP probes
                                       properties:
                                         name:
+                                          description: The header field name
                                           type: string
                                         value:
+                                          description: The header field value
                                           type: string
                                       required:
                                         - name
@@ -1553,56 +2928,103 @@ spec:
                                       type: object
                                     type: array
                                   path:
+                                    description: Path to access on the HTTP server.
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Name or number of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
+                                    description: Scheme to use for connecting to the
+                                      host. Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
                                 type: object
                               initialDelaySeconds:
+                                description: 'Number of seconds after the container
+                                has started before liveness probes are initiated.
+                                More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                               periodSeconds:
+                                description: How often (in seconds) to perform the probe.
+                                  Default to 10 seconds. Minimum value is 1.
                                 format: int32
                                 type: integer
                               successThreshold:
+                                description: Minimum consecutive successes for the probe
+                                  to be considered successful after having failed. Defaults
+                                  to 1. Must be 1 for liveness and startup. Minimum
+                                  value is 1.
                                 format: int32
                                 type: integer
                               tcpSocket:
+                                description: 'TCPSocket specifies an action involving
+                                a TCP port. TCP hooks not yet supported TODO: implement
+                                a realistic TCP lifecycle hook'
                                 properties:
                                   host:
+                                    description: 'Optional: Host name to connect to,
+                                    defaults to the pod IP.'
                                     type: string
                                   port:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Number or name of the port to access
+                                      on the container. Number must be in the range
+                                      1 to 65535. Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                               timeoutSeconds:
+                                description: 'Number of seconds after which the probe
+                                times out. Defaults to 1 second. Minimum value is
+                                1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                 format: int32
                                 type: integer
                             type: object
                           volumeMounts:
+                            description: Pod volumes to mount into the container's filesystem.
                             items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
                               properties:
                                 mountPath:
+                                  description: Path within the container at which the
+                                    volume should be mounted.  Must not contain ':'.
                                   type: string
                                 mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and the
+                                    other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
                                   type: string
                                 name:
+                                  description: This must match the Name of a Volume.
                                   type: string
                                 readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to false.
                                   type: boolean
                                 subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults to
+                                    "" (volume's root).
                                   type: string
                                 subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the container's
+                                    environment. Defaults to "" (volume's root). SubPathExpr
+                                    and SubPath are mutually exclusive.
                                   type: string
                               required:
                                 - mountPath
@@ -1610,81 +3032,158 @@ spec:
                               type: object
                             type: array
                           workingDir:
+                            description: Container's working directory.
                             type: string
                         required:
                           - name
                         type: object
                       type: array
                     terminationGracePeriodSeconds:
+                      description: TerminationGracePeriodSeconds is the amount of time
+                        that kubernetes will give for a pod before terminating it.
                       format: int64
                       type: integer
                     tolerations:
+                      description: Tolerations specifies the tolerations of a Pod
                       items:
+                        description: The pod this Toleration is attached to tolerates
+                          any taint that matches the triple <key,value,effect> using
+                          the matching operator <operator>.
                         properties:
                           effect:
+                            description: Effect indicates the taint effect to match.
+                              Empty means match all taint effects. When specified, allowed
+                              values are NoSchedule, PreferNoSchedule and NoExecute.
                             type: string
                           key:
+                            description: Key is the taint key that the toleration applies
+                              to. Empty means match all taint keys. If the key is empty,
+                              operator must be Exists; this combination means to match
+                              all values and all keys.
                             type: string
                           operator:
+                            description: Operator represents a key's relationship to
+                              the value. Valid operators are Exists and Equal. Defaults
+                              to Equal. Exists is equivalent to wildcard for value,
+                              so that a pod can tolerate all taints of a particular
+                              category.
                             type: string
                           tolerationSeconds:
+                            description: TolerationSeconds represents the period of
+                              time the toleration (which must be of effect NoExecute,
+                              otherwise this field is ignored) tolerates the taint.
+                              By default, it is not set, which means tolerate the taint
+                              forever (do not evict). Zero and negative values will
+                              be treated as 0 (evict immediately) by the system.
                             format: int64
                             type: integer
                           value:
+                            description: Value is the taint value the toleration matches
+                              to. If the operator is Exists, the value should be empty,
+                              otherwise just a regular string.
                             type: string
                         type: object
                       type: array
                     vars:
+                      description: Vars specifies the environment variables of a Pod
                       items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
                         properties:
                           name:
+                            description: Name of the environment variable. Must be a
+                              C_IDENTIFIER.
                             type: string
                           value:
+                            description: 'Variable references $(VAR_NAME) are expanded
+                            using the previous defined environment variables in the
+                            container and any service environment variables. If a
+                            variable cannot be resolved, the reference in the input
+                            string will be unchanged. The $(VAR_NAME) syntax can be
+                            escaped with a double $$, ie: $$(VAR_NAME). Escaped references
+                            will never be expanded, regardless of whether the variable
+                            exists or not. Defaults to "".'
                             type: string
                           valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
                             properties:
                               configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
                                 properties:
                                   key:
+                                    description: The key to select.
                                     type: string
                                   name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                     type: string
                                   optional:
+                                    description: Specify whether the ConfigMap or its
+                                      key must be defined
                                     type: boolean
                                 required:
                                   - key
                                 type: object
                               fieldRef:
+                                description: 'Selects a field of the pod: supports metadata.name,
+                                metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                spec.serviceAccountName, status.hostIP, status.podIP,
+                                status.podIPs.'
                                 properties:
                                   apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
                                     type: string
                                   fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
                                     type: string
                                 required:
                                   - fieldPath
                                 type: object
                               resourceFieldRef:
+                                description: 'Selects a resource of the container: only
+                                resources limits and requests (limits.cpu, limits.memory,
+                                limits.ephemeral-storage, requests.cpu, requests.memory
+                                and requests.ephemeral-storage) are currently supported.'
                                 properties:
                                   containerName:
+                                    description: 'Container name: required for volumes,
+                                    optional for env vars'
                                     type: string
                                   divisor:
                                     anyOf:
                                       - type: integer
                                       - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   resource:
+                                    description: 'Required: resource to select'
                                     type: string
                                 required:
                                   - resource
                                 type: object
                               secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
                                 properties:
                                   key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
                                     type: string
                                   name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
                                     type: string
                                   optional:
+                                    description: Specify whether the Secret or its key
+                                      must be defined
                                     type: boolean
                                 required:
                                   - key
@@ -1695,22 +3194,66 @@ spec:
                         type: object
                       type: array
                     volumes:
+                      description: Volumes defines extra volumes of the pod.
                       items:
+                        description: Volume represents a named volume in a pod that
+                          may be accessed by any container in the pod. The Volume API
+                          from the core group is not used directly to avoid unneeded
+                          fields defined in `VolumeSource` and reduce the size of the
+                          CRD. New fields in VolumeSource could be added as needed.
                         properties:
                           configMap:
+                            description: ConfigMap represents a configMap that should
+                              populate this volume
                             properties:
                               defaultMode:
+                                description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0
+                                and 511. YAML accepts both octal and decimal values,
+                                JSON requires decimal values for mode bits. Defaults
+                                to 0644. Directories within the path are not affected
+                                by this setting. This might be in conflict with other
+                                options that affect the file mode, like fsGroup, and
+                                the result can be other mode bits set.'
                                 format: int32
                                 type: integer
                               items:
+                                description: If unspecified, each key-value pair in
+                                  the Data field of the referenced ConfigMap will be
+                                  projected into the volume as a file whose name is
+                                  the key and content is the value. If specified, the
+                                  listed keys will be projected into the specified paths,
+                                  and unlisted keys will not be present. If a key is
+                                  specified which is not present in the ConfigMap, the
+                                  volume setup will error unless it is marked optional.
+                                  Paths must be relative and may not contain the '..'
+                                  path or start with '..'.
                                 items:
+                                  description: Maps a string key to a path within a
+                                    volume.
                                   properties:
                                     key:
+                                      description: The key to project.
                                       type: string
                                     mode:
+                                      description: 'Optional: mode bits used to set
+                                      permissions on this file. Must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
                                       format: int32
                                       type: integer
                                     path:
+                                      description: The relative path of the file to
+                                        map the key to. May not be an absolute path.
+                                        May not contain the path element '..'. May not
+                                        start with the string '..'.
                                       type: string
                                   required:
                                     - key
@@ -1718,26 +3261,70 @@ spec:
                                   type: object
                                 type: array
                               name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
                                 type: string
                               optional:
+                                description: Specify whether the ConfigMap or its keys
+                                  must be defined
                                 type: boolean
                             type: object
                           name:
+                            description: 'Volume''s name. Must be a DNS_LABEL and unique
+                            within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                             type: string
                           secret:
+                            description: Secret represents a secret that should populate
+                              this volume.
                             properties:
                               defaultMode:
+                                description: 'Optional: mode bits used to set permissions
+                                on created files by default. Must be an octal value
+                                between 0000 and 0777 or a decimal value between 0
+                                and 511. YAML accepts both octal and decimal values,
+                                JSON requires decimal values for mode bits. Defaults
+                                to 0644. Directories within the path are not affected
+                                by this setting. This might be in conflict with other
+                                options that affect the file mode, like fsGroup, and
+                                the result can be other mode bits set.'
                                 format: int32
                                 type: integer
                               items:
+                                description: If unspecified, each key-value pair in
+                                  the Data field of the referenced Secret will be projected
+                                  into the volume as a file whose name is the key and
+                                  content is the value. If specified, the listed keys
+                                  will be projected into the specified paths, and unlisted
+                                  keys will not be present. If a key is specified which
+                                  is not present in the Secret, the volume setup will
+                                  error unless it is marked optional. Paths must be
+                                  relative and may not contain the '..' path or start
+                                  with '..'.
                                 items:
+                                  description: Maps a string key to a path within a
+                                    volume.
                                   properties:
                                     key:
+                                      description: The key to project.
                                       type: string
                                     mode:
+                                      description: 'Optional: mode bits used to set
+                                      permissions on this file. Must be an octal value
+                                      between 0000 and 0777 or a decimal value between
+                                      0 and 511. YAML accepts both octal and decimal
+                                      values, JSON requires decimal values for mode
+                                      bits. If not specified, the volume defaultMode
+                                      will be used. This might be in conflict with
+                                      other options that affect the file mode, like
+                                      fsGroup, and the result can be other mode bits
+                                      set.'
                                       format: int32
                                       type: integer
                                     path:
+                                      description: The relative path of the file to
+                                        map the key to. May not be an absolute path.
+                                        May not contain the path element '..'. May not
+                                        start with the string '..'.
                                       type: string
                                   required:
                                     - key
@@ -1745,8 +3332,12 @@ spec:
                                   type: object
                                 type: array
                               optional:
+                                description: Specify whether the Secret or its keys
+                                  must be defined
                                 type: boolean
                               secretName:
+                                description: 'Name of the secret in the pod''s namespace
+                                to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                 type: string
                             type: object
                         required:
@@ -1755,13 +3346,29 @@ spec:
                       type: array
                   type: object
                 replicas:
+                  description: Replicas is the expected size of the zookeeper cluster.
+                    The zookeeper operator will eventually make the size of the running
+                    cluster equal to the expected size.
                   format: int32
                   type: integer
               type: object
             status:
+              description: ZooKeeperClusterStatus defines the observed state of ZooKeeperCluster
               properties:
                 conditions:
+                  description: Conditions represent observations of the ZookeeperCluster's
+                    state
                   items:
+                    description: "Condition represents an observation of an object's
+                    state. Conditions are an extension mechanism intended to be used
+                    when the details of an observation are not a priori known or would
+                    not apply to all instances of a given Kind. \n Conditions should
+                    be added to explicitly convey properties that users and components
+                    care about rather than requiring those properties to be inferred
+                    from other observations. Once defined, the meaning of a Condition
+                    can not be changed arbitrarily - it becomes part of the API, and
+                    has the same backwards- and forwards-compatibility concerns of
+                    any other part of the API."
                     properties:
                       lastTransitionTime:
                         format: date-time
@@ -1769,10 +3376,20 @@ spec:
                       message:
                         type: string
                       reason:
+                        description: ConditionReason is intended to be a one-word, CamelCase
+                          representation of the category of cause of the current status.
+                          It is intended to be used in concise output, such as one-line
+                          kubectl get output, and in summarizing occurrences of causes.
                         type: string
                       status:
                         type: string
                       type:
+                        description: "ConditionType is the type of the condition and
+                        is typically a CamelCased word or short phrase. \n Condition
+                        types should indicate state in the \"abnormal-true\" polarity.
+                        For example, if the condition indicates when a policy is invalid,
+                        the \"is valid\" case is probably the norm, so the condition
+                        should be called \"Invalid\"."
                         type: string
                     required:
                       - status
@@ -1780,24 +3397,39 @@ spec:
                     type: object
                   type: array
                 externalServiceEndpoint:
+                  description: ExternalServiceEndpoint is the external service endpoint
+                    (ip:port)
                   type: string
                 internalServiceEndpoint:
+                  description: InternalServiceEndpoint is the internal service endpoint
+                    (ip:port)
                   type: string
                 labelSelector:
+                  description: Label selector for scaling
                   type: string
                 numReadyServers:
+                  description: NumReadyServers is the number of zookeeper servers in
+                    the cluster that are in ready status
                   format: int32
                   type: integer
                 observedGeneration:
+                  description: ObservedGeneration is the most recent generation observed
+                    for this cluster. It corresponds to the metadata generation, which
+                    is updated on mutation by the API Server.
                   format: int64
                   type: integer
                 readyReplicas:
+                  description: ReadyReplicas is the number of ready zookeeper servers
+                    in the cluster
                   format: int32
                   type: integer
                 replicas:
+                  description: Replicas is the number of desired zookeeper servers in
+                    the cluster
                   format: int32
                   type: integer
                 servers:
+                  description: Servers is the list of servers in the zookeeper cluster
                   properties:
                     notReady:
                       items:
@@ -1812,6 +3444,8 @@ spec:
                     - ready
                   type: object
                 updatedReplicas:
+                  description: UpdatedReplicas is the number of zookeeper servers that
+                    has been updated to the latest configuration
                   format: int32
                   type: integer
               required:


### PR DESCRIPTION
### Motivation
Add description to crd so user can see detailed explanation of fields when doing kubectl explain like `kubectl explain pulsarbroker.spec.image`.
