### PR TITLE
[sn-platform] Presto support tls authentication

### DIFF
--- a/charts/sn-platform/templates/presto/_presto.tpl
+++ b/charts/sn-platform/templates/presto/_presto.tpl
@@ -75,3 +75,14 @@ Define Presto TLS certificate secret name
 {{ .Release.Name }}-{{ .Values.tls.presto.cert_name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Defines Presto jks password
+*/}}
+{{- define "pulsar.presto.jks.password" -}}
+{{- if .Values.tls.presto.passwordSecretRef -}}
+{{- print "/pulsar/jks-password/password" -}}
+{{- else -}}
+{{- print "changeit" -}}
+{{- end -}}
+{{- end -}}

--- a/charts/sn-platform/templates/presto/presto-authrozationpolicy.yaml
+++ b/charts/sn-platform/templates/presto/presto-authrozationpolicy.yaml
@@ -51,6 +51,9 @@ spec:
   - to:
     - operation:
         ports:
+        {{- if .Values.tls.presto.enabled }}
+        - "{{ .Values.presto.worker.ports.https }}"
+        {{- else }}
         - "{{ .Values.presto.worker.ports.http }}"
         {{- if .Values.presto.exporter.enabled }}
         - "5556"

--- a/charts/sn-platform/templates/presto/presto-authrozationpolicy.yaml
+++ b/charts/sn-platform/templates/presto/presto-authrozationpolicy.yaml
@@ -55,6 +55,7 @@ spec:
         - "{{ .Values.presto.worker.ports.https }}"
         {{- else }}
         - "{{ .Values.presto.worker.ports.http }}"
+        {{- end }}
         {{- if .Values.presto.exporter.enabled }}
         - "5556"
         {{- end }}

--- a/charts/sn-platform/templates/presto/presto-coordinator-configmap.yaml
+++ b/charts/sn-platform/templates/presto/presto-coordinator-configmap.yaml
@@ -88,6 +88,10 @@ data:
     http-server.https.truststore.key=changeit
     {{- end }}
     discovery.uri=https://localhost:{{ .Values.presto.coordinator.ports.https }}
+    {{- if .Values.presto.security.authentication.tls.enabled }}
+    http-server.authentication.type=CERTIFICATE
+    http-server.authentication.certificate.user-mapping.pattern=CN=([^,]+).*
+    {{- end }}
 {{- else }}
     http-server.https.enabled=false
     internal-communication.https.required=false

--- a/charts/sn-platform/templates/presto/presto-coordinator-configmap.yaml
+++ b/charts/sn-platform/templates/presto/presto-coordinator-configmap.yaml
@@ -79,13 +79,13 @@ data:
     http-server.https.enabled=true
     http-server.https.port={{ .Values.presto.coordinator.ports.https }}
     http-server.https.keystore.path=/pulsar/jks/presto.keystore.jks
-    http-server.https.keystore.key=changeit
+    http-server.https.keystore.key={{ template "pulsar.presto.jks.password" . }}
     internal-communication.https.required=true
     internal-communication.https.keystore.path=/pulsar/jks/presto.keystore.jks
-    internal-communication.https.keystore.key=changeit
+    internal-communication.https.keystore.key={{ template "pulsar.presto.jks.password" . }}
     {{- if .Values.tls.presto.trustCertsEnabled }}
     http-server.https.truststore.path=/pulsar/jks/trust.jks
-    http-server.https.truststore.key=changeit
+    http-server.https.truststore.key={{ template "pulsar.presto.jks.password" . }}
     {{- end }}
     discovery.uri=https://localhost:{{ .Values.presto.coordinator.ports.https }}
     {{- if .Values.presto.security.authentication.tls.enabled }}

--- a/charts/sn-platform/templates/presto/presto-coordinator-configmap.yaml
+++ b/charts/sn-platform/templates/presto/presto-coordinator-configmap.yaml
@@ -78,12 +78,16 @@ data:
     http-server.http.enabled=false
     http-server.https.enabled=true
     http-server.https.port={{ .Values.presto.coordinator.ports.https }}
-    http-server.https.keystore.path=<keystore path>
-    http-server.https.keystore.key=<keystore password>
-    discovery.uri=https://localhost:{{ .Values.presto.coordinator.ports.https }}
+    http-server.https.keystore.path=/pulsar/jks/presto.keystore.jks
+    http-server.https.keystore.key=changeit
     internal-communication.https.required=true
