### PR TITLE
[sn-platform][sn-platform-slim]: update to use the operator auto generated jvm memory options. 

### DIFF
--- a/charts/sn-platform-slim/templates/_helpers.tpl
+++ b/charts/sn-platform-slim/templates/_helpers.tpl
@@ -136,11 +136,12 @@ JVM Options
 */}}
 {{- define "pulsar.jvm.options" -}}
 jvmOptions:
-  memoryOptions:
   {{- if .configData.PULSAR_MEM }}
+  memoryOptions:
   - {{ .configData.PULSAR_MEM | quote }}
   {{- else }}
   {{- with .jvm.memoryOptions }}
+  memoryOptions:
   {{- toYaml . | nindent 2 }}
   {{- end }}
   {{- end }}

--- a/charts/sn-platform-slim/values.yaml
+++ b/charts/sn-platform-slim/values.yaml
@@ -1394,7 +1394,7 @@ proxy:
   gracePeriod: 30
   resources:
     requests:
-      memory: "128Mi"
+      memory: "512Mi"
       cpu: "0.2"
     # limits:
     #   memory: "512Mi"

--- a/charts/sn-platform-slim/values.yaml
+++ b/charts/sn-platform-slim/values.yaml
@@ -669,9 +669,8 @@ zookeeper:
   # Automtically Roll Deployments when configmap is changed
   autoRollDeployment: true
   jvm:
-    memoryOptions:
-    - >
-      -Xms64m -Xmx128m
+    # ZooKeeper Operator will automatically generate the JVM memory options based on the Pod memory size. You can override this by entering a new value.
+    memoryOptions: []
     gcOptions:
     - >
       -XX:+UseG1GC
@@ -871,11 +870,8 @@ bookkeeper:
         # extraParameters:
         #   iopsPerGB: "50"
   jvm:
-    memoryOptions:
-    - >
-      -Xms128m
-      -Xmx256m
-      -XX:MaxDirectMemorySize=256m
+    # BookKeeper Operator will automatically generate the JVM memory options based on the Pod memory size. You can override this by entering a new value.
+    memoryOptions: []
     gcOptions:
     - >
       -XX:+UseG1GC
@@ -941,8 +937,8 @@ autorecovery:
   # extra environment variable to define for the containers
   extraEnv: []
   jvm:
-    memoryOptions:
-    - -Xms128m -Xmx256m
+    # BookKeeper Operator will automatically generate the JVM memory options based on the Pod memory size. You can override this by entering a new value.
+    memoryOptions: []
     gcOptions: []
     extraOptions: []
     gcLoggingOptions: []
@@ -1120,9 +1116,8 @@ broker:
     # whether to create a cluster role
     clusterRole: true
   jvm:
-    memoryOptions:
-      - >
-        -Xms128m -Xmx256m -XX:MaxDirectMemorySize=256m
+    # Pulsar Operator will automatically generate the JVM memory options based on the Pod memory size. You can override this by entering a new value.
+    memoryOptions: []
     gcOptions:
       - >
         -XX:+UseG1GC
@@ -1432,9 +1427,8 @@ proxy:
   brokerServiceURLTLS: ""
   brokerWebServiceURLTLS: ""
   jvm:
-    memoryOptions:
-    - >
-      -Xms64m -Xmx64m -XX:MaxDirectMemorySize=64m
+    # Pulsar Operator will automatically generate the JVM memory options based on the Pod memory size. You can override this by entering a new value.
+    memoryOptions: []
     gcOptions:
     - >
       -XX:+UseG1GC

--- a/charts/sn-platform-slim/values.yaml
+++ b/charts/sn-platform-slim/values.yaml
@@ -679,7 +679,6 @@ zookeeper:
       -Djute.maxbuffer=10485760
       -XX:+ParallelRefProcEnabled
       -XX:+UnlockExperimentalVMOptions
-      -XX:+AggressiveOpts
       -XX:+DoEscapeAnalysis
       -XX:+DisableExplicitGC
       -XX:+PerfDisableSharedMem
@@ -878,7 +877,6 @@ bookkeeper:
       -XX:MaxGCPauseMillis=10
       -XX:+ParallelRefProcEnabled
       -XX:+UnlockExperimentalVMOptions
-      -XX:+AggressiveOpts
       -XX:+DoEscapeAnalysis
       -XX:ParallelGCThreads=4
       -XX:ConcGCThreads=4
@@ -1126,7 +1124,6 @@ broker:
         -Dio.netty.recycler.linkCapacity=1024
         -XX:+ParallelRefProcEnabled
         -XX:+UnlockExperimentalVMOptions
-        -XX:+AggressiveOpts
         -XX:+DoEscapeAnalysis
         -XX:ParallelGCThreads=4
         -XX:ConcGCThreads=4
@@ -1437,7 +1434,6 @@ proxy:
       -Dio.netty.recycler.linkCapacity=1024
       -XX:+ParallelRefProcEnabled
       -XX:+UnlockExperimentalVMOptions
-      -XX:+AggressiveOpts
       -XX:+DoEscapeAnalysis
       -XX:ParallelGCThreads=4
       -XX:ConcGCThreads=4

