### PR TITLE
fix internal issuer reference name.

### DIFF
--- a/charts/sn-platform/templates/tls/istio/tls-certs.yaml
+++ b/charts/sn-platform/templates/tls/istio/tls-certs.yaml
@@ -46,7 +46,7 @@ spec:
   # by the *.{{ .Values.domain.suffix }} if they are defined.
   issuerRef:
 {{- if .Values.certs.istio_internal_issuer.enabled }} 
-    name: "{{ template "pulsar.fullname" . }}-{{ .Values.certs.istio_internal_issuer.component }}"
+    name: "{{ template "pulsar.fullname" . }}-{{ .Values.certs.istio_internal_issuer.component }}-ca-issuer"
 {{- else if .Values.certs.istio_public_issuer.enabled }}  
     name: "{{ template "pulsar.fullname" . }}-{{ .Values.certs.istio_public_issuer.component }}"
 {{- end }}


### PR DESCRIPTION



### Motivation

* when using istio, internal issuer, the cert will failed due to issuer not found. 


### Modifications

* change the issuer reference name in istio cert when using internal issuer. 

### Verifying this change


### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ *] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