-    internal-communication.https.keystore.path=<keystore path>
-    internal-communication.https.keystore.key=<keystore password>
+    internal-communication.https.keystore.path=/pulsar/jks/presto.keystore.jks
+    internal-communication.https.keystore.key=changeit
+    {{- if .Values.tls.presto.trustCertsEnabled }}
+    http-server.https.truststore.path=/pulsar/jks/trust.jks
+    http-server.https.truststore.key=changeit
+    {{- end }}
+    discovery.uri=https://localhost:{{ .Values.presto.coordinator.ports.https }}
 {{- else }}
     http-server.https.enabled=false
     internal-communication.https.required=false

--- a/charts/sn-platform/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/sn-platform/templates/presto/presto-coordinator-statefulset.yaml
@@ -129,10 +129,10 @@ spec:
               {{- if .Values.tls.presto.enabled }}
               set -ex;
               mkdir -p /pulsar/jks;
-              openssl pkcs12 -export -in /pulsar/certs/presto/tls.crt -inkey /pulsar/certs/presto/tls.key -out /pulsar/jks/server-cert.p12 -name presto-coordinator -passout "pass:changeit";
-              keytool -importkeystore -srckeystore /pulsar/jks/server-cert.p12 -srcstoretype PKCS12 -srcstorepass "changeit" -alias presto-coordinator -destkeystore /pulsar/jks/presto.keystore.jks -deststorepass "changeit";
+              openssl pkcs12 -export -in /pulsar/certs/presto/tls.crt -inkey /pulsar/certs/presto/tls.key -out /pulsar/jks/server-cert.p12 -name presto-coordinator -passout "pass:{{ template "pulsar.presto.jks.password" . }}";
+              keytool -importkeystore -srckeystore /pulsar/jks/server-cert.p12 -srcstoretype PKCS12 -srcstorepass "{{ template "pulsar.presto.jks.password" . }}" -alias presto-coordinator -destkeystore /pulsar/jks/presto.keystore.jks -deststorepass "{{ template "pulsar.presto.jks.password" . }}";
               {{- if .Values.tls.presto.trustCertsEnabled }}
-              echo "y" | keytool -import -alias selfsigned -file /pulsar/certs/presto/ca.crt -keystore /pulsar/jks/trust.jks -trustcacerts -storepass "changeit"; 
+              echo "y" | keytool -import -alias selfsigned -file /pulsar/certs/presto/ca.crt -keystore /pulsar/jks/trust.jks -trustcacerts -storepass "{{ template "pulsar.presto.jks.password" . }}"; 
               {{- end }}
               {{- end }}
               bin/pulsar sql-worker run \
@@ -208,6 +208,11 @@ spec:
               mountPath: "/pulsar/certs/presto"
               readOnly: true
             {{- end}}
+            {{- if and .Values.tls.presto.enabled .Values.tls.presto.passwordSecretRef }}
+            - name: presto-password
+              mountPath: "/pulsar/jks-password"
+              readOnly: true
+            {{- end }}
 {{- with .Values.presto.extraVolumeMounts }}
 {{ toYaml . | indent 12 }}
 {{- end }}            
@@ -272,6 +277,14 @@ spec:
               - key: ca.crt
                 path: ca.crt
               {{- end }}
+        {{- end }}
+        {{- if and .Values.tls.presto.enabled .Values.tls.presto.passwordSecretRef }}
+        - name: presto-password
+          secret:
+            secretName: "{{ .Values.tls.presto.passwordSecretRef.name }}"
+            items:
+              - key: "{{ .Values.tls.presto.passwordSecretRef.key }}"
+                path: password
         {{- end }}
         - name: config-volume
           configMap:

--- a/charts/sn-platform/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/sn-platform/templates/presto/presto-coordinator-statefulset.yaml
@@ -81,7 +81,11 @@ spec:
           livenessProbe:
             httpGet:
               {{- if .Values.tls.presto.enabled }}
+              {{- if .Values.presto.security.authentication.tls.enabled }}
+              path: /
+              {{- else }}
               path: {{ .Values.presto.coordinator.probe.liveness.path }}
+              {{- end }}
               port: {{ .Values.presto.coordinator.ports.https }}
               scheme: HTTPS
               {{- else }}
@@ -96,7 +100,11 @@ spec:
           readinessProbe:
             httpGet:
               {{- if .Values.tls.presto.enabled }}