--- a/charts/sn-platform/templates/_helpers.tpl
+++ b/charts/sn-platform/templates/_helpers.tpl
@@ -136,11 +136,12 @@ JVM Options
 */}}
 {{- define "pulsar.jvm.options" -}}
 jvmOptions:
-  memoryOptions:
   {{- if .configData.PULSAR_MEM }}
+  memoryOptions:
   - {{ .configData.PULSAR_MEM | quote }}
   {{- else }}
   {{- with .jvm.memoryOptions }}
+  memoryOptions:
   {{- toYaml . | nindent 2 }}
   {{- end }}
   {{- end }}

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1469,7 +1469,7 @@ proxy:
   gracePeriod: 30
   resources:
     requests:
-      memory: "128Mi"
+      memory: "512Mi"
       cpu: "0.2"
     # limits:
     #   memory: "512Mi"

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -754,7 +754,6 @@ zookeeper:
       -Djute.maxbuffer=10485760
       -XX:+ParallelRefProcEnabled
       -XX:+UnlockExperimentalVMOptions
-      -XX:+AggressiveOpts
       -XX:+DoEscapeAnalysis
       -XX:+DisableExplicitGC
       -XX:+PerfDisableSharedMem
@@ -953,7 +952,6 @@ bookkeeper:
       -XX:MaxGCPauseMillis=10
       -XX:+ParallelRefProcEnabled
       -XX:+UnlockExperimentalVMOptions
-      -XX:+AggressiveOpts
       -XX:+DoEscapeAnalysis
       -XX:ParallelGCThreads=4
       -XX:ConcGCThreads=4
@@ -1201,7 +1199,6 @@ broker:
         -Dio.netty.recycler.linkCapacity=1024
         -XX:+ParallelRefProcEnabled
         -XX:+UnlockExperimentalVMOptions
-        -XX:+AggressiveOpts
         -XX:+DoEscapeAnalysis
         -XX:ParallelGCThreads=4
         -XX:ConcGCThreads=4
@@ -1514,7 +1511,6 @@ proxy:
       -Dio.netty.recycler.linkCapacity=1024
       -XX:+ParallelRefProcEnabled
       -XX:+UnlockExperimentalVMOptions
-      -XX:+AggressiveOpts
       -XX:+DoEscapeAnalysis
       -XX:ParallelGCThreads=4
       -XX:ConcGCThreads=4

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -744,9 +744,8 @@ zookeeper:
   # Automtically Roll Deployments when configmap is changed
   autoRollDeployment: true
   jvm:
-    memoryOptions:
-    - >
-      -Xms64m -Xmx128m
+    # ZooKeeper Operator will automatically generate the JVM memory options based on the Pod memory size. You can override this by entering a new value.
+    memoryOptions: []
     gcOptions:
     - >
       -XX:+UseG1GC
@@ -946,11 +945,8 @@ bookkeeper:
         # extraParameters:
         #   iopsPerGB: "50"
   jvm:
-    memoryOptions:
-    - >
-      -Xms128m
-      -Xmx256m
-      -XX:MaxDirectMemorySize=256m
+    # BookKeeper Operator will automatically generate the JVM memory options based on the Pod memory size. You can override this by entering a new value.
+    memoryOptions: []
     gcOptions:
     - >
       -XX:+UseG1GC
@@ -1016,8 +1012,8 @@ autorecovery:
   # extra environment variable to define for the containers
   extraEnv: []
   jvm:
-    memoryOptions:
-    - -Xms128m -Xmx256m
+    # BookKeeper Operator will automatically generate the JVM memory options based on the Pod memory size. You can override this by entering a new value.
+    memoryOptions: []
     gcOptions: []
     extraOptions: []
     gcLoggingOptions: []
@@ -1195,9 +1191,8 @@ broker:
     # whether to create a cluster role
     clusterRole: true
   jvm:
-    memoryOptions:
-      - >
-        -Xms128m -Xmx256m -XX:MaxDirectMemorySize=256m
+    # Pulsar Operator will automatically generate the JVM memory options based on the Pod memory size. You can override this by entering a new value.
+    memoryOptions: []
     gcOptions:
       - >
         -XX:+UseG1GC
@@ -1509,9 +1504,8 @@ proxy:
   authenticateMetricsEndpoint:
     enabled: true
   jvm:
-    memoryOptions:
-    - >
-      -Xms64m -Xmx64m -XX:MaxDirectMemorySize=64m
+    # Pulsar Operator will automatically generate the JVM memory options based on the Pod memory size. You can override this by entering a new value.
+    memoryOptions: []
     gcOptions:
     - >
       -XX:+UseG1GC


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[charts/<chart-name>] Title of the pull request".
    Skip *[charts/<chart-name>]* if the PR doesn't change a specific chart. E.g. `[docs] Fix typo in README`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

Pulsar Operators have the capability to auto-generate the JVM memory options based on the Pod memory size. 

### Modifications

By default to use the operator auto-generated JVM memory options config but also supports to override.  

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

