### PR TITLE
fix: generate secret from json string

### DIFF
--- a/charts/sn-platform-slim/templates/broker/broker-secret.yaml
+++ b/charts/sn-platform-slim/templates/broker/broker-secret.yaml
@@ -20,7 +20,7 @@
 {{- if .Values.auth.oauth.enabled }}
 apiVersion: v1
 data:
-  broker_client_credential.json: {{ .Values.auth.oauth.brokerClientCredential | toJson | b64enc | quote }}
+  broker_client_credential.json: {{ .Values.auth.oauth.brokerClientCredential | fromYaml | toJson | b64enc | quote }}
 kind: Secret
 metadata:
   name: "{{ template "pulsar.fullname" . }}-oauth-broker-secret"

--- a/charts/sn-platform/templates/broker/broker-secret.yaml
+++ b/charts/sn-platform/templates/broker/broker-secret.yaml
@@ -20,7 +20,7 @@
 {{- if .Values.auth.oauth.enabled }}
 apiVersion: v1
 data:
-  broker_client_credential.json: {{ .Values.auth.oauth.brokerClientCredential | toJson | b64enc | quote }}
+  broker_client_credential.json: {{ .Values.auth.oauth.brokerClientCredential | fromYaml | toJson | b64enc | quote }}
 kind: Secret
 metadata:
   name: "{{ template "pulsar.fullname" . }}-oauth-broker-secret"


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[charts/<chart-name>] Title of the pull request".
    Skip *[charts/<chart-name>]* if the PR doesn't change a specific chart. E.g. `[docs] Fix typo in README`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

### Motivation

The content that decodes from the secret is not correct, because it has backslashes.

```shell
"{\"client_id\":\"b097d864-4b4d-0020-a34e-0929dkjslkj29\",\"client_secret\":\"XFXXXXXXX_51ZijnihaoVqGJbbzk\"}"
```
The correct format should be like this
```shell
{"client_id":"b097d864-4b4d-0020-a34e-0929dkjslkj29","client_secret":"XFXXXXXXX_51ZijnihaoVqGJbbzk"}
```


### Modifications

Use the `fromYaml` first before the `toJson`.

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