+              {{- if .Values.presto.security.authentication.tls.enabled }}
+              path: /
+              {{- else }}
               path: {{ .Values.presto.coordinator.probe.liveness.path }}
+              {{- end }}
               port: {{ .Values.presto.coordinator.ports.https }}
               scheme: HTTPS
               {{- else }}

--- a/charts/sn-platform/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/sn-platform/templates/presto/presto-coordinator-statefulset.yaml
@@ -80,8 +80,14 @@ spec:
           {{- if .Values.presto.coordinator.probe.liveness.enabled }}
           livenessProbe:
             httpGet:
+              {{- if .Values.tls.presto.enabled }}
+              path: {{ .Values.presto.coordinator.probe.liveness.path }}
+              port: {{ .Values.presto.coordinator.ports.https }}
+              scheme: HTTPS
+              {{- else }}
               path: {{ .Values.presto.coordinator.probe.liveness.path }}
               port: {{ .Values.presto.coordinator.ports.http }}
+              {{- end }}
             initialDelaySeconds: {{ .Values.presto.coordinator.probe.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.presto.coordinator.probe.liveness.periodSeconds }}
             failureThreshold: {{ .Values.presto.coordinator.probe.liveness.failureThreshold }}
@@ -89,8 +95,14 @@ spec:
           {{- if .Values.presto.coordinator.probe.readiness.enabled }}
           readinessProbe:
             httpGet:
+              {{- if .Values.tls.presto.enabled }}
+              path: {{ .Values.presto.coordinator.probe.liveness.path }}
+              port: {{ .Values.presto.coordinator.ports.https }}
+              scheme: HTTPS
+              {{- else }}
               path: {{ .Values.presto.coordinator.probe.readiness.path }}
               port: {{ .Values.presto.coordinator.ports.http }}
+              {{- end }}
             initialDelaySeconds: {{ .Values.presto.coordinator.probe.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.presto.coordinator.probe.readiness.periodSeconds }}
             failureThreshold: {{ .Values.presto.coordinator.probe.readiness.failureThreshold }}
@@ -106,6 +118,15 @@ spec:
               echo "node.id=${HOSTNAME}" >> {{ template "pulsar.home" . }}/conf/presto/node.properties ;
               echo "node.internal-address=${HOSTNAME}.{{ template "presto.service" . }}.{{ template "pulsar.namespace" . }}.svc.cluster.local" >> {{ template "pulsar.home" . }}/conf/presto/node.properties ;
               ln -s {{ template "pulsar.home" . }}/conf/presto {{ template "pulsar.home" . }}/lib/presto/etc;
+              {{- if .Values.tls.presto.enabled }}
+              set -ex;
+              mkdir -p /pulsar/jks;
+              openssl pkcs12 -export -in /pulsar/certs/presto/tls.crt -inkey /pulsar/certs/presto/tls.key -out /pulsar/jks/server-cert.p12 -name presto-coordinator -passout "pass:changeit";
+              keytool -importkeystore -srckeystore /pulsar/jks/server-cert.p12 -srcstoretype PKCS12 -srcstorepass "changeit" -alias presto-coordinator -destkeystore /pulsar/jks/presto.keystore.jks -deststorepass "changeit";
+              {{- if .Values.tls.presto.trustCertsEnabled }}
+              echo "y" | keytool -import -alias selfsigned -file /pulsar/certs/presto/ca.crt -keystore /pulsar/jks/trust.jks -trustcacerts -storepass "changeit"; 
+              {{- end }}
+              {{- end }}
               bin/pulsar sql-worker run \
                 --etc-dir={{ template "pulsar.home" . }}/conf/presto \
                 --data-dir={{ template "pulsar.home" . }}/data;
@@ -179,6 +200,9 @@ spec:
               mountPath: "/pulsar/certs/presto"
               readOnly: true
             {{- end}}
+{{- with .Values.presto.extraVolumeMounts }}
+{{ toYaml . | indent 12 }}
+{{- end }}            
           ports:
 {{- if .Values.tls.presto.enabled }}
             - name: https
@@ -236,6 +260,10 @@ spec:
                 path: tls.crt
               - key: tls.key
                 path: tls.key
+              {{- if .Values.tls.presto.trustCertsEnabled }}
+              - key: ca.crt
+                path: ca.crt
+              {{- end }}
         {{- end }}
         - name: config-volume
           configMap:
@@ -258,4 +286,7 @@ spec:
           configMap:
             name: "{{ template "pulsar.fullname" . }}-presto-jmx-exporter"
         {{- end }}
