### PR TITLE
Update ZooKeeper dynamic reconfig.

### DIFF
--- a/charts/pulsar/templates/zookeeper/zookeeper-configmap.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-configmap.yaml
@@ -44,7 +44,6 @@ data:
   {{- end }}
   {{- if .Values.zookeeper.reconfig.enabled }}
   PULSAR_PREFIX_reconfigEnabled: "true"
-  PULSAR_PREFIX_quorumListenOnAllIPs: "true"
   PULSAR_PREFIX_skipACL: "yes"
   {{- end }}
   PULSAR_PREFIX_peerType: {{ .Values.zookeeper.peerType }}

--- a/charts/pulsar/templates/zookeeper/zookeeper-configmap.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-configmap.yaml
@@ -45,6 +45,7 @@ data:
   {{- if .Values.zookeeper.reconfig.enabled }}
   PULSAR_PREFIX_reconfigEnabled: "true"
   PULSAR_PREFIX_quorumListenOnAllIPs: "true"
+  PULSAR_PREFIX_skipACL: "yes"
   {{- end }}
   PULSAR_PREFIX_peerType: {{ .Values.zookeeper.peerType }}
 {{ toYaml .Values.zookeeper.configData | indent 2 }}


### PR DESCRIPTION
### Motivation
Add skipACL if enabled dynamic reconfig for zookeeper.
We need to either skipACL or set a password, so use skipACL here.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

