### PR TITLE
[sn-platform] Improve function-worker compatibility

### DIFF
--- a/charts/sn-platform/templates/broker/function-worker-configfile-configmap.yaml
+++ b/charts/sn-platform/templates/broker/function-worker-configfile-configmap.yaml
@@ -30,31 +30,32 @@ metadata:
 data:
   functions_worker.yml: |
     # Function package management
-    {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
+    workerPort: {{ .Values.functions.ports.http }}
+    {{- if and .Values.tls.enabled .Values.tls.functions.enabled }}
+    # TLS Settings
     # `tlsEnabled` and `workerPortTls` are required to set to true in order to make HTTPS work for functions REST api
-    workerPortTls: {{ .Values.broker.ports.https }}
     workerPortTls: {{ .Values.functions.ports.https }}
     tlsEnabled: true
-    {{- else}}
-    workerPort: {{ .Values.functions.ports.http }}
+    tlsCertificateFilePath: "/pulsar/certs/function/tls.crt"
+    tlsKeyFilePath: "/pulsar/certs/function/tls.key"
+    {{- if .Values.tls.functions.trustCertsEnabled }}
+    tlsTrustCertsFilePath: "/pulsar/certs/ca/ca.crt"
+    {{- end }}
     {{- end }}
     numFunctionPackageReplicas: {{ .Values.broker.configData.managedLedgerDefaultEnsembleSize }}
-    pulsarServiceUrl: {{template "pulsar.function.broker.service.url" . }}
-    pulsarWebServiceUrl: {{template "pulsar.function.web.service.url" . }}
     pulsarFunctionsCluster: {{ template "pulsar.fullname" . }}
     functionRuntimeFactoryConfigs:
       jobNamespace: {{ template "pulsar.functions.namespace" . }}
       pulsarDockerImageName: "{{ .Values.images.functions.repository }}:{{ .Values.images.functions.tag }}"
       pulsarRootDir: {{ template "pulsar.functions.pulsarRootDir" . }}
-      {{- if and .Values.tls.enabled .Values.tls.broker.enabled -}}
+      {{- if eq .Values.functions.configData.functionRuntimeFactoryClassName "org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactory" }}
+      {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
       pulsarAdminUrl: {{ template "pulsar.function.web.service.url.tls" . }}
-      {{- else }}
-      pulsarAdminUrl: {{ template "pulsar.function.web.service.url" . }}
-      {{- end }}
-      {{- if and .Values.tls.enabled .Values.tls.broker.enabled -}}
       pulsarServiceUrl: {{ template "pulsar.function.broker.service.url.tls" . }}
       {{- else }}
+      pulsarAdminUrl: {{ template "pulsar.function.web.service.url" . }}
       pulsarServiceUrl: {{ template "pulsar.function.broker.service.url" . }}
+      {{- end }}
       {{- end }}
       changeConfigMap: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}-config"
       changeConfigMapNamespace: {{ template "pulsar.namespace" . }}
@@ -69,17 +70,15 @@ data:
     {{- end }}
     {{- if .Values.functions.useDedicatedRunner}}
     workerHostname: {{template "pulsar.function.service" . }}
-    # TLS Settings
     {{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
     # if broker enables TLS, configure function to talk to broker using TLS
     useTLS: true
     pulsarServiceUrl: {{ template "pulsar.function.broker.service.url.tls" . }}
     pulsarWebServiceUrl: {{ template "pulsar.function.web.service.url.tls" . }}
-    tlsEnabled: true
-    tlsCertificateFilePath: "/pulsar/certs/function/tls.crt"
-    tlsKeyFilePath: "/pulsar/certs/function/tls.key"
-    tlsTrustCertsFilePath: "/pulsar/certs/ca/ca.crt"
     brokerClientTrustCertsFilePath: "/pulsar/certs/ca/ca.crt"
+    {{- else }}
+    pulsarServiceUrl: {{template "pulsar.function.broker.service.url" . }}
+    pulsarWebServiceUrl: {{template "pulsar.function.web.service.url" . }}
     {{- end }}
 
     {{- if .Values.pulsar_metadata.configurationStore }}

--- a/charts/sn-platform/templates/function-worker/_function_worker.tpl
+++ b/charts/sn-platform/templates/function-worker/_function_worker.tpl
@@ -38,7 +38,11 @@ Pulsar Broker Service URL TLS
 */}}
 {{- define "pulsar.function.broker.service.url.tls" -}}
 {{- if or .Values.functions.useDedicatedRunner (eq .Values.functions.configData.functionRuntimeFactoryClassName "org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactory") -}}
+{{- if .Values.components.proxy -}}
 pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.cluster.local:{{ .Values.proxy.ports.pulsarssl }}
+{{- else -}}
+pulsar+ssl://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.cluster.local:{{ .Values.broker.ports.pulsarssl }}
+{{- end -}}
 {{- else -}}
 pulsar+ssl://localhost:6651
 {{- end -}}
@@ -49,7 +53,11 @@ Pulsar Web Service URL TLS
 */}}
 {{- define "pulsar.function.web.service.url.tls" -}}
 {{- if or .Values.functions.useDedicatedRunner (eq .Values.functions.configData.functionRuntimeFactoryClassName "org.apache.pulsar.functions.runtime.kubernetes.KubernetesRuntimeFactory") -}}