+{{- with .Values.presto.extraVolumes }}
+{{ toYaml . | indent 8 }}
+{{- end }}
 {{- end }}

--- a/charts/sn-platform/templates/presto/presto-serviceentry.yaml
+++ b/charts/sn-platform/templates/presto/presto-serviceentry.yaml
@@ -50,9 +50,15 @@ spec:
   - "{{ template "presto.worker" $ }}-{{ $i }}.{{ template "presto.worker.hostname" $ }}"
   location: MESH_INTERNAL
   ports:
+  {{- if $.Values.tls.presto.enabled }}
+  - name: tls-web
+    number: {{ $.Values.presto.worker.ports.https }}
+    protocol: HTTPS
+  {{- else }}
   - name: tcp-web
     number: {{ $.Values.presto.worker.ports.http }}
     protocol: HTTP
+  {{- end }}
   resolution: DNS
 ---
 {{- end }}

--- a/charts/sn-platform/templates/presto/presto-worker-configmap.yaml
+++ b/charts/sn-platform/templates/presto/presto-worker-configmap.yaml
@@ -78,11 +78,15 @@ data:
     http-server.http.enabled=false
     http-server.https.enabled=true
     http-server.https.port={{ .Values.presto.coordinator.ports.https }}
-    http-server.https.keystore.path=<keystore path>
-    http-server.https.keystore.key=<keystore password>
+    http-server.https.keystore.path=/pulsar/jks/presto.keystore.jks
+    http-server.https.keystore.key=changeit
     internal-communication.https.required=true
-    internal-communication.https.keystore.path=<keystore path>
-    internal-communication.https.keystore.key=<keystore password>
+    internal-communication.https.keystore.path=/pulsar/jks/presto.keystore.jks
+    internal-communication.https.keystore.key=changeit
+    {{- if .Values.tls.presto.trustCertsEnabled }}
+    http-server.https.truststore.path=/pulsar/jks/trust.jks
+    http-server.https.truststore.key=changeit
+    {{- end }}
     discovery.uri=https://{{ template "presto.service" . }}:{{ .Values.presto.coordinator.ports.https }}
 {{- else }}
     http-server.https.enabled=false
@@ -247,6 +251,10 @@ data:
 
   health_check.sh: |
     #!/bin/bash
