### PR TITLE
upgrade pulsarctl default download version to support arm64(Apple M1)

### DIFF
--- a/scripts/pulsar/common_auth.sh
+++ b/scripts/pulsar/common_auth.sh
@@ -25,7 +25,7 @@ fi
 
 OUTPUT=${CHART_HOME}/output
 OUTPUT_BIN=${OUTPUT}/bin
-PULSARCTL_VERSION=v0.4.0
+PULSARCTL_VERSION=v2.10.3.3
 PULSARCTL_BIN=${HOME}/.pulsarctl/pulsarctl
 export PATH=${HOME}/.pulsarctl/plugins:${PATH}
 

--- a/scripts/pulsar/common_auth.sh
+++ b/scripts/pulsar/common_auth.sh
@@ -25,7 +25,7 @@ fi
 
 OUTPUT=${CHART_HOME}/output
 OUTPUT_BIN=${OUTPUT}/bin
-PULSARCTL_VERSION=v2.10.3.3
+PULSARCTL_VERSION=v2.10.2.2
 PULSARCTL_BIN=${HOME}/.pulsarctl/pulsarctl
 export PATH=${HOME}/.pulsarctl/plugins:${PATH}
 


### PR DESCRIPTION
### Motivation

upgrade pulsarctl default download version to support arm64(Apple M1)

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

