### PR TITLE
[Feat][Pulsar] Allow customizing Proxy ingress svc https port.

### DIFF
--- a/charts/pulsar/templates/proxy/proxy-service-ingress.yaml
+++ b/charts/pulsar/templates/proxy/proxy-service-ingress.yaml
@@ -39,9 +39,9 @@ spec:
   type: {{ .Values.ingress.proxy.type }}
   ports:
     {{- if .Values.ingress.proxy.tls.enabled }}
-    {{- if .Values.ingress.proxy.ports.https }}
+    {{- if .Values.ingress.proxy.ports.https.enabled }}
     - name: https
-      port: {{ .Values.proxy.ports.https }}
+      port: {{ .Values.ingress.proxy.ports.https.port }}
       protocol: TCP
       targetPort: {{ template "pulsar.proxy.ingress.targetPort.admin" . }}
     {{- end }}

--- a/charts/pulsar/templates/proxy/proxy-service-ingress.yaml
+++ b/charts/pulsar/templates/proxy/proxy-service-ingress.yaml
@@ -39,9 +39,9 @@ spec:
   type: {{ .Values.ingress.proxy.type }}
   ports:
     {{- if .Values.ingress.proxy.tls.enabled }}
-    {{- if .Values.ingress.proxy.ports.https.enabled }}
+    {{- if .Values.ingress.proxy.ports.https }}
     - name: https
-      port: {{ .Values.ingress.proxy.ports.https.port }}
+      port: {{ .Values.ingress.proxy.ports.portNumbers.https }}
       protocol: TCP
       targetPort: {{ template "pulsar.proxy.ingress.targetPort.admin" . }}
     {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -405,7 +405,9 @@ ingress:
     # this section is used to control individal ports
     ports:
       http: true
-      https: true
+      https:
+        enabled: true
+        port: 443
       pulsar: true
       pulsarssl: true
       websocket: true

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -405,13 +405,13 @@ ingress:
     # this section is used to control individal ports
     ports:
       http: true
-      https:
-        enabled: true
-        port: 443
+      https: true
       pulsar: true
       pulsarssl: true
       websocket: true
       websockettls: true
+      portNumbers:
+        https: 443
     type: LoadBalancer
     annotations: {}
     extraSpec: {}


### PR DESCRIPTION
### Motivation
Allow customizing Proxy ingress svc https port so it's not tie to https container port. Mainly for Pulsar 2.10+ compatibility, as non-root user can't use port < 1000.

### Modifications
Add config to config port for Proxy https port so we can choose different port for Proxy container https port.

### Verifying this change

- [x] Make sure that the change passes the CI checks.
This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [x] `doc-required` 
  