### PR TITLE
Support openshift reuse an existing SCC

### DIFF
--- a/charts/sn-platform/templates/openshift/_openshift.tpl
+++ b/charts/sn-platform/templates/openshift/_openshift.tpl
@@ -1,3 +1,12 @@
-{{- define "pulsar.openshift.scc.name" -}}
-{{ template "pulsar.namespace" . }}-{{ template "pulsar.fullname" . }}-openshift-scc
+{{- define "pulsar.openshift.scc" -}}
+{{- $defaultSCC := printf "%s-%s-openshift-scc" (include "pulsar.namespace" .) (include "pulsar.fullname" .) -}}
+{{- .Values.openshift.scc.name | default $defaultSCC }}
+{{- end -}}
+
+{{- define "pulsar.openshift.role" -}}
+{{- printf "%s-%s-openshift-role" (include "pulsar.namespace" .) (include "pulsar.fullname" .) }}
+{{- end -}}
+
+{{- define "pulsar.openshift.rolebinding" -}}
+{{- printf "%s-%s-openshift-rolebinding" (include "pulsar.namespace" .) (include "pulsar.fullname" .) }}
 {{- end -}}

--- a/charts/sn-platform/templates/openshift/scc-role.yaml
+++ b/charts/sn-platform/templates/openshift/scc-role.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-{{- if and .Values.openshift.enabled .Values.openshift.ssc.enabled }}
+{{- if and .Values.openshift.enabled .Values.openshift.scc.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -31,5 +31,5 @@ rules:
     resources:
       - securitycontextconstraints
     resourceNames:
-      - {{ include "pulsar.openshift.scc.name" . }}
+      - {{ default (include "pulsar.openshift.scc.name" . ) .Values.openshift.scc.name }}
 {{- end -}}

--- a/charts/sn-platform/templates/openshift/scc-role.yaml
+++ b/charts/sn-platform/templates/openshift/scc-role.yaml
@@ -21,7 +21,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "pulsar.openshift.scc.name" . }}
+  name: {{ include "pulsar.openshift.role" . }}
   namespace: {{ include "pulsar.namespace" . }}
 rules:
   - verbs:
@@ -31,5 +31,5 @@ rules:
     resources:
       - securitycontextconstraints
     resourceNames:
-      - {{ default (include "pulsar.openshift.scc.name" . ) .Values.openshift.scc.name }}
+      - {{ include "pulsar.openshift.scc" . }}
 {{- end -}}

--- a/charts/sn-platform/templates/openshift/scc-rolebinding.yaml
+++ b/charts/sn-platform/templates/openshift/scc-rolebinding.yaml
@@ -28,12 +28,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "pulsar.openshift.scc.name" .}}
+  name: {{ include "pulsar.openshift.rolebinding" .}}
   namespace: {{ include "pulsar.namespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "pulsar.openshift.scc.name" . }}
+  name: {{ include "pulsar.openshift.role" . }}
 subjects:
     {{- range $sas }}
   - kind: ServiceAccount

--- a/charts/sn-platform/templates/openshift/scc-rolebinding.yaml
+++ b/charts/sn-platform/templates/openshift/scc-rolebinding.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-{{- if and .Values.openshift.enabled .Values.openshift.ssc.enabled -}}
+{{- if and .Values.openshift.enabled .Values.openshift.scc.enabled -}}
 {{- $sas := list (include "pulsar.vault.serviceAccount" .) -}}
 {{- $sas = append $sas (include "pulsar.zookeeper.serviceAccount" .) -}}
 {{- $sas = append $sas (include "pulsar.bookkeeper.serviceAccount" .) -}}

--- a/charts/sn-platform/templates/openshift/scc.yaml
+++ b/charts/sn-platform/templates/openshift/scc.yaml
@@ -17,11 +17,11 @@
 # under the License.
 #
 
-{{- if and .Values.openshift.enabled .Values.openshift.scc.enabled (not .Values.openshift.scc.name) }}
+{{- if and .Values.openshift.enabled .Values.openshift.scc.enabled .Values.openshift.scc.create }}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: {{ include "pulsar.openshift.scc.name" . }}
+  name: {{ include "pulsar.openshift.scc" . }}
 allowHostDirVolumePlugin: false
 allowHostIPC: false
 allowHostNetwork: false

--- a/charts/sn-platform/templates/openshift/scc.yaml
+++ b/charts/sn-platform/templates/openshift/scc.yaml
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-{{- if and .Values.openshift.enabled .Values.openshift.ssc.enabled }}
+{{- if and .Values.openshift.enabled .Values.openshift.scc.enabled (not .Values.openshift.scc.name) }}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -381,9 +381,12 @@ auth:
 # Support deploy on OpenShift
 openshift:
   enabled: false
-  # SecurityContextConstrains is enabled by default
-  ssc:
+  # SecurityContextConstrains (SCC) is enabled by default
+  scc:
     enabled: true
+    # Create an SCC automatically when `name` is not set or empty. Default behavior
+    # Use an existing SCC when `name` is set to a specific SCC name
+    name: ""
 
 ######################################################################
 # External dependencies

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -384,8 +384,12 @@ openshift:
   # SecurityContextConstrains (SCC) is enabled by default
   scc:
     enabled: true
-    # Create an SCC automatically when `name` is not set or empty. Default behavior
-    # Use an existing SCC when `name` is set to a specific SCC name
+    # If create is true and name is not set or empty. Will create an SCC with generated name
+    # If create is true and name is set. Will create an SCC with specific name
+    # If create is false and name is not set or empty. Will reuse an existing SCC with generated name
+    # If create is false and name is set. Will reuse an existing SCC with specific name
+    create: true
+    # The name of the SCC to use.
     name: ""
 
 ######################################################################


### PR DESCRIPTION
Fixes #765 

### Motivation

We are currently only creating a new SCC by default, but we should also allow referencing an existing SCC.

### Modifications

Added `openshift.scc.name` for referencing the existing SCC.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [x] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

