### PR TITLE
Update CODEOWNERS: Remove platform team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*                       @streamnative/platform @streamnative/cloud @sijie @addisonj 
+*                       @streamnative/cloud @sijie @addisonj 


### PR DESCRIPTION
Seems like the platform team is not the owner of those charts

