### PR TITLE
Simplify vault component name.

### DIFF
--- a/charts/sn-platform-common/templates/_commmon.tpl
+++ b/charts/sn-platform-common/templates/_commmon.tpl
@@ -158,7 +158,7 @@ Define the pulsar zookeeper
 Inject vault token values to pod through env variables
 */}}
 {{- define "pulsar.vault-secret-key-name" -}}
-{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-secret-env-injection
+{{ template "pulsar.fullname" . }}-secret-env-injection
 {{- end }}
 
 {{- define "pulsar.vault.url" -}}

--- a/charts/sn-platform-vault/templates/_vault.tpl
+++ b/charts/sn-platform-vault/templates/_vault.tpl
@@ -1,10 +1,16 @@
+{{- define "vault.component" -}}
+{{- if .Values.global.stackName -}}
+{{- printf "-%s" .Values.vault.component }}
+{{- end -}}
+{{- end -}}
+
 {{/*Define vault service account*/}}
 {{- define "vault.serviceAccount" -}}
 {{- if .Values.vault.serviceAccount.created -}}
     {{- if .Values.vault.serviceAccount.name -}}
 {{ .Values.vault.serviceAccount.name }}
     {{- else -}}
-{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-acct
+{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-acct
     {{- end -}}
 {{- else -}}
 {{ .Values.vault.serviceAccount.name }}
@@ -20,7 +26,7 @@
 {{- end -}}
 
 {{- define "console-secret-key-name" -}}
-{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-console-admin-passwd
+{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-console-admin-passwd
 {{- end }}
 
 {{/*Define vault datadog annotation*/}}
@@ -50,11 +56,11 @@ ad.datadoghq.com/vault.instances: |
 {{- end }}
 
 {{- define "vault-unseal-secret-key-name" -}}
-{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-unseal-keys
+{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-unseal-keys
 {{- end }}
 
 {{- define "vault.url" -}}
-http://{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}:8200
+http://{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}:8200
 {{- end }}
 
 {{- define "vault.storage.class" -}}
@@ -71,7 +77,7 @@ storageClassName: "{{ .Values.vault.volume.storageClassName }}"
 Define pulsar vault root tokens volume mounts
 */}}
 {{- define "vault.rootToken.volumeMounts" -}}
-- name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-root-token"
+- name: "{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-root-token"
   mountPath: "/root/{{ template "pulsar.home" .}}/rootToken"
   subPath: vault-root
 {{- end }}
@@ -80,7 +86,7 @@ Define pulsar vault root tokens volume mounts
 Define pulsar vault root tokens volume
 */}}
 {{- define "vault.rootToken.volumes" -}}
-- name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-root-token"
+- name: "{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-root-token"
   secret:
     secretName: "{{ template "vault-unseal-secret-key-name" }}
 {{- end }}
@@ -89,7 +95,7 @@ Define pulsar vault root tokens volume
 Define pulsar create pulsar tokens volume mounts
 */}}
 {{- define "vault.createPulsarTokens.volumeMounts" -}}
-- name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-create-pulsar-tokens"
+- name: "{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-create-pulsar-tokens"
   mountPath: "/root/{{ template "pulsar.home" .}}/create_pulsar_tokens/"
 {{- end }}
 
@@ -97,9 +103,9 @@ Define pulsar create pulsar tokens volume mounts
 Define pulsar create pulsar tokens volumes
 */}}
 {{- define "vault.createPulsarTokens.volumes" -}}
-- name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-create-pulsar-tokens"
+- name: "{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-create-pulsar-tokens"
   configMap:
-    name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-create-pulsar-tokens"
+    name: "{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-create-pulsar-tokens"
 {{- end }}
 
 
@@ -107,7 +113,7 @@ Define pulsar create pulsar tokens volumes
 Define pulsar init pulsar manager volume mounts
 */}}
 {{- define "vault.initStreamNativeConsole.volumeMounts" -}}
-- name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-init-streamnative-console"
+- name: "{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-init-streamnative-console"
   mountPath: "/root/{{ template "pulsar.home" .}}/init_vault_streamnative_console/"
 {{- end }}
 
