### PR TITLE
[sn-platform] Fix resources limits for broker metadata init job

### DIFF
--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -346,7 +346,6 @@ spec:
       PULSAR_PREFIX_managedLedgerOffloadServiceEndpoint: "{{ .Values.broker.offload.azureblob.managedLedgerOffloadServiceEndpoint }}"
       {{- end}}
       {{- end }}
-  {{- if .Values.zookeeper.customTools.restore.enable }}
   initJobPod:
     initContainers:
       - name: cleanup
@@ -369,7 +368,6 @@ spec:
       - name: cleanup-config
         configMap:
           name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.customTools.restore.component }}"
-  {{- end }}
   {{- if and .Values.components.autoscaling .Values.broker.autoscaling.maxReplicas }}
   autoScalingPolicy:
     maxReplicas: {{ .Values.broker.autoscaling.maxReplicas }}

--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -361,13 +361,13 @@ spec:
         volumeMounts:
           - name: cleanup-config
             mountPath: /pulsar-metadata-tool/conf/pulsar-metadata-tool
-        {{- if .Values.broker.resources }}
-        resources: {{- toYaml .Values.broker.resources | nindent 10 }}
-        {{- end }}
     volumes:
       - name: cleanup-config
         configMap:
           name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.customTools.restore.component }}"
+    {{- if .Values.broker.resources }}
+    resources: {{- toYaml .Values.broker.resources | nindent 10 }}
+    {{- end }}
   {{- if and .Values.components.autoscaling .Values.broker.autoscaling.maxReplicas }}
   autoScalingPolicy:
     maxReplicas: {{ .Values.broker.autoscaling.maxReplicas }}


### PR DESCRIPTION
Fixes #831 


### Motivation

Set resources limits/requests for `broker-metadata-init` Job.

### Modifications

- Remove the `.Values.zookeeper.customTools.restore.enable` condition for broker init job.
- Use `spec.initJobPod.resources` rather than `spec.initJobPod.initContainers[*].resources`. Because the Operator itself uses the latter one.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

