### PR TITLE
[sn-platform] Make annotation merge-metrics configurable

### DIFF
--- a/charts/sn-platform/templates/_helpers.tpl
+++ b/charts/sn-platform/templates/_helpers.tpl
@@ -112,8 +112,12 @@ Extra necessary Pod annotations in Istio mode
 */}}
 {{- define "pulsar.istio.pod.annotations" -}}
 {{- if .Values.istio.enabled -}}
+{{- if .Values.istio.mergeMetrics -}}
+prometheus.istio.io/merge-metrics: "true"
+{{- else -}}
 prometheus.istio.io/merge-metrics: "false"
-{{- end }}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -2335,6 +2335,8 @@ istio:
   enabled: false
   # istio labels used to inject sidecars if it's not `sidecar.istio.io/inject: "true"`
   labels: {}
+  # If you're using the prometheus in this chart, please keep mergeMetrics disabled.
+  mergeMetrics: false
   gateway:
     # gateway selector if it's not `istio: ingressgateway`
     selector: {}


### PR DESCRIPTION
### Motivation

Make annotation merge-metrics configurable

### Modifications

Define `.Values.istio.mergeMetrics`, and default value is `false`

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

