### PR TITLE
Fix chart-testing(upgrade) job

### DIFF
--- a/.github/workflows/pulsar_upgrade.yml
+++ b/.github/workflows/pulsar_upgrade.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: apache/pulsar-helm-chart
-          ref: 'master'
+          ref: 'pulsar-2.9.4'
           path: 'apache-charts'
 
       - name: Run chart-testing (upgrade)


### PR DESCRIPTION
Fixes #882 

### Motivation

apache pulsar helm chart adds a dependency, making helm install failed

### Modifications

Fix apache/pulsar-helm-chart to pulsar-2.9.4

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

