### PR TITLE
fix(sn-platform): remove legacy image configs for configmapReload

### DIFF
--- a/charts/sn-platform/templates/prometheus/prometheus-statefulset.yaml
+++ b/charts/sn-platform/templates/prometheus/prometheus-statefulset.yaml
@@ -126,8 +126,8 @@ spec:
       containers:
       {{- if .Values.configmapReload.prometheus.enabled }}
       - name: {{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}-{{ .Values.configmapReload.prometheus.name }}
-        image: "{{ .Values.configmapReload.prometheus.image.repository }}:{{ .Values.configmapReload.prometheus.image.tag }}"
-        imagePullPolicy: "{{ .Values.configmapReload.prometheus.image.pullPolicy }}"
+        image: "{{ .Values.images.configmapReload.repository }}:{{ .Values.images.configmapReload.tag }}"
+        imagePullPolicy: "{{ .Values.images.configmapReload.pullPolicy }}"
         args:
           - --volume-dir=/etc/config
           - --webhook-url=http://127.0.0.1:{{ .Values.prometheus.port }}{{ template "pulsar.control_center_path.prometheus" . }}/-/reload

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -239,7 +239,7 @@ images:
     pullPolicy: IfNotPresent
   configmapReload:
     repository: jimmidyson/configmap-reload
-    tag: v0.3.0
+    tag: "v0.3.0"
     pullPolicy: IfNotPresent
   external_dns:
     repository: k8s.gcr.io/external-dns/external-dns

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1532,14 +1532,6 @@ configmapReload:
     ## configmap-reload container name
     ##
     name: configmap-reload
-    ## configmap-reload container image
-    ##
-    # Deprecated, this configuration repository, tag and pullPolicy has been moved to the images section
-    image:
-      repository: jimmidyson/configmap-reload
-      tag: v0.3.0
-      pullPolicy: IfNotPresent
-
     ## Additional configmap-reload container arguments
     ##
     extraArgs: {}
@@ -1568,15 +1560,6 @@ configmapReload:
     ## configmap-reload container name
     ##
     name: configmap-reload
-
-    # Deprecated, this configuration repository, tag and pullPolicy has been moved to the images section
-    ## configmap-reload container image
-    ##
-    image:
-      repository: jimmidyson/configmap-reload
-      tag: v0.3.0
-      pullPolicy: IfNotPresent
-
     ## Additional configmap-reload container arguments
     ##
     extraArgs: {}


### PR DESCRIPTION
Signed-off-by: ericsyh <ericshenyuhao@outlook.com>

<!--
### Contribution Checklist
  
  - Name the pull request in the form "[charts/<chart-name>] Title of the pull request".
    Skip *[charts/<chart-name>]* if the PR doesn't change a specific chart. E.g. `[docs] Fix typo in README`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

`.Values.configmapReload.prometheus.image.repository` configs should be replaced by `.Values.images.configmapReload.repository`. AlertManager has the correct configs while Prometheus has the legacy configs.

### Modifications

Replace `image: "{{ .Values.configmapReload.prometheus.image.repository }}:{{ .Values.configmapReload.prometheus.image.tag }}"` by `image: "{{ .Values.images.configmapReload.repository }}:{{ .Values.images.configmapReload.tag }}"` and remove the legacy configs in values.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

