### PR TITLE
Update console version for fixed curl missing issue

### DIFF
--- a/charts/sn-console/values.yaml
+++ b/charts/sn-console/values.yaml
@@ -21,7 +21,7 @@ initialize: true
 
 image:
   repository: streamnative/sn-platform-console
-  tag: "v1.14.1"
+  tag: "v1.14.2"
   pullPolicy: IfNotPresent
   hasCommand: false
 

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -207,7 +207,7 @@ images:
     pullPolicy: IfNotPresent
   streamnative_console:
     repository: streamnative/sn-platform-console
-    tag: "v1.14.1"
+    tag: "v1.14.2"
     pullPolicy: IfNotPresent
     hasCommand: false
   node_exporter:


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[charts/<chart-name>] Title of the pull request".
    Skip *[charts/<chart-name>]* if the PR doesn't change a specific chart. E.g. `[docs] Fix typo in README`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

## Summary of the issue

They have provided a full analysis of the problem and a workaround for the issue:

> During K8S deployment, streamnative-console-init pod gets stuck into “NotReady” State, where injected istio-proxy container keeps “Running”.

```
pulsar-sn-platform-streamnative-console-init-dthg4    1/2     NotReady    0               3m10s
```

> Using istioctl 1.15.3 + SN:1.6.0
> Looking at the logs of the stuck NotReady pod “pulsar-sn-platform-streamnative-console-init-hxt2r”:

```
$ kubectl logs pulsar-sn-platform-streamnative-console-init-dthg4 -n pulsar
.
.
StreamNative Console is ready to use~
sh: 6: curl: not found

```

> This error comes with missing “curl” binary in the PATH from following code:
```
      python3 /root/init_instance/init_instance.py 2>/dev/null; until [ $? -eq 0 ]; do
      
        echo "streamnative console is not ready now! wait another 10s~";
        sleep 10;
        python3 /root/init_instance/init_instance.py 2>/dev/null;
      done; echo "StreamNative Console is ready to use~"; curl -sf -XPOST http://127.0.0.1:15020/quitquitquit || true;

```
> The issue is because of missing curl command, which fails to signal to the Istio-proxy to (gracefully) shutdown. As that curl calls fails, the istio-proxy continues to run leading to the current issue.

> Following is the workaround to run that curl command in the other (istio-proxy) container, which will make istio-proxy container to Complete:
kubectl exec -it pulsar-sn-platform-streamnative-console-init-dthg4 -n pulsar -c istio-proxy -- /usr/bin/curl -sf -XPOST http://127.0.0.1:15020/quitquitquit

> Added the transcript that includes output of "describe" and "logs" from the NotReady pod. 

[sn-console-init-transcript.txt](https://github.com/streamnative/eng-support-tickets/files/10042997/sn-console-init-transcript.txt)

> This issue blocks our Streamnative Pulsar deployment with istio enabled in Pulsar namespace.


### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

