### PR TITLE
[Pulsar] Add oauth2 support for pulsar charts

### DIFF
--- a/charts/pulsar/templates/broker/_broker.tpl
+++ b/charts/pulsar/templates/broker/_broker.tpl
@@ -119,6 +119,35 @@ Define broker tls certs volumes
 {{- end }}
 
 {{/*
+Define broker oauth2 mounts
+*/}}
+{{- define "pulsar.broker.oauth2.volumeMounts" -}}
+{{- if .Values.auth.authentication.enabled }}
+{{- if eq .Values.auth.authentication.provider "oauth2" }}
+- mountPath: "/pulsar/oauth2"
+  name: broker-oauth2
+  readOnly: true
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Define broker oauth2 volumes
+*/}}
+{{- define "pulsar.broker.oauth2.volumes" -}}
+{{- if .Values.auth.authentication.enabled }}
+{{- if eq .Values.auth.authentication.provider "oauth2" }}
+- name: broker-oauth2
+  secret:
+    secretName: "{{ .Release.Name }}-oauth2-private-key"
+    items:
+      - key: auth.json
+        path: auth.json
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 Define broker token mounts
 */}}
 {{- define "pulsar.broker.token.volumeMounts" -}}

--- a/charts/pulsar/templates/broker/broker-configmap.yaml
+++ b/charts/pulsar/templates/broker/broker-configmap.yaml
@@ -132,6 +132,15 @@ data:
   tokenPublicKey: "file:///pulsar/keys/token/public.key"
   {{- end }}
   {{- end }}
+  {{- if (eq .Values.auth.authentication.provider "oauth2") }}
+  PULSAR_PREFIX_oauthIssuerUrl: {{ .Values.auth.authentication.oauth2.issuerUrl }}
+  PULSAR_PREFIX_oauthAudience: {{ .Values.auth.authentication.oauth2.audience }}
+  PULSAR_PREFIX_oauthSubjectClaim: {{ .Values.auth.authentication.oauth2.subjectClaim }}
+  PULSAR_PREFIX_oauthAdminScope: {{ .Values.auth.authentication.oauth2.adminScope }}
+  authenticationProviders:  {{ .Values.auth.authentication.oauth2.authenticationProviders }}
+  brokerClientAuthenticationParameters: '{"privateKey":"file:///pulsar/oauth2/auth.json","issuerUrl":"{{ .Values.auth.authentication.oauth2.issuerUrlParam }}","audience":"{{ .Values.auth.authentication.oauth2.audienceParam }}","scope":"{{ .Values.auth.authentication.oauth2.adminScopeParam }}"}'
+  brokerClientAuthenticationPlugin: org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2
+  {{- end }}
   {{- end }}
 
   {{- if and .Values.tls.enabled .Values.tls.bookie.enabled }}

--- a/charts/pulsar/templates/broker/broker-statefulset.yaml
+++ b/charts/pulsar/templates/broker/broker-statefulset.yaml
@@ -368,6 +368,7 @@ spec:
         - configMapRef:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.broker.component }}"
         volumeMounts:
+          {{- include "pulsar.broker.oauth2.volumeMounts" . | nindent 10 }}
           {{- include "pulsar.broker.token.volumeMounts" . | nindent 10 }}
           {{- include "pulsar.broker.log.volumeMounts" . | nindent 10 }}
           {{- include "pulsar.broker.certs.volumeMounts" . | nindent 10 }}
@@ -385,6 +386,7 @@ spec:
 {{ toYaml . | indent 10 }}
 {{- end }}
       volumes:
+      {{- include "pulsar.broker.oauth2.volumes" . | nindent 6 }}
       {{- include "pulsar.broker.token.volumes" . | nindent 6 }}
       {{- include "pulsar.broker.certs.volumes" . | nindent 6 }}
       {{- if and .Values.tls.enabled .Values.tls.kop.enabled }}

