### PR TITLE
Default enable wal compression, for avoid prometheus oom

### DIFF
--- a/charts/sn-platform/templates/prometheus/prometheus-statefulset.yaml
+++ b/charts/sn-platform/templates/prometheus/prometheus-statefulset.yaml
@@ -172,6 +172,9 @@ spec:
   {{ if .Values.prometheus.maxQuerySamples }}
           - --query.max-samples={{.Values.prometheus.maxQuerySamples }}
   {{- end }}
+  {{ if .Values.prometheus.args.walCompressionEnabled }}
+          - --storage.tsdb.wal-compression
+  {{- end }}
         ports:
         - name: server
           containerPort: {{ .Values.prometheus.port }}

--- a/charts/sn-platform/templates/prometheus/prometheus-statefulset.yaml
+++ b/charts/sn-platform/templates/prometheus/prometheus-statefulset.yaml
@@ -172,9 +172,9 @@ spec:
   {{ if .Values.prometheus.maxQuerySamples }}
           - --query.max-samples={{.Values.prometheus.maxQuerySamples }}
   {{- end }}
-  {{ if .Values.prometheus.args.walCompressionEnabled }}
-          - --storage.tsdb.wal-compression
-  {{- end }}
+          {{- with .Values.prometheus.extraArgs }}
+          {{ toYaml . | nindent 10 }}
+          {{- end }}
         ports:
         - name: server
           containerPort: {{ .Values.prometheus.port }}

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1664,8 +1664,9 @@ prometheus:
     ## Prometheus data retention period (default if not specified is 15 days)
     ##
     retention: "15d"
+  extraArgs:
     # https://prometheus.io/docs/prometheus/latest/storage/#operational-aspects
-    walCompressionEnabled: true
+    - --storage.tsdb.wal-compression
   scrapeInterval: 15s
   securityContext:
     runAsUser: 65534

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1664,6 +1664,8 @@ prometheus:
     ## Prometheus data retention period (default if not specified is 15 days)
     ##
     retention: "15d"
+    # https://prometheus.io/docs/prometheus/latest/storage/#operational-aspects
+    walCompressionEnabled: true
   scrapeInterval: 15s
   securityContext:
     runAsUser: 65534


### PR DESCRIPTION



Master Issue: #716 

### Motivation

https://prometheus.io/docs/prometheus/latest/storage/#operational-aspects

```
--storage.tsdb.wal-compression: Enables compression of the write-ahead log (WAL). Depending on your data, you can expect the WAL size to be halved with little extra cpu load. This flag was introduced in 2.11.0 and enabled by default in 2.20.0. Note that once enabled, downgrading Prometheus to a version below 2.11.0 will require deleting the WAL.
```

### Modifications

* Add option for enable wal compression for prometheus

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

