### PR TITLE
Fix ingress api kind compatibility when k8s version is 1.22+

### DIFF
--- a/charts/pulsar/templates/control-center/control-center-ingress.yaml
+++ b/charts/pulsar/templates/control-center/control-center-ingress.yaml
@@ -19,10 +19,13 @@
 
 {{- if .Values.ingress.control_center.enabled }}
 {{- $fullName := include "pulsar.fullname" . -}}
+{{- $isIngressAPIStable := eq (include "pulsar.ingress.isStable" .) "true" -}}
 
 {{/* COMMENT */}}
 {{- if .Values.deployment.openshift }}
 apiVersion: networking.k8s.io/v1beta1
+{{- else if $isIngressAPIStable }}
+apiVersion: networking.k8s.io/v1
 {{- else }}
 apiVersion: extensions/v1beta1
 {{- end }}
@@ -68,37 +71,91 @@ spec:
         paths:
           {{- if and .Values.monitoring.grafana .Values.ingress.control_center.endpoints.grafana }}
           - path: /grafana
+            {{- if $isIngressAPIStable }}
+            pathType: {{ .Values.grafana.pathType | default "ImplementationSpecific" }}
+            backend:
+              service:
+                name: "{{ $fullName }}-{{ .Values.grafana.component }}"
+                port:
+                  number: {{ .Values.grafana.port }}
+            {{- else }}
             backend:
               serviceName: "{{ $fullName }}-{{ .Values.grafana.component }}"
               servicePort: {{ .Values.grafana.port }}
+            {{- end }}
           {{- end }}
           {{- if and .Values.monitoring.alert_manager .Values.ingress.control_center.endpoints.alertmanager }}
           - path: /alerts
+            {{- if $isIngressAPIStable }}
+            pathType: {{ .Values.alert_manager.pathType | default "ImplementationSpecific" }}
+            backend:
+              service: 
+                name: "{{ $fullName }}-{{ .Values.alert_manager.component }}"
+                port: 
+                  number: {{ .Values.alert_manager.port }}
+            {{- else }}
             backend:
               serviceName: "{{ $fullName }}-{{ .Values.alert_manager.component }}"
               servicePort: {{ .Values.alert_manager.port }}
+            {{- end }}
           {{- end }}
           {{- if and .Values.monitoring.prometheus .Values.ingress.control_center.endpoints.prometheus }}
           - path: /prometheus
+            {{- if $isIngressAPIStable }}
+            pathType: {{ .Values.prometheus.pathType | default "ImplementationSpecific" }}
+            backend:
+              service:
+                name: "{{ $fullName }}-{{ .Values.prometheus.component }}"
+                port: 
+                  number: {{ .Values.prometheus.port }}
+            {{- else }}
             backend:
               serviceName: "{{ $fullName }}-{{ .Values.prometheus.component }}"
               servicePort: {{ .Values.prometheus.port }}
+            {{- end }}
           {{- end }}
           {{- if .Values.components.streamnative_console }}
           - path: /console
+            {{- if $isIngressAPIStable }}
+            pathType: {{ .Values.streamnative_console.pathType | default "ImplementationSpecific" }}
+            backend:
+              service: 
+                name: "{{ $fullName }}-{{ .Values.streamnative_console.component }}"
+                port: 
+                  number: {{ .Values.streamnative_console.ports.frontend }}
+            {{- else }}
             backend:
               serviceName: "{{ $fullName }}-{{ .Values.streamnative_console.component }}"
               servicePort: {{ .Values.streamnative_console.ports.frontend }}
+            {{- end }}
           {{- end }}
           {{- if .Values.components.pulsar_manager }}
           - path: /
+            {{- if $isIngressAPIStable }}
+            pathType: {{ .Values.pulsar_manager.pathType | default "ImplementationSpecific" }}
+            backend:
+              service:
+                name: "{{ $fullName }}-{{ .Values.pulsar_manager.component }}"
+                port:
+                  number: {{ .Values.pulsar_manager.ports.frontend }}
+            {{- else }}
             backend:
               serviceName: "{{ $fullName }}-{{ .Values.pulsar_manager.component }}"
               servicePort: {{ .Values.pulsar_manager.ports.frontend }}
+            {{- end }}
           {{- else }}
           - path: /
+            {{- if $isIngressAPIStable }}
+            pathType: "ImplementationSpecific"
+            backend:
+              service: 
+                name: default
+                port: 
+                  number: 80
+            {{- else }}
             backend:
               serviceName: default
               servicePort: 80
+            {{- end }}
           {{- end }}
 {{- end }}

--- a/charts/pulsar/templates/control-center/ingress-controller-deployment.yaml
+++ b/charts/pulsar/templates/control-center/ingress-controller-deployment.yaml
@@ -18,6 +18,7 @@
 #
 
 {{- if .Values.ingress.controller.enabled }}
+{{- $isKubeVersionLessThanV122 := eq (include "pulsar.kubeVersion.isLessThanV122" .) "true" }}
 
 apiVersion: apps/v1
 kind: Deployment
@@ -60,7 +61,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.ingress.controller.gracePeriod }}
       containers:
       - name: nginx-ingress-controller
-        image: "{{ .Values.images.nginx_ingress_controller.repository }}:{{ .Values.images.nginx_ingress_controller.tag }}"
+        image: {{ include "pulsar.ingress.image" .}}
         imagePullPolicy: {{ .Values.images.nginx_ingress_controller.pullPolicy }}
         args:
         - /nginx-ingress-controller
@@ -76,8 +77,13 @@ spec:
               - ALL
             add:
               - NET_BIND_SERVICE
+          {{- if $isKubeVersionLessThanV122 }}
           # www-data -> 33
           runAsUser: 33
+          {{- else }}
+          # www-data -> 101, use image v1.1.1 will need this user permission
+          runAsUser: 101
+          {{- end }}
         env:
         - name: POD_NAME
           valueFrom:

--- a/charts/pulsar/templates/control-center/ingress-controller-rbac.yaml
+++ b/charts/pulsar/templates/control-center/ingress-controller-rbac.yaml
@@ -113,6 +113,8 @@ rules:
       # This has to be adapted if you change either parameter
       # when launching the nginx-ingress-controller.
       - "ingress-controller-leader-nginx"
+      # Upgrade to v1.1.1, controller will update this configmap
+      - "ingress-controller-leader"
     verbs:
       - get
       - update


### PR DESCRIPTION

<!--
### Contribution Checklist
  
  - Name the pull request in the form "[charts/<chart-name>] Title of the pull request".
    Skip *[charts/<chart-name>]* if the PR doesn't change a specific chart. E.g. `[docs] Fix typo in README`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #640 

### Motivation

Fix ingress api kind compatibility issue when k8s version is greater than 1.21 and less than 1.24.

### Modifications

Use different API kind and path fields according to the k8s version.

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

Check the box below.

Need to update docs? 

- [x] `no-need-doc` 
  
