### PR TITLE
[Feat] Support adding additional PVC to Pulsar Broker.

### DIFF
--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -406,13 +406,21 @@ spec:
 {{- end }}
     {{- end }}
   {{- end }}
-  {{- if or .Values.tls.broker.enabled .Values.broker.extraVolumeMounts }}
+  {{- if or .Values.tls.broker.enabled .Values.broker.extraVolumeMounts .Values.broker.extraVolumeClaimTemplates }}
   apiObjects:
     statefulSet:
+{{- if or .Values.tls.broker.enabled .Values.broker.extraVolumeMounts }}
       volumeMounts:
       {{- include "pulsar.broker.certs.volumeMounts" . | nindent 6 }}
 {{- with .Values.broker.extraVolumeMounts }}
 {{ toYaml . | indent 6 }}
+{{- end }}
+{{- end }}
+{{- if or .Values.tls.broker.enabled .Values.broker.extraVolumeMounts }}
+      volumeClaimTemplates:
+{{- with .Values.broker.extraVolumeClaimTemplates }}
+{{ toYaml . | indent 6 }}
+{{- end }}        
 {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1092,15 +1092,28 @@ broker:
   #   secretName: "[secret name]"
   extraSecretRefs: []
   # extra volumes to mount to broker pod, need to mount it in .Value.broker.
-  extraVolumes:
+  extraVolumes: []
 #  - name: my-extra-volume
 #    configMap:
 #      name: additional-config
 #      defaultMode: 511
   # extra volumes to mount to broker pod, need to mount it in .Value.broker.
-  extraVolumeMounts:
+  extraVolumeMounts: []
 #  - name: my-extra-volume
 #    mountPath: /pulsar/conf/custom
+  # extra volumes claim template if broker needs to persistent data like offloading to FS.
+  extraVolumeClaimTemplates: []
+#  - apiVersion: v1
+#    kind: PersistentVolumeClaim
+#    metadata:
+#      name: fs-offload
+#    spec:
+#      storageClassName: standard
+#      accessModes:
+#        - ReadWriteOnce
+#      resources:
+#        requests:
+#          storage: 20Gi
   # Definition of the serviceAccount used to run brokers.
   serviceAccount:
     # Specifies whether to use a service account to run this component


### PR DESCRIPTION
Related to https://github.com/streamnative/pulsar-operators/issues/591

### Motivation
Mounting additional PVC to Pulsar Broker if needed to support use case like offloading to FS where persistent storage is required.

### Modifications
Add PVC spec to PulsarBroker's APIObject's STS template if defined.

### Verifying this change
- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

- [x] `no-need-doc` 
  