@@ -115,7 +121,7 @@ Define pulsar init pulsar manager volume mounts
 Define pulsar init pulsar manager volumes
 */}}
 {{- define "vault.initStreamNativeConsole.volumes" -}}
-- name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-init-streamnative-console"
+- name: "{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-init-streamnative-console"
   configMap:
-    name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-init-streamnative-console"
+    name: "{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-init-streamnative-console"
 {{- end }}

--- a/charts/sn-platform-vault/templates/vault-authorizationpolicy.yaml
+++ b/charts/sn-platform-vault/templates/vault-authorizationpolicy.yaml
@@ -20,7 +20,7 @@
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}"
+  name: "{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}"
   namespace: {{ template "pulsar.namespace" . }}
 spec:
   rules:
@@ -33,5 +33,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: vault
-      vault_cr: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}"
+      vault_cr: "{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}"
 {{- end }}

--- a/charts/sn-platform-vault/templates/vault-clear-resource.yaml
+++ b/charts/sn-platform-vault/templates/vault-clear-resource.yaml
@@ -26,7 +26,7 @@ metadata:
     helm.sh/hook: pre-delete
     helm.sh/hook-weight: "-5"
     helm.sh/hook-delete-policy: hook-succeeded
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-clear-resource"
+  name: "{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-clear-resource"
   namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
@@ -38,7 +38,7 @@ spec:
     spec:
       serviceAccountName: {{ template "vault.serviceAccount" . }}
       containers:
-      - name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-init"
+      - name: "{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-init"
         image: "{{ .Values.images.vault_init.repository }}:{{ .Values.images.vault_init.tag }}"
         imagePullPolicy: {{ .Values.images.vault.pullPolicy }}
         command: ["sh", "-c"]

--- a/charts/sn-platform-vault/templates/vault-configmap.yaml
+++ b/charts/sn-platform-vault/templates/vault-configmap.yaml
@@ -19,7 +19,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-create-pulsar-tokens"
+  name: "{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-create-pulsar-tokens"
   namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
@@ -30,7 +30,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-init-streamnative-console"
+  name: "{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-init-streamnative-console"
   namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}

--- a/charts/sn-platform-vault/templates/vault-initialize-public-key.yaml
+++ b/charts/sn-platform-vault/templates/vault-initialize-public-key.yaml
@@ -20,7 +20,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-init-public-key"
+  name: "{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-init-public-key"
   namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
@@ -36,7 +36,7 @@ spec:
     spec:
       serviceAccountName: {{ template "vault.serviceAccount" . }}
       containers:
-      - name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-init"
+      - name: "{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-init"
         image: "{{ .Values.images.vault_init.repository }}:{{ .Values.images.vault_init.tag }}"
         imagePullPolicy: {{ .Values.images.vault.pullPolicy }}
         command: ["sh", "-c"]
