### PR TITLE
Support custom configs for Presto coordinator and worker

### DIFF
--- a/charts/sn-platform/templates/presto/presto-coordinator-configmap.yaml
+++ b/charts/sn-platform/templates/presto/presto-coordinator-configmap.yaml
@@ -98,6 +98,11 @@ data:
     http-server.authentication.type=JWT
     http-server.authentication.jwt.key-file={{ template "pulsar.home" . }}/conf/presto/{{ .Values.presto.security.authentication.jwt.publicKeyFileName }}
 {{- end }}
+    {{- if .Values.presto.coordinator.config.custom }}
+    {{- range $k, $v := .Values.presto.coordinator.config.custom }}
+    {{ $k }}={{ $v }}
+    {{- end }}
+    {{- end }}
 
   log.properties: |
     #

--- a/charts/sn-platform/templates/presto/presto-worker-configmap.yaml
+++ b/charts/sn-platform/templates/presto/presto-worker-configmap.yaml
@@ -83,6 +83,11 @@ data:
     query.max-memory={{ .Values.presto.worker.config.query.maxMemory }}
     query.max-memory-per-node={{ .Values.presto.worker.config.query.maxMemoryPerNode }}
     query.max-total-memory-per-node={{ .Values.presto.worker.config.query.maxTotalMemoryPerNode }}
+    {{- if .Values.presto.worker.config.custom }}
+    {{- range $k, $v := .Values.presto.worker.config.custom }}
+    {{ $k }}={{ $v }}
+    {{- end }}
+    {{- end }}
   log.properties: |
     #
     # Licensed to the Apache Software Foundation (ASF) under one

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -2101,6 +2101,10 @@ presto:
         maxMemory: "1GB"
         maxMemoryPerNode: "128MB"
         maxTotalMemoryPerNode: "256MB"
+      # Add custom configs to config.properties
+      custom:
+        # To add custom config `sql.forced-session-time-zone=America/New_York`
+        #sql.forced-session-time-zone: America/New_York
     jvm:
       memory: 2G
     log:
@@ -2150,6 +2154,10 @@ presto:
         maxMemory: "1GB"
         maxMemoryPerNode: "128MB"
         maxTotalMemoryPerNode: "256MB"
+      # Add custom configs to config.properties
+      custom:
+        # To add custom config `sql.forced-session-time-zone=America/New_York`
+        #sql.forced-session-time-zone: America/New_York
     jvm:
       memory: 2G
     log:

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -2104,7 +2104,7 @@ presto:
       # Add custom configs to config.properties
       custom:
         # To add custom config `sql.forced-session-time-zone=America/New_York`
-        #sql.forced-session-time-zone: America/New_York
+        # sql.forced-session-time-zone: America/New_York
     jvm:
       memory: 2G
     log:
@@ -2157,7 +2157,7 @@ presto:
       # Add custom configs to config.properties
       custom:
         # To add custom config `sql.forced-session-time-zone=America/New_York`
-        #sql.forced-session-time-zone: America/New_York
+        # sql.forced-session-time-zone: America/New_York
     jvm:
       memory: 2G
     log:


### PR DESCRIPTION
Fixes #708

### Motivation

Users would like to be able to include custom values in Presto `config.properties`

### Modifications

Added two parameters as shown below table:

| Parameter  | Type  | Default  | 
|:-:|:-:|:-:|
| `presto.coordinator.config.custom`  |  map | {}  |
| `presto.worker.config.custom`  | map  |  {} |

Example values file:
```
presto:
  coordinator:
    config:
       custom:
          sql.forced-session-time-zone: America/New_York
   worker:
     config:
        custom:
          sql.forced-session-time-zone: America/New_York   
```

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [x] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