--- a/charts/pulsar/templates/oauth2/oauth2-secret.yaml
+++ b/charts/pulsar/templates/oauth2/oauth2-secret.yaml
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+
+{{- if .Values.auth.authentication.enabled }}
+{{- if eq .Values.auth.authentication.provider "oauth2" }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ .Release.Name }}-oauth2-private-key"
+  namespace: {{ template "pulsar.namespace" . }}
+data:
+  auth.json: {{ .Values.auth.authentication.oauth2.brokerClientCredential | b64enc }}
+{{- end }}
+{{- end }}

--- a/charts/pulsar/templates/proxy/_proxy.tpl
+++ b/charts/pulsar/templates/proxy/_proxy.tpl
@@ -363,3 +363,33 @@ Define Proxy TLS certificate secret name
 {{ .Release.Name }}-{{ .Values.tls.proxy.cert_name }}
 {{- end -}}
 {{- end -}}
+
+
+{{/*
+Define Proxy oauth2 mounts
+*/}}
+{{- define "pulsar.proxy.oauth2.volumeMounts" -}}
+{{- if .Values.auth.authentication.enabled }}
+{{- if eq .Values.auth.authentication.provider "oauth2" }}
+- mountPath: "/pulsar/oauth2"
+  name: proxy-oauth2
+  readOnly: true
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Define Proxy oauth2 volumes
+*/}}
+{{- define "pulsar.proxy.oauth2.volumes" -}}
+{{- if .Values.auth.authentication.enabled }}
+{{- if eq .Values.auth.authentication.provider "oauth2" }}
+- name: proxy-oauth2
+  secret:
+    secretName: "{{ .Release.Name }}-oauth2-private-key"
+    items:
+      - key: auth.json
+        path: auth.json
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/pulsar/templates/proxy/proxy-configmap.yaml
+++ b/charts/pulsar/templates/proxy/proxy-configmap.yaml
@@ -76,6 +76,15 @@ data:
   tokenPublicKey: "file:///pulsar/keys/token/public.key"
   {{- end }}
   {{- end }}
+  {{- if (eq .Values.auth.authentication.provider "oauth2") }}
+  PULSAR_PREFIX_oauthIssuerUrl: {{ .Values.auth.authentication.oauth2.issuerUrl }}
+  PULSAR_PREFIX_oauthAudience: {{ .Values.auth.authentication.oauth2.audience }}
+  PULSAR_PREFIX_oauthSubjectClaim: {{ .Values.auth.authentication.oauth2.subjectClaim }}
+  PULSAR_PREFIX_oauthAdminScope: {{ .Values.auth.authentication.oauth2.adminScope }}
+  authenticationProviders:  {{ .Values.auth.authentication.oauth2.authenticationProviders }}
+  brokerClientAuthenticationParameters: '{"privateKey":"file:///pulsar/oauth2/auth.json","issuerUrl":"{{ .Values.auth.authentication.oauth2.issuerUrlParam }}","audience":"{{ .Values.auth.authentication.oauth2.audienceParam }}","scope":"{{ .Values.auth.authentication.oauth2.adminScopeParam }}"}'
+  brokerClientAuthenticationPlugin: org.apache.pulsar.client.impl.auth.oauth2.AuthenticationOAuth2
+  {{- end }}
   {{- end }}
   {{- if .Values.functions.useDedicatedRunner}}
   functionWorkerWebServiceURL: {{ template "pulsar.proxy.function.service.url" . }}

--- a/charts/pulsar/templates/proxy/proxy-statefulset.yaml
+++ b/charts/pulsar/templates/proxy/proxy-statefulset.yaml
@@ -249,6 +249,7 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
         volumeMounts:
+          {{- include "pulsar.proxy.oauth2.volumeMounts" . | nindent 10 }}
           {{- include "pulsar.proxy.log.volumeMounts" . | nindent 10 }}
           {{- include "pulsar.proxy.token.volumeMounts" . | nindent 10 }}
           {{- include "pulsar.proxy.certs.volumeMounts" . | nindent 10 }}
