### PR TITLE
[pulsar] Support proxy service port mapping in toolset

### DIFF
--- a/charts/pulsar/templates/toolset/_toolset.tpl
+++ b/charts/pulsar/templates/toolset/_toolset.tpl
@@ -204,7 +204,7 @@ http://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}:{{ .Val
 {{- end -}}
 {{- else -}}
 {{- if and .Values.tls.enabled .Values.tls.proxy.enabled -}}
-https://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:{{ .Values.proxy.ports.https }}
+https://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:{{ .Values.proxy.ports.httpsServicePort | default .Values.proxy.ports.https }}
 {{- else -}}
 http://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}:{{ .Values.proxy.ports.http }}
 {{- end -}}


### PR DESCRIPTION
### Motivation

Fix `toolset.web.service.url` template rendering when `.Values.proxy.ports.httpsServicePort` configured

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 
  
- [x] `no-need-doc` 

