### PR TITLE
[sn-platform] Fix broker initJob definition

### DIFF
--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -347,6 +347,7 @@ spec:
       {{- end}}
       {{- end }}
   initJobPod:
+    {{- if .Values.zookeeper.customTools.restore.enable }}
     initContainers:
       - name: cleanup
         image: "{{ .Values.images.zookeeper.customTools.restore.repository }}:{{ .Values.images.zookeeper.customTools.restore.tag }}"
@@ -365,6 +366,7 @@ spec:
       - name: cleanup-config
         configMap:
           name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.customTools.restore.component }}"
+    {{- end }}
     {{- if .Values.broker.resources }}
     resources: {{- toYaml .Values.broker.resources | nindent 10 }}
     {{- end }}


### PR DESCRIPTION
### Motivation

Use `.Values.zookeeper.customTools.restore.enable` control enabling cleanup initContainer in Broker initJob Pod.

**PS: Please test with a pure installation**

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

