### PR TITLE
[sn-platform] Fix stale imagePullSecrets config

### DIFF
--- a/charts/sn-platform/templates/alert-manager/alertmanager-deployment.yaml
+++ b/charts/sn-platform/templates/alert-manager/alertmanager-deployment.yaml
@@ -42,9 +42,8 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      - name: {{ .Values.imagePullSecrets }}
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
     {{- if .Values.alert_manager.nodeSelector }}
       nodeSelector:

--- a/charts/sn-platform/templates/control-center/ingress-controller-deployment.yaml
+++ b/charts/sn-platform/templates/control-center/ingress-controller-deployment.yaml
@@ -45,9 +45,8 @@ spec:
         prometheus.io/scrape: "true"
 {{- end }}
     spec:
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      - name: {{ .Values.imagePullSecrets }}
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
     {{- if .Values.ingress.controller.nodeSelector }}
       nodeSelector:

--- a/charts/sn-platform/templates/detector/pulsar-detector-deployment.yaml
+++ b/charts/sn-platform/templates/detector/pulsar-detector-deployment.yaml
@@ -45,9 +45,8 @@ spec:
 {{ toYaml .Values.pulsar_detector.annotations | indent 8 }}
 {{- end }}
     spec:
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      - name: {{ .Values.imagePullSecrets }}
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
     {{- if .Values.pulsar_detector.serviceAccount.use }}
       serviceAccountName: {{ template "pulsar.detector.serviceAccount" . }}

--- a/charts/sn-platform/templates/function-worker/function-worker-statefulset.yaml
+++ b/charts/sn-platform/templates/function-worker/function-worker-statefulset.yaml
@@ -56,9 +56,8 @@ spec:
 {{- end }}
 {{- end }}    
     spec:
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-        - name: {{ .Values.imagePullSecrets }}
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
       securityContext:
 {{- with .Values.functions.securityContext }}

--- a/charts/sn-platform/templates/grafana/grafana-deployment.yaml
+++ b/charts/sn-platform/templates/grafana/grafana-deployment.yaml
@@ -44,9 +44,8 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      - name: {{ .Values.imagePullSecrets }}
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
     {{- if .Values.grafana.nodeSelector }}
       nodeSelector:

--- a/charts/sn-platform/templates/grafana/grafana-statefulset.yaml
+++ b/charts/sn-platform/templates/grafana/grafana-statefulset.yaml
@@ -48,9 +48,8 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      - name: {{ .Values.imagePullSecrets }}
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
     {{- if .Values.grafana.nodeSelector }}
       nodeSelector:

--- a/charts/sn-platform/templates/node-exporter/node-exporter.yaml
+++ b/charts/sn-platform/templates/node-exporter/node-exporter.yaml
@@ -52,9 +52,8 @@ spec:
 {{- end }}
 {{- end }}   
     spec:
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      - name: {{ .Values.imagePullSecrets }}
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
     {{- if .Values.node_exporter.nodeSelector }}
       nodeSelector:

--- a/charts/sn-platform/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/sn-platform/templates/presto/presto-coordinator-statefulset.yaml
@@ -98,9 +98,8 @@ spec:
           {{ end }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.presto.coordinator.gracePeriod }}
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      - name: {{ .Values.imagePullSecrets }}
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}-coordinator

--- a/charts/sn-platform/templates/presto/presto-worker-statefulset.yaml
+++ b/charts/sn-platform/templates/presto/presto-worker-statefulset.yaml
@@ -98,9 +98,8 @@ spec:
           {{ end }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.presto.worker.gracePeriod }}
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      - name: {{ .Values.imagePullSecrets }}
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}-worker

--- a/charts/sn-platform/templates/prometheus/prometheus-statefulset.yaml
+++ b/charts/sn-platform/templates/prometheus/prometheus-statefulset.yaml
@@ -59,9 +59,8 @@ spec:
         {{ toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      - name: {{ .Values.imagePullSecrets }}
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
     {{- if .Values.prometheus.nodeSelector }}
       nodeSelector:

--- a/charts/sn-platform/templates/vault/vault-initialize.yaml
+++ b/charts/sn-platform/templates/vault/vault-initialize.yaml
@@ -34,9 +34,8 @@ spec:
         {{- include "pulsar.template.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "pulsar.vault.serviceAccount" . }}
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      - name: {{ .Values.imagePullSecrets }}
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
       containers:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.vault.component }}-init"

--- a/charts/sn-platform/templates/vault/vault-statefulset.yaml
+++ b/charts/sn-platform/templates/vault/vault-statefulset.yaml
@@ -31,13 +31,10 @@ spec:
   bankVaultsImage: "{{ .Values.images.bank_vaults.repository }}:{{ .Values.images.bank_vaults.tag }}"
   serviceAccount: {{ template "pulsar.vault.serviceAccount" . }}
   serviceType: {{ .Values.vault.serviceType }}
-
   statsdDisabled: true
-
   vaultLabels:
     component: "{{ .Values.vault.component }}"
   {{- include "pulsar.template.labels" . | nindent 4 }}
-  
   {{- if or .Values.monitoring.datadog .Values.vault.annotations }}
   vaultAnnotations:
 {{- if .Values.vault.annotations }}    
@@ -50,16 +47,13 @@ spec:
   tolerations:
 {{ toYaml .Values.vault.tolerations | indent 4 }}
   {{- end }}
-
   {{- if .Values.vault.nodeSelector }}
   nodeSelector:
 {{ toYaml .Values.vault.nodeSelector | indent 4 }}
   {{- end }}
-
-  {{- if .Values.imagePullSecrets }}
+  {{- if .Values.global.imagePullSecrets }}
   vaultPodSpec:
-    imagePullSecrets:
-    - name: {{ .Values.global.imagePullSecrets }}
+    imagePullSecrets: {{- toYaml .Values.global.imagePullSecrets | nindent 6 }}
   {{- end }}
   {{- if or .Values.vault.config.bankVaults.probe.livenessProbe .Values.vault.config.bankVaults.probe.startupProbe .Values.vault.config.bankVaults.probe.readinessProbe }}
   vaultContainerSpec:
@@ -98,20 +92,16 @@ spec:
   unsealConfig:
     kubernetes:
       secretNamespace: {{ template "pulsar.namespace" . }}
-  
   istioEnabled: {{ .Values.istio.enabled }}
-
   {{- if .Values.vault.config }}
   # A YAML representation of a final vault config file.
   # See https://www.vaultproject.io/docs/configuration/ for more information.
   config:
   {{ toYaml .Values.vault.config | nindent 4 }}
   {{- end }}
-
   {{- if .Values.vault.resources }}
   resources:
     vault:
 {{ toYaml .Values.vault.resources | indent 6 }}
 {{- end }}
-
 {{- end }}

--- a/charts/sn-platform/templates/zookeeper/zookeeper-backup-statefulset.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-backup-statefulset.yaml
@@ -53,9 +53,8 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:
-      {{- if .Values.imagePullSecrets }}
-      imagePullSecrets:
-      - name: {{ .Values.imagePullSecrets }}
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
       securityContext:
       {{- with .Values.zookeeper.securityContext }}


### PR DESCRIPTION
### Motivation

Some imagePullSecrets-related configs are stale. We need to use the new config.

### Modifications

Replacing stale config with `.Values.global.imagePullSecrets`

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

