### PR TITLE
[sn-platform] Fix Presto JMX exporter enable condition

### DIFF
--- a/charts/sn-platform/templates/presto/presto-coordinator-configmap.yaml
+++ b/charts/sn-platform/templates/presto/presto-coordinator-configmap.yaml
@@ -42,7 +42,7 @@ data:
     -XX:+ExitOnOutOfMemoryError
     -Dpresto-temporarily-allow-java8=true
     -Djdk.attach.allowAttachSelf=true
-    {{- if .Values.presto.exporter }}
+    {{- if .Values.presto.exporter.enabled }}
     -Dcom.sun.management.jmxremote.rmi.port=9081
     -Dcom.sun.management.jmxremote.ssl=false
     -Dcom.sun.management.jmxremote=true
@@ -70,7 +70,7 @@ data:
     #
 
     coordinator=true
-    {{- if .Values.presto.exporter }}
+    {{- if .Values.presto.exporter.enabled }}
     jmx.rmiregistry.port=9081
     jmx.rmiserver.port=9081
     {{- end }}

--- a/charts/sn-platform/templates/presto/presto-coordinator-deployment.yaml
+++ b/charts/sn-platform/templates/presto/presto-coordinator-deployment.yaml
@@ -222,7 +222,7 @@ spec:
               containerPort: {{ .Values.presto.coordinator.ports.http }}
               protocol: TCP
 {{- end }}
-        {{- if .Values.presto.exporter }}
+        {{- if .Values.presto.exporter.enabled }}
         - name: jmx-exporter
           image: "bitnami/jmx-exporter:0.17.0"
           image: "{{ .Values.images.presto.exporter.repository }}:{{ .Values.images.presto.exporter.tag }}"
@@ -298,7 +298,7 @@ spec:
             - key: {{ .Values.presto.security.authentication.password.passwordFileSecretKey }}
               path: {{ .Values.presto.security.authentication.password.passwordFileName }}
         {{- end}}
-        {{- if .Values.presto.exporter }}
+        {{- if .Values.presto.exporter.enabled }}
         - name: jmx-exporter-config-volume
           configMap:
             name: "{{ template "pulsar.fullname" . }}-presto-jmx-exporter"

--- a/charts/sn-platform/templates/presto/presto-worker-configmap.yaml
+++ b/charts/sn-platform/templates/presto/presto-worker-configmap.yaml
@@ -43,7 +43,7 @@ data:
     -XX:+ExitOnOutOfMemoryError
     -Dpresto-temporarily-allow-java8=true
     -Djdk.attach.allowAttachSelf=true
-{{- if .Values.presto.exporter }}
+{{- if .Values.presto.exporter.enabled }}
     -Dcom.sun.management.jmxremote.rmi.port=9081
     -Dcom.sun.management.jmxremote.ssl=false
     -Dcom.sun.management.jmxremote=true
@@ -70,7 +70,7 @@ data:
     # under the License.
     #
     coordinator=false
-{{- if .Values.presto.exporter }}
+{{- if .Values.presto.exporter.enabled }}
     jmx.rmiregistry.port=9081
     jmx.rmiserver.port=9081
 {{- end }}

--- a/charts/sn-platform/templates/presto/presto-worker-deployment.yaml
+++ b/charts/sn-platform/templates/presto/presto-worker-deployment.yaml
@@ -185,7 +185,7 @@ spec:
             - name: http
               containerPort: {{ .Values.presto.worker.ports.http }}
               protocol: TCP
-        {{- if .Values.presto.exporter }}
+        {{- if .Values.presto.exporter.enabled }}
         - name: jmx-exporter
           image: "{{ .Values.images.presto.exporter.repository }}:{{ .Values.images.presto.exporter.tag }}"
           imagePullPolicy: {{ .Values.images.presto.exporter.pullPolicy }}
@@ -239,7 +239,7 @@ spec:
         - name: config-volume
           configMap:
             name: "{{ template "pulsar.fullname" . }}-{{ .Values.presto.worker.component }}"
-        {{- if .Values.presto.exporter }}
+        {{- if .Values.presto.exporter.enabled }}
         - name: jmx-exporter-config-volume
           configMap:
             name: "{{ template "pulsar.fullname" . }}-presto-jmx-exporter"


### PR DESCRIPTION
Fixes #900 

### Motivation

- can't disable presto exporter

### Modifications

- Use `.Values.presto.exporter.enabled` replace `.Values.presto.exporter` as enable condition

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

