### PR TITLE
[pulsar-operator] Upgrade to v0.12.3

### DIFF
--- a/charts/pulsar-operator/Chart.yaml
+++ b/charts/pulsar-operator/Chart.yaml
@@ -19,7 +19,7 @@
 
 apiVersion: v1
 version: 0.12.0
-appVersion: "0.12.0"
+appVersion: "0.12.3"
 kubeVersion: ">= 1.16.0-0 <= 1.24.0-0"
 description: Apache Pulsar Operators Helm chart for Kubernetes
 name: pulsar-operator

--- a/charts/pulsar-operator/crds/pulsar.streamnative.io_pulsarproxies.yaml
+++ b/charts/pulsar-operator/crds/pulsar.streamnative.io_pulsarproxies.yaml
@@ -1310,6 +1310,51 @@ spec:
                     enabled:
                       description: Enabled defines whether to enable Istio
                       type: boolean
+                    gateway:
+                      description: Gateway defines the gateway configuration The operator
+                        could either create a gateway automatically or use an existing
+                        one
+                      properties:
+                        create:
+                          description: Create defines whether to create a gateway
+                          type: boolean
+                        gateways:
+                          description: Gateways defines a list of existing gateways
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
+                        selector:
+                          additionalProperties:
+                            type: string
+                          description: Selector defines the selector for the gateway
+                            to create
+                          nullable: true
+                          type: object
+                        tls:
+                          properties:
+                            certSecretName:
+                              description: "SIMPLE mode:   CertSecretName defines the
+                                name of the secret that contains the   certificate to
+                                use in Istio Ingress Gateway. The value should be   name
+                                of the secret in the gateway workload namespace. PASSTHROUGH
+                                mode: \t CertSecretName defines the name of the secret
+                                that contains the \t certificate to use in Broker. The
+                                value should be name of the secret   name of the secret
+                                in the Broker workload namespace. Required in both SIMPLE
+                                and PASSTHROUGH mode."
+                              type: string
+                            mode:
+                              description: 'Optional: Indicates whether connections
+                                to this port should be secured using TLS. The value
+                                of this field determines how TLS is enforced.'
+                              type: string
+                            trustCertsEnabled:
+                              description: TrustCertsEnabled defines whether to enable
+                                trust store
+                              type: boolean
+                          type: object
+                      type: object
                   type: object
                 labels:
                   additionalProperties:

--- a/charts/pulsar-operator/values.yaml
+++ b/charts/pulsar-operator/values.yaml
@@ -45,7 +45,7 @@ components:
 ## Control what images to use for each component
 images:
   registry: "docker.cloudsmith.io"
-  tag: "v0.12.0"
+  tag: "v0.12.3"
 
   zookeeper:
     registry: ""


### PR DESCRIPTION
### Motivation
1. Upgrade pulsar-operator
### Modifications
1. Update PulsarProxy CRD
2. Update operators image tag to v0.12.3

*Describe the modifications you've done.*

### Verifying this change

- [x] Make sure that the change passes the CI checks.

### Documentation

Check the box below.

Need to update docs? 

  
- [x] `no-need-doc` 
  
  (Please explain why)
  
