### PR TITLE
Use latest grafana image (based on 8.4.3 Grafana)

### DIFF
--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -195,7 +195,7 @@ images:
     pullPolicy: IfNotPresent
   grafana:
     repository: streamnative/apache-pulsar-grafana-dashboard-k8s
-    tag: 0.0.16
+    tag: 0.0.17
     pullPolicy: IfNotPresent
   pulsar_manager:
     repository: streamnative/pulsar-manager

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -197,7 +197,7 @@ images:
     pullPolicy: IfNotPresent
   grafana:
     repository: streamnative/apache-pulsar-grafana-dashboard-k8s
-    tag: "0.0.16"
+    tag: "0.0.17"
     pullPolicy: IfNotPresent
   streamnative_console:
     repository: streamnative/sn-platform-console


### PR DESCRIPTION
Needed for https://github.com/streamnative/cloud-support-tickets/issues/104

### Motivation

In other sections of code, we're using/relying on Grafana 8.x. This was using 7.x which has a few bugs we are experiencing.

### Modifications

New base image based of grafana 8.4.3

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

- [x] This change is a trivial rework / code cleanup without any test coverage.

### Documentation
- [x] `no-need-doc` 
  
We actually thought we were using 8.x afaik. This brings it in line.  