+{{- if .Values.components.proxy -}}
 https://{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}.{{ template "pulsar.namespace" . }}.svc.cluster.local:{{ .Values.proxy.ports.https }}
+{{- else -}}
+https://{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}.{{ template "pulsar.namespace" . }}.svc.cluster.local:{{ .Values.broker.ports.https }}
+{{- end -}}
 {{- else -}}
 https://localhost:8443
 {{- end -}}
@@ -73,7 +81,7 @@ Define function tls certs mounts
 Define function tls certs volumes
 */}}
 {{- define "pulsar.function.certs.volumes" -}}
-{{- if and .Values.tls.enabled .Values.tls.broker.enabled }}
+{{- if and .Values.tls.enabled .Values.tls.functions.enabled }}
 - name: function-certs
   secret:
     secretName: "{{ template "pulsar.function.tls.secret.name" . }}"

--- a/charts/sn-platform/templates/function-worker/function-worker-authorizationpolicy.yaml
+++ b/charts/sn-platform/templates/function-worker/function-worker-authorizationpolicy.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.components.functions (and .Values.functions.useDedicatedRunner .Values.istio.enabled) }}
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: "{{ template "pulsar.fullname" . }}-{{ .Values.functions.component }}"
+  namespace: {{ template "pulsar.namespace" . }}
+spec:
+  action: ALLOW
+  rules:
+  - to:
+    - operation:
+        ports:
+        - "{{ .Values.functions.ports.http }}"
+        {{- if and .Values.tls.enabled .Values.tls.functions.enabled }}
+        - "{{ .Values.functions.ports.https }}"
+        {{- end }}
+  selector:
+    matchLabels:
+      {{- include "pulsar.template.labels" . | nindent 6 }}
+      component: {{ .Values.functions.component }}
+{{- end }}

--- a/charts/sn-platform/templates/function-worker/function-worker-authorizationpolicy.yaml
+++ b/charts/sn-platform/templates/function-worker/function-worker-authorizationpolicy.yaml
@@ -1,3 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 {{- if and .Values.components.functions (and .Values.functions.useDedicatedRunner .Values.istio.enabled) }}
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy

--- a/charts/sn-platform/templates/function-worker/function-worker-statefulset.yaml
+++ b/charts/sn-platform/templates/function-worker/function-worker-statefulset.yaml
@@ -117,6 +117,7 @@ spec:
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.functions.gracePeriod }}
       initContainers:
+      {{- if .Values.components.proxy }}
         # This init container will wait for pulsar proxy to be ready before deploying the function worker
         - name: wait-proxy-ready
           image: "{{ .Values.images.function_worker.repository }}:{{ .Values.images.function_worker.tag }}"
@@ -131,6 +132,7 @@ spec:
                 sleep 10;
                 proxyServiceNumber="$(nslookup -timeout=10 {{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }} | grep Name | wc -l)";
               done;
+      {{- end }}
 {{- with .Values.common.extraInitContainers }}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -298,6 +298,7 @@ tls:
     cert_name: tls-function
     # specify name of secret contain certificate if using pre-generated certificate
     certSecretName:
+    trustCertsEnabled: false
   # settings for generating certs for bookies
   bookie:
     enabled: false


### PR DESCRIPTION
### Motivation
- support Istio mode
- function worker compatible with TLS authentication

### Modifications
- add AuthorizationPolicy for function worker
- skip wait-proxy-ready initContainer when the proxy is disabled
- improve/fix function-worker TLS related configurations

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Need to update docs? 
  
- [x] `no-need-doc` 
  