-    curl --silent {{ template "presto.service" . }}:{{ .Values.presto.coordinator.ports.http }}/v1/node | tr "," "\n" | grep --silent $(hostname)
+    {{- if .Values.tls.presto.enabled }}
+    curl --silent https://{{ template "presto.service" . }}:{{ .Values.presto.coordinator.ports.https }}/v1/node -k | tr "," "\n" | grep --silent $(hostname)
+    {{- else }}
+    curl --silent http://{{ template "presto.service" . }}:{{ .Values.presto.coordinator.ports.http }}/v1/node | tr "," "\n" | grep --silent $(hostname)
+    {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sn-platform/templates/presto/presto-worker-configmap.yaml
+++ b/charts/sn-platform/templates/presto/presto-worker-configmap.yaml
@@ -88,6 +88,10 @@ data:
     http-server.https.truststore.key=changeit
     {{- end }}
     discovery.uri=https://{{ template "presto.service" . }}:{{ .Values.presto.coordinator.ports.https }}
+    {{- if .Values.presto.security.authentication.tls.enabled }}
+    http-server.authentication.type=CERTIFICATE
+    http-server.authentication.certificate.user-mapping.pattern=CN=([^,]+).*
+    {{- end }}
 {{- else }}
     http-server.https.enabled=false
     internal-communication.https.required=false

--- a/charts/sn-platform/templates/presto/presto-worker-configmap.yaml
+++ b/charts/sn-platform/templates/presto/presto-worker-configmap.yaml
@@ -79,13 +79,13 @@ data:
     http-server.https.enabled=true
     http-server.https.port={{ .Values.presto.coordinator.ports.https }}
     http-server.https.keystore.path=/pulsar/jks/presto.keystore.jks
-    http-server.https.keystore.key=changeit
+    http-server.https.keystore.key={{ template "pulsar.presto.jks.password" . }}
     internal-communication.https.required=true
     internal-communication.https.keystore.path=/pulsar/jks/presto.keystore.jks
-    internal-communication.https.keystore.key=changeit
+    internal-communication.https.keystore.key={{ template "pulsar.presto.jks.password" . }}
     {{- if .Values.tls.presto.trustCertsEnabled }}
     http-server.https.truststore.path=/pulsar/jks/trust.jks
-    http-server.https.truststore.key=changeit
+    http-server.https.truststore.key={{ template "pulsar.presto.jks.password" . }}
     {{- end }}
     discovery.uri=https://{{ template "presto.service" . }}:{{ .Values.presto.coordinator.ports.https }}
     {{- if .Values.presto.security.authentication.tls.enabled }}

--- a/charts/sn-platform/templates/presto/presto-worker-statefulset.yaml
+++ b/charts/sn-platform/templates/presto/presto-worker-statefulset.yaml
@@ -78,20 +78,30 @@ spec:
           {{- include "presto.worker.image" . | nindent 10 }}
           {{- if .Values.presto.worker.probe.liveness.enabled }}
           livenessProbe:
+            {{- if .Values.presto.security.authentication.tls.enabled }}
+            tcpSocket:
+              port: {{ .Values.presto.coordinator.ports.https }}
+            {{- else }}
             exec:
               command:
                 - /bin/bash
                 - /presto/health_check.sh
+            {{- end }}
             initialDelaySeconds: {{ .Values.presto.worker.probe.liveness.initialDelaySeconds }}
             periodSeconds: {{ .Values.presto.worker.probe.liveness.periodSeconds }}
             failureThreshold: {{ .Values.presto.worker.probe.liveness.failureThreshold }}
           {{- end }}
           {{- if .Values.presto.worker.probe.readiness.enabled }}
           readinessProbe:
+            {{- if .Values.presto.security.authentication.tls.enabled }}
+            tcpSocket:
+              port: {{ .Values.presto.coordinator.ports.https }}
+            {{- else }}
             exec:
               command:
                 - /bin/bash
                 - /presto/health_check.sh
+            {{- end }}    
             initialDelaySeconds: {{ .Values.presto.worker.probe.readiness.initialDelaySeconds }}
             periodSeconds: {{ .Values.presto.worker.probe.readiness.periodSeconds }}
             failureThreshold: {{ .Values.presto.worker.probe.readiness.failureThreshold }}

--- a/charts/sn-platform/templates/presto/presto-worker-statefulset.yaml
+++ b/charts/sn-platform/templates/presto/presto-worker-statefulset.yaml
@@ -107,6 +107,15 @@ spec:
               echo "node.id=${HOSTNAME}" >> {{ template "pulsar.home" . }}/conf/presto/node.properties ;
               echo "node.internal-address=${HOSTNAME}.{{ template "presto.worker.service" . }}.{{ template "pulsar.namespace" . }}.svc.cluster.local" >> {{ template "pulsar.home" . }}/conf/presto/node.properties ;
               ln -s {{ template "pulsar.home" . }}/conf/presto {{ template "pulsar.home" . }}/lib/presto/etc;
+              {{- if .Values.tls.presto.enabled }}
+              set -ex;
+              mkdir -p /pulsar/jks;
+              openssl pkcs12 -export -in /pulsar/certs/presto/tls.crt -inkey /pulsar/certs/presto/tls.key -out /pulsar/jks/server-cert.p12 -name presto-coordinator -passout "pass:changeit";
+              keytool -importkeystore -srckeystore /pulsar/jks/server-cert.p12 -srcstoretype PKCS12 -srcstorepass "changeit" -alias presto-coordinator -destkeystore /pulsar/jks/presto.keystore.jks -deststorepass "changeit";
+              {{- if .Values.tls.presto.trustCertsEnabled }}
+              echo "y" | keytool -import -alias selfsigned -file /pulsar/certs/presto/ca.crt -keystore /pulsar/jks/trust.jks -trustcacerts -storepass "changeit"; 
+              {{- end }}
+              {{- end }}
               bin/pulsar sql-worker run \
                 --etc-dir={{ template "pulsar.home" . }}/conf/presto \
                 --data-dir={{ template "pulsar.home" . }}/data;
@@ -163,6 +172,9 @@ spec:
               mountPath: "/pulsar/certs/presto"
               readOnly: true
             {{- end}}
+{{- with .Values.presto.extraVolumeMounts }}
+{{ toYaml . | indent 12 }}
+{{- end }}                        
           ports:
             - name: http
               containerPort: {{ .Values.presto.worker.ports.http }}
@@ -213,6 +225,10 @@ spec:
                 path: tls.crt
               - key: tls.key
                 path: tls.key
+              {{- if .Values.tls.presto.trustCertsEnabled }}
+              - key: ca.crt
+                path: ca.crt
+              {{- end }}
         {{- end }}
         - name: config-volume
           configMap:
@@ -222,5 +238,8 @@ spec:
           configMap:
             name: "{{ template "pulsar.fullname" . }}-presto-jmx-exporter"
         {{- end }}
+{{- with .Values.presto.extraVolumes }}
+{{ toYaml . | indent 8 }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sn-platform/templates/presto/presto-worker-statefulset.yaml
+++ b/charts/sn-platform/templates/presto/presto-worker-statefulset.yaml
@@ -120,10 +120,10 @@ spec:
               {{- if .Values.tls.presto.enabled }}
               set -ex;
               mkdir -p /pulsar/jks;
-              openssl pkcs12 -export -in /pulsar/certs/presto/tls.crt -inkey /pulsar/certs/presto/tls.key -out /pulsar/jks/server-cert.p12 -name presto-coordinator -passout "pass:changeit";
-              keytool -importkeystore -srckeystore /pulsar/jks/server-cert.p12 -srcstoretype PKCS12 -srcstorepass "changeit" -alias presto-coordinator -destkeystore /pulsar/jks/presto.keystore.jks -deststorepass "changeit";
+              openssl pkcs12 -export -in /pulsar/certs/presto/tls.crt -inkey /pulsar/certs/presto/tls.key -out /pulsar/jks/server-cert.p12 -name presto-coordinator -passout "pass:{{ template "pulsar.presto.jks.password" . }}";
+              keytool -importkeystore -srckeystore /pulsar/jks/server-cert.p12 -srcstoretype PKCS12 -srcstorepass {{ template "pulsar.presto.jks.password" . }} -alias presto-coordinator -destkeystore /pulsar/jks/presto.keystore.jks -deststorepass {{ template "pulsar.presto.jks.password" . }};
               {{- if .Values.tls.presto.trustCertsEnabled }}
-              echo "y" | keytool -import -alias selfsigned -file /pulsar/certs/presto/ca.crt -keystore /pulsar/jks/trust.jks -trustcacerts -storepass "changeit"; 
+              echo "y" | keytool -import -alias selfsigned -file /pulsar/certs/presto/ca.crt -keystore /pulsar/jks/trust.jks -trustcacerts -storepass {{ template "pulsar.presto.jks.password" . }}; 
               {{- end }}
               {{- end }}
               bin/pulsar sql-worker run \

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -344,6 +344,7 @@ tls:
     cert_name: tls-presto
     # specify name of secret contain certificate if using pre-generated certificate
     certSecretName:
+    trustCertsEnabled: false
   streamnative_console:
     enabled: false
     # name of chart generated certificate
@@ -2141,6 +2142,7 @@ presto:
     gracePeriod: 10
     ports:
       http: 8081
+      https: 8443
     resources:
       requests:
         memory: 4Gi

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -345,6 +345,10 @@ tls:
     # specify name of secret contain certificate if using pre-generated certificate
     certSecretName:
     trustCertsEnabled: false
+    # use "changeit" as password if not set passwordSecretRef 
+    # passwordSecretRef:
+    #   key: password
+    #   name: ""
   streamnative_console:
     enabled: false
     # name of chart generated certificate

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -2061,6 +2061,8 @@ presto:
         # you can use `openssl rsa -pubin -in <public key file> -inform DER -pubout -out <public key file in PEM format> -outform PEM`
         # to convert the public key file to a public key file in PEM format.
         publicKeyConfigMapKey: 'public.key'
+      tls:
+        enabled: false
     rules: >
       {
         "rules": [

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -345,7 +345,7 @@ tls:
     # specify name of secret contain certificate if using pre-generated certificate
     certSecretName:
     trustCertsEnabled: false
-    # use "changeit" as password if not set passwordSecretRef 
+    # use "changeit" as password if not set passwordSecretRef
     # passwordSecretRef:
     #   key: password
     #   name: ""


### PR DESCRIPTION
Fixes #868 

### Motivation

Presto coordinator and worker support tls authentication

### Modifications

1. Fix tls configuration of presto
   ```yaml
   tls:
      presto:
        enabled: true
        trustCertsEnabled: true
   ```
3. Add tls authentication configuration for presto
   ```yaml
   presto:
      security:
        tls:
          enabled: true
   ```

### Verifying this change

- [x] Make sure that the change passes the CI checks.


This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