@@ -62,7 +62,7 @@ spec:
            echo "vault is ready~";
            echo "Start init public key to secret";
            publicKey=$(wget -qO- http://{{ template "vault.url" . }}/v1/identity/oidc/.well-known/keys | base64 | tr -d \\n);
-           kubectl patch secret {{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-public-key --type='json' -p='[{"op":"replace","path":"/data/publicKey","value":"'$publicKey'"}]' -n {{ template "pulsar.namespace" . }};
+           kubectl patch secret {{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-public-key --type='json' -p='[{"op":"replace","path":"/data/publicKey","value":"'$publicKey'"}]' -n {{ template "pulsar.namespace" . }};
            echo -ne "POST /quitquitquit HTTP/1.1\r\nHost: 127.0.0.1:15020\r\nUser-Agent: curl/7.68.0\r\nAccept: */*\r\n\r\n"|nc 127.0.0.1:15020 || true;
         env:
         - name: VAULT_ADDR

--- a/charts/sn-platform-vault/templates/vault-initialize.yaml
+++ b/charts/sn-platform-vault/templates/vault-initialize.yaml
@@ -20,7 +20,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-init"
+  name: "{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-init"
   namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
@@ -41,7 +41,7 @@ spec:
 {{ toYaml .Values.global.imagePullSecrets | indent 8 }}
       {{- end }}
       containers:
-      - name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-init"
+      - name: "{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-init"
         image: "{{ .Values.images.vault_init.repository }}:{{ .Values.images.vault_init.tag }}"
         imagePullPolicy: {{ .Values.images.vault.pullPolicy }}
         command: ["sh", "-c"]

--- a/charts/sn-platform-vault/templates/vault-public-key-secret.yaml
+++ b/charts/sn-platform-vault/templates/vault-public-key-secret.yaml
@@ -21,6 +21,6 @@ kind: Secret
 data:
   publicKey: ""
 metadata:
-  name: {{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-public-key
+  name: {{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-public-key
   namespace: {{ template "pulsar.namespace" . }}
 type: Opaque

--- a/charts/sn-platform-vault/templates/vault.yaml
+++ b/charts/sn-platform-vault/templates/vault.yaml
@@ -19,7 +19,7 @@
 apiVersion: vault.banzaicloud.com/v1alpha1
 kind: Vault
 metadata:
-  name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}"
+  name: "{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}"
   namespace: {{ template "pulsar.namespace" . }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
@@ -55,7 +55,7 @@ spec:
   {{- end }}
   {{- if or .Values.vault.config.bankVaults.probe.livenessProbe .Values.vault.config.bankVaults.probe.startupProbe .Values.vault.config.bankVaults.probe.readinessProbe }}
   vaultContainerSpec:
-    name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-vault"
+    name: "{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-vault"
     {{- if .Values.vault.config.bankVaults.probe.readinessProbe }}
     readinessProbe:
 {{ toYaml .Values.vault.config.bankVaults.probe.readinessProbe | indent 6 }}
@@ -72,7 +72,7 @@ spec:
 {{- if and .Values.volumes.persistence .Values.vault.volume.persistence}}
   volumeClaimTemplates:
   - metadata:
-      name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-{{ .Values.vault.volume.name }}"
+      name: "{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-{{ .Values.vault.volume.name }}"
     spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
@@ -81,11 +81,11 @@ spec:
       {{- include "vault.storage.class" . | nindent 6 }}
 {{- else }}
   volumes:
-  - name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-{{ .Values.vault.volume.name }}"
+  - name: "{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-{{ .Values.vault.volume.name }}"
     emptyDir: {}
   {{- end }}
   volumeMounts:
-    - name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-{{ .Values.vault.volume.name }}"
+    - name: "{{ template "pulsar.fullname" . }}{{ template "vault.component" . }}-{{ .Values.vault.volume.name }}"
       mountPath: /vault/file
   unsealConfig:
     kubernetes:

--- a/charts/sn-platform-vault/values.yaml
+++ b/charts/sn-platform-vault/values.yaml
@@ -16,11 +16,14 @@
 # specific language governing permissions and limitations
 # under the License.
 #
+global:
+  ## Reference to one or more secrets to be used when pulling images
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  imagePullSecrets: []
+  stackName: ""
 
 ## Namespace to deploy 
 namespace: ""
-stackName: pulsar
-stackVersion: "1.0.0"
 
 ###
 ### Global Settings
@@ -87,11 +90,6 @@ auth:
     # pulsar-admin client to broker/proxy communication
     client: "admin"
     
-global:
-  ## Reference to one or more secrets to be used when pulling images
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-  imagePullSecrets: []
-
 vault:
   component: "vault"
   # -- replicaCount indicates the number of vault pod
@@ -109,7 +107,7 @@ vault:
   volumeClaimTemplates: []
   unsealConfig: {}
   volumeMounts:
-    - name: vault-raft
+    - name: raft
       mountPath: /vault/file
       # use raft protocol for a vault cluster
   config:
@@ -147,7 +145,7 @@ vault:
       cpu: "100m"
   volume:
     persistence: true
-    name: "vault-volume"
+    name: "volume"
     size: 10Gi
     local_storage: true
     # storageClassName: ""


### PR DESCRIPTION
### Motivation
Simplify vault component name. Currently component name can look like `my-release-sn-platform-vault-vault-init`
where the component name `vault` is kind of duplicated and confusing.

### Modifications
Only add component name `vault` when it's needed.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

- [x] `no-need-doc` 
  