### PR TITLE
Update Proxy service port mapping.

### DIFF
--- a/charts/pulsar/templates/proxy/proxy-service.yaml
+++ b/charts/pulsar/templates/proxy/proxy-service.yaml
@@ -62,8 +62,8 @@ spec:
     {{- end }}
     {{- if and .Values.tls.enabled .Values.tls.proxy.enabled }}
     - name: https
-      port: {{ .Values.proxy.ports.httpsServicePort }}
-{{- if not (eq .Values.proxy.ports.httpsServicePort .Values.proxy.ports.https) }}
+      port: {{ .Values.proxy.ports.httpsServicePort | default .Values.proxy.ports.https }}
+{{- if and .Values.proxy.ports.httpsServicePort (not (eq .Values.proxy.ports.httpsServicePort .Values.proxy.ports.https)) }}
       targetPort: {{ template "pulsar.proxy.ingress.targetPort.admin" . }}
 {{- end }}
       protocol: TCP

--- a/charts/pulsar/templates/proxy/proxy-service.yaml
+++ b/charts/pulsar/templates/proxy/proxy-service.yaml
@@ -63,7 +63,7 @@ spec:
     {{- if and .Values.tls.enabled .Values.tls.proxy.enabled }}
     - name: https
       port: {{ .Values.proxy.ports.httpsServicePort | default .Values.proxy.ports.https }}
-{{- if and .Values.proxy.ports.httpsServicePort (not (eq .Values.proxy.ports.httpsServicePort .Values.proxy.ports.https)) }}
+{{- if and .Values.proxy.ports.httpsServicePort (ne .Values.proxy.ports.httpsServicePort .Values.proxy.ports.https) }}
       targetPort: {{ template "pulsar.proxy.ingress.targetPort.admin" . }}
 {{- end }}
       protocol: TCP

--- a/charts/pulsar/templates/proxy/proxy-service.yaml
+++ b/charts/pulsar/templates/proxy/proxy-service.yaml
@@ -62,7 +62,10 @@ spec:
     {{- end }}
     {{- if and .Values.tls.enabled .Values.tls.proxy.enabled }}
     - name: https
-      port: {{ .Values.proxy.ports.https }}
+      port: {{ .Values.proxy.ports.httpsServicePort }}
+{{- if not (eq .Values.proxy.ports.httpsServicePort .Values.proxy.ports.https) }}
+      targetPort: {{ template "pulsar.proxy.ingress.targetPort.admin" . }}
+{{- end }}
       protocol: TCP
     - name: pulsarssl
       port: {{ .Values.proxy.ports.pulsarssl }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1349,7 +1349,7 @@ proxy:
   ports:
     http: 8080
     https: 443
-    httpsServicePort: 443
+    #httpsServicePort:
     pulsar: 6650
     pulsarssl: 6651
     websocket: 9090

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -1349,6 +1349,7 @@ proxy:
   ports:
     http: 8080
     https: 443
+    httpsServicePort: 443
     pulsar: 6650
     pulsarssl: 6651
     websocket: 9090


### PR DESCRIPTION
### Motivation
Follow up for https://github.com/streamnative/charts/pull/771
Also upgading Proxy service to able to customize https port mapping.

### Modifications
Add config for Proxy service https port, set targetPort if service port doesn't match container port.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