@@ -329,6 +330,7 @@ spec:
         {{- if .Values.proxy.websocket.enabled }}
         {{- include "pulsar.websocket.token.volumes" . | nindent 8 }}
         {{- end }}
+        {{- include "pulsar.proxy.oauth2.volumes" . | nindent 8 }}
         {{- include "pulsar.proxy.log.volumes" . | nindent 8 }}
         {{- include "pulsar.proxy.token.volumes" . | nindent 8 }}
         {{- include "pulsar.proxy.certs.volumes" . | nindent 8 }}

--- a/examples/pulsar/values-oauth2.yaml
+++ b/examples/pulsar/values-oauth2.yaml
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+images:
+  broker:
+    # the image should contain the `io.streamnative.pulsar.broker.authentication.AuthenticationProviderOAuth` lib
+    repository: streamnative/sn-platform
+    tag: 2.9.2.19
+  proxy: # if the proxy component is enabled
+    repository: streamnative/sn-platform
+    tag: 2.9.2.19
+
+auth:
+  authorization:
+    # if set to true, please set one of the superRoles to your super-application-id
+    enabled: false 
+  authentication:
+    enabled: true
+    provider: "oauth2"
+    # below configurations are using Azure as the provider
+    # please refer to: https://streamnative.slab.com/posts/how-oauth-2-broker-plugin-work-with-azure-active-directory-azure-ad-platform-ui9a8ox8
+    oauth2:
+      issuerUrl: https://xxxxxx/ 
+      issuerUrlParam: https://xxxxxx/v2.0
+      audience: api://xxxxxx
+      audienceParam: api://xxxxxx/.default
+      brokerClientCredential: '{"client_id":"****","client_secret":"*****"}'
+      subjectClaim: appid
+      adminScope: appid
+      adminScopeParam: api://xxxxxx
+      authenticationProviders: io.streamnative.pulsar.broker.authentication.AuthenticationProviderOAuth

--- a/examples/pulsar/values-oauth2.yaml
+++ b/examples/pulsar/values-oauth2.yaml
@@ -34,14 +34,13 @@ auth:
     enabled: true
     provider: "oauth2"
     # below configurations are using Azure as the provider
-    # please refer to: https://streamnative.slab.com/posts/how-oauth-2-broker-plugin-work-with-azure-active-directory-azure-ad-platform-ui9a8ox8
     oauth2:
-      issuerUrl: https://xxxxxx/ 
-      issuerUrlParam: https://xxxxxx/v2.0
-      audience: api://xxxxxx
-      audienceParam: api://xxxxxx/.default
+      issuerUrl: https://xxxxxx/ # the issuerUrl, such as https://sts.windows.net/xxxxxx/
+      issuerUrlParam: https://xxxxxx/v2.0 # such as https://sts.windows.net/xxxxxx/v2.0
+      audience: api://YOUR-APPLICATION-ID
+      audienceParam: api://YOUR-APPLICATION-ID/.default
       brokerClientCredential: '{"client_id":"****","client_secret":"*****"}'
       subjectClaim: appid
       adminScope: appid
-      adminScopeParam: api://xxxxxx
+      adminScopeParam: api://YOUR-APPLICATION-ID
       authenticationProviders: io.streamnative.pulsar.broker.authentication.AuthenticationProviderOAuth


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[charts/<chart-name>] Title of the pull request".
    Skip *[charts/<chart-name>]* if the PR doesn't change a specific chart. E.g. `[docs] Fix typo in README`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

Fixes #850


### Motivation

Make it easy to test Pulsar with oauth2 enabled

### Modifications

Add the oauth2 authentication provider support to the Pulsar charts

### Verifying this change

- [x] Make sure that the change passes the CI checks.


### Documentation

Check the box below.

Need to update docs? 
  
- [x] `doc-required` 
  
  There is an example values file, but a doc would be better

