### PR TITLE
Replace removed tolerate-unready-endpoints annotation with publishNotReadyAddresses

### DIFF
--- a/charts/pulsar/templates/zookeeper/zookeeper-backup-service.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-backup-service.yaml
@@ -38,6 +38,7 @@ spec:
       port: {{ .Values.zookeeper.ports.clientTls }}
     {{- end }}
   clusterIP: None
+  publishNotReadyAddresses: true
   selector:
     {{- include "pulsar.matchLabels" . | nindent 4 }}
     component: {{ .Values.zookeeper.customTools.backup.component }}

--- a/charts/pulsar/templates/zookeeper/zookeeper-service.yaml
+++ b/charts/pulsar/templates/zookeeper/zookeeper-service.yaml
@@ -42,6 +42,7 @@ spec:
       port: {{ .Values.zookeeper.ports.clientTls }}
     {{- end }}
   clusterIP: None
+  publishNotReadyAddresses: true
   selector:
     {{- include "pulsar.matchLabels" . | nindent 4 }}
     component: {{ .Values.zookeeper.component }}

--- a/charts/pulsar/values.yaml
+++ b/charts/pulsar/values.yaml
@@ -642,8 +642,7 @@ zookeeper:
   ## templates/zookeeper-service.yaml
   ##
   service:
-    annotations:
-      service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+    annotations: {}
   ## Zookeeper PodDisruptionBudget
   ## templates/zookeeper-pdb.yaml
   ##
@@ -853,8 +852,7 @@ bookkeeper:
   ## templates/bookkeeper-service.yaml
   ##
   service:
-    annotations:
-      publishNotReadyAddresses: "true"
+    annotations: {}
   ## Bookkeeper PodDisruptionBudget
   ## templates/bookkeeper-pdb.yaml
   ##

--- a/charts/sn-platform-slim/templates/zookeeper/zookeeper-backup-service.yaml
+++ b/charts/sn-platform-slim/templates/zookeeper/zookeeper-backup-service.yaml
@@ -38,6 +38,7 @@ spec:
       port: {{ .Values.zookeeper.ports.clientTls }}
     {{- end }}
   clusterIP: None
+  publishNotReadyAddresses: true
   selector:
     {{- include "pulsar.matchLabels" . | nindent 4 }}
     component: {{ .Values.zookeeper.customTools.backup.component }}

--- a/charts/sn-platform-slim/values.yaml
+++ b/charts/sn-platform-slim/values.yaml
@@ -690,8 +690,7 @@ zookeeper:
   ## templates/zookeeper-service.yaml
   ##
   service:
-    annotations:
-      service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+    annotations: {}
   customTools:
     serviceAccount:
       use: true

--- a/charts/sn-platform/templates/zookeeper/zookeeper-backup-service.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-backup-service.yaml
@@ -38,6 +38,7 @@ spec:
       port: {{ .Values.zookeeper.ports.clientTls }}
     {{- end }}
   clusterIP: None
+  publishNotReadyAddresses: true
   selector:
     {{- include "pulsar.matchLabels" . | nindent 4 }}
     component: {{ .Values.zookeeper.customTools.backup.component }}

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -765,8 +765,7 @@ zookeeper:
   ## templates/zookeeper-service.yaml
   ##
   service:
-    annotations:
-      service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+    annotations: {}
   customTools:
     serviceAccount:
       use: true


### PR DESCRIPTION
### Motivation

StreamNative Pulsar helm chart isn't compatible with k8s 1.24+ since there isn't a way to configure Zookeeper service with `publishNotReadyAddresses: true`.
- `service.alpha.kubernetes.io/tolerate-unready-endpoints` annotation was removed in k8s 1.24 with commit https://github.com/kubernetes/kubernetes/commit/ae9f1173870822c186a1ddd696835cc5a9b989ec

### Modifications

- set `publishNotReadyAddresses: true` for zookeeper services
- remove traces of removed `service.alpha.kubernetes.io/tolerate-unready-endpoints` annotation 

### Documentation

- [x] `no-need-doc`