### PR TITLE
Adding support for cloudflare in public certificate issuing process

### DIFF
--- a/charts/pulsar/templates/tls/tls-cert-public-issuer.yaml
+++ b/charts/pulsar/templates/tls/tls-cert-public-issuer.yaml
@@ -49,6 +49,12 @@ spec:
 {{ toYaml .Values.certs.issuers.acme.solvers.route53 | indent 10 }}
       {{- end }}
       {{- end }}
+      {{- if eq .Values.certs.issuers.acme.solver "cloudflare" }}
+      {{- if .Values.certs.issuers.acme.solvers.cloudflare }}
+        cloudflare:
+{{ toYaml .Values.certs.issuers.acme.solvers.cloudflare | indent 10 }}
+      {{- end }}
+      {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -352,6 +352,11 @@ certs:
         #     name: "[NAME OF SECRET]"
         #     key: "[KEY OF SECRET]"
         #   role: "[ASSUME A ROLE]"
+        # cloudflare:
+        #   email: "[YOUR ACCOUNT EMAIL]"
+        #   apiTokenSecretRef:
+        #     name: "[NAME OF SECRET]"
+        #     key: "[KEY OF SECRET]"
   lets_encrypt:
     ca_ref:
       secretName: "[SECRET STORES lets encrypt CA]"

--- a/charts/sn-platform/templates/tls/istio/tls-cert-public-issuer.yaml
+++ b/charts/sn-platform/templates/tls/istio/tls-cert-public-issuer.yaml
@@ -48,6 +48,12 @@ spec:
 {{ toYaml .Values.certs.issuers.acme.solvers.route53 | indent 10 }}
       {{- end }}
       {{- end }}
+      {{- if eq .Values.certs.issuers.acme.solver "cloudflare" }}
+      {{- if .Values.certs.issuers.acme.solvers.cloudflare }}
+        cloudflare:
+{{ toYaml .Values.certs.issuers.acme.solvers.cloudflare | indent 10 }}
+      {{- end }}
+      {{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sn-platform/templates/tls/tls-cert-public-issuer.yaml
+++ b/charts/sn-platform/templates/tls/tls-cert-public-issuer.yaml
@@ -47,5 +47,11 @@ spec:
 {{ toYaml .Values.certs.issuers.acme.solvers.route53 | indent 10 }}
       {{- end }}
       {{- end }}
+      {{- if eq .Values.certs.issuers.acme.solver "cloudflare" }}
+      {{- if .Values.certs.issuers.acme.solvers.cloudflare }}
+        cloudflare:
+{{ toYaml .Values.certs.issuers.acme.solvers.cloudflare | indent 10 }}
+      {{- end }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -446,6 +446,11 @@ certs:
         #     name: "[NAME OF SECRET]"
         #     key: "[KEY OF SECRET]"
         #   role: "[ASSUME A ROLE]"
+        # cloudflare:
+        #   email: "[YOUR ACCOUNT EMAIL]"
+        #   apiTokenSecretRef:
+        #     name: "[NAME OF SECRET]"
+        #     key: "[KEY OF SECRET]"
   lets_encrypt:
     ca_ref:
       secretName: "[SECRET STORES lets encrypt CA]"


### PR DESCRIPTION
### Motivation

Working with Pulsar in a mixed environment running on Google Kubernetes with Cloudflare for security reasons and for managing your DNS, provisioning of public TLS certificates does not work since Cloudflare is currently not supported as a DNS resolver, rendering Let's encrypt issuer nonoperative. 

### Modifications

three issuer templates were modified to enable Cloudflare:
- charts/sn-platform/templates/tls/istio/tls-cert-public-issuer.yaml
- charts/sn-platform/templates/tls/tls-cert-public-issuer.yaml
- charts/pulsar/templates/tls/tls-cert-public-issuer.yaml

### Verifying this change

The change was verified using single and wildcard hosts for new installations and for helm upgrade process. No other specific tests were made. 

### Documentation

- [ ] `doc-required` 
(Your PR needs to update docs and you will update later)

- [x] `doc-not-needed` 
Did not find any reference inside of existing documentation where. Moreover it is marked as TODO: add a link about how to configure this section

I've added sections in the values.yaml file describing possible options as was done so for the route53 resolver. 
- charts/pulsar/values.yaml
- charts/sn-platform/values.yaml

Leaving all defaults as they were. 
 
- [ ] `doc` 
(Your PR contains doc changes)

- [ ] `doc-complete`
(Docs have been already added)
  