### PR TITLE
[pulsar-operator] Add Istio resource rbac for zk/bk operator

### DIFF
--- a/charts/pulsar-operator/templates/bookkeeper-operator/rbac.yaml
+++ b/charts/pulsar-operator/templates/bookkeeper-operator/rbac.yaml
@@ -205,6 +205,30 @@ rules:
       - get
       - list
       - update
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - security.istio.io
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 kind: {{ template "pulsar.bookkeeperRoleBindingKind" . }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/pulsar-operator/templates/zookeeper-operator/rbac.yaml
+++ b/charts/pulsar-operator/templates/zookeeper-operator/rbac.yaml
@@ -173,6 +173,30 @@ rules:
       - get
       - list
       - update
+  - apiGroups:
+      - networking.istio.io
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - security.istio.io
+    resources:
+      - '*'
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
 ---
 kind: {{ template "pulsar.zookeeperRoleBindingKind" . }}
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Fixes #943 

### Motivation

zk/bk operator don't have permission to watch Istio resources in Istio env.

### Modifications

Add Istio resources rbac for zk/bk operator

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

