### PR TITLE
feat(operator): Add some extra configs on operator deployment

### DIFF
--- a/charts/pulsar-operator/templates/bookkeeper-operator/operator.yaml
+++ b/charts/pulsar-operator/templates/bookkeeper-operator/operator.yaml
@@ -37,6 +37,13 @@ spec:
       labels:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.bookkeeper.component }}
+        {{- if .Values.bookkeeper.podLabels }}
+{{ toYaml .Values.bookkeeper.podLabels | indent 8 }}
+        {{- end }}
+      {{- if .Values.bookkeeper.podAnnotations }}
+      annotations:
+{{ toYaml .Values.bookkeeper.podAnnotations | indent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: '{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.serviceAccount.name }}'
       {{- with .Values.imagePullSecrets }}
@@ -65,6 +72,10 @@ spec:
         resources:
 {{ toYaml .Values.bookkeeper.resources | indent 10 }}
         {{- end }}
+        {{- if .Values.bookkeeper.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.bookkeeper.containerSecurityContext | indent 10 }}
+        {{- end }}
       {{- if .Values.bookkeeper.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.bookkeeper.nodeSelector | indent 8 }}
@@ -80,5 +91,9 @@ spec:
       {{- if .Values.bookkeeper.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds:
 {{ toYaml .Values.bookkeeper.terminationGracePeriodSeconds | indent 8 }}
+      {{- end }}
+      {{- if .Values.bookkeeper.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.bookkeeper.podSecurityContext | indent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/pulsar-operator/templates/pulsar-operator/operator.yaml
+++ b/charts/pulsar-operator/templates/pulsar-operator/operator.yaml
@@ -36,6 +36,13 @@ spec:
       labels:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.pulsar.component }}
+        {{- if .Values.pulsar.podLabels }}
+{{ toYaml .Values.pulsar.podLabels | indent 8 }}
+        {{- end }}
+      {{- if .Values.pulsar.podAnnotations }}
+      annotations:
+{{ toYaml .Values.pulsar.podAnnotations | indent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: '{{ template "pulsar.fullname" . }}-{{ .Values.pulsar.serviceAccount.name }}'
       {{- with .Values.imagePullSecrets }}
@@ -77,6 +84,10 @@ spec:
       nodeSelector:
 {{ toYaml .Values.pulsar.nodeSelector | indent 8 }}
       {{- end }}
+      {{- if .Values.pulsar.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.pulsar.containerSecurityContext | indent 10 }}
+        {{- end }}
       {{- if .Values.pulsar.affinity }}
       affinity:
 {{ toYaml .Values.pulsar.affinity | indent 8 }}
@@ -88,5 +99,9 @@ spec:
       {{- if .Values.pulsar.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds:
 {{ toYaml .Values.pulsar.terminationGracePeriodSeconds | indent 8 }}
+      {{- end }}
+      {{- if .Values.pulsar.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.pulsar.podSecurityContext | indent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/pulsar-operator/templates/zookeeper-operator/operator.yaml
+++ b/charts/pulsar-operator/templates/zookeeper-operator/operator.yaml
@@ -37,6 +37,13 @@ spec:
       labels:
         {{- include "pulsar.template.labels" . | nindent 8 }}
         component: {{ .Values.zookeeper.component }}
+        {{- if .Values.zookeeper.podLabels }}
+{{ toYaml .Values.zookeeper.podLabels | indent 8 }}
+        {{- end }}
+      {{- if .Values.zookeeper.podAnnotations }}
+      annotations:
+{{ toYaml .Values.zookeeper.podAnnotations | indent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: '{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.serviceAccount.name }}'
       {{- with .Values.imagePullSecrets }}
@@ -65,6 +72,10 @@ spec:
         resources:
 {{ toYaml .Values.zookeeper.resources | indent 10 }}
         {{- end }}
+        {{- if .Values.zookeeper.containerSecurityContext }}
+        securityContext:
+{{ toYaml .Values.zookeeper.containerSecurityContext | indent 10 }}
+        {{- end }}
       {{- if .Values.zookeeper.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.zookeeper.nodeSelector | indent 8 }}
@@ -80,5 +91,9 @@ spec:
       {{- if .Values.zookeeper.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds:
 {{ toYaml .Values.zookeeper.terminationGracePeriodSeconds | indent 8 }}
+      {{- end }}
+      {{- if .Values.zookeeper.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.zookeeper.podSecurityContext | indent 8 }}
       {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: ericsyh <ericshenyuhao@outlook.com>

<!--
### Contribution Checklist
  
  - Name the pull request in the form "[charts/<chart-name>] Title of the pull request".
    Skip *[charts/<chart-name>]* if the PR doesn't change a specific chart. E.g. `[docs] Fix typo in README`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

I referred the [vault-operator configs](https://github.com/banzaicloud/bank-vaults/blob/main/charts/vault-operator/README.md#configuration) and added some extra configs like `podSecurityContext`, `containerSecurityContext`, `podAnnotations` and `podLabels`

### Modifications

Added some extra configs like `podSecurityContext`, `containerSecurityContext`, `podAnnotations` and `podLabels`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

