### PR TITLE
fix: missing template for proxy wss

### DIFF
--- a/charts/sn-platform-slim/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform-slim/templates/proxy/proxy-cluster.yaml
@@ -43,6 +43,7 @@ spec:
   replicas: {{ .Values.proxy.replicaCount }}
   image: "{{ .Values.images.proxy.repository }}:{{ .Values.images.proxy.tag }}"
   imagePullPolicy: {{ .Values.images.proxy.pullPolicy }}
+  webSocketServiceEnabled: {{ .Values.proxy.websocket.enabled }}
   logConfig:
     level: {{ .Values.proxy.logConfig.level }}
     format: {{ .Values.proxy.logConfig.format }}

--- a/charts/sn-platform-slim/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform-slim/templates/proxy/proxy-cluster.yaml
@@ -43,7 +43,6 @@ spec:
   replicas: {{ .Values.proxy.replicaCount }}
   image: "{{ .Values.images.proxy.repository }}:{{ .Values.images.proxy.tag }}"
   imagePullPolicy: {{ .Values.images.proxy.pullPolicy }}
-  webSocketServiceEnabled: {{ .Values.proxy.websocket.enabled }}
   logConfig:
     level: {{ .Values.proxy.logConfig.level }}
     format: {{ .Values.proxy.logConfig.format }}
@@ -152,6 +151,9 @@ spec:
       authenticationProviders: {{ include "pulsar.authenticationProviders" . }}
 {{- include "pulsar.authConfiguration" . | indent 6 }}
       superUserRoles: "{{ .Values.auth.superUsers.proxy }}"
+      {{- end }}
+      {{- if .Values..proxy.websocket.enabled }}
+      PULSAR_PREFIX_webSocketServiceEnabled: "true"
       {{- end }}
       {{- if and (.Values.tls.enabled) (.Values.tls.proxy.enabled) }}
       {{- if .Values.certs.internal_issuer.enabled }}

--- a/charts/sn-platform-slim/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform-slim/templates/proxy/proxy-cluster.yaml
@@ -152,7 +152,7 @@ spec:
 {{- include "pulsar.authConfiguration" . | indent 6 }}
       superUserRoles: "{{ .Values.auth.superUsers.proxy }}"
       {{- end }}
-      {{- if .Values..proxy.websocket.enabled }}
+      {{- if .Values.proxy.websocket.enabled }}
       PULSAR_PREFIX_webSocketServiceEnabled: "true"
       {{- end }}
       {{- if and (.Values.tls.enabled) (.Values.tls.proxy.enabled) }}

--- a/charts/sn-platform/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-cluster.yaml
@@ -43,6 +43,7 @@ spec:
   replicas: {{ .Values.proxy.replicaCount }}
   image: "{{ .Values.images.proxy.repository }}:{{ .Values.images.proxy.tag }}"
   imagePullPolicy: {{ .Values.images.proxy.pullPolicy }}
+  webSocketServiceEnabled: {{ .Values.proxy.websocket.enabled }}
   logConfig:
     level: {{ .Values.proxy.logConfig.level }}
     format: {{ .Values.proxy.logConfig.format }}

--- a/charts/sn-platform/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-cluster.yaml
@@ -43,7 +43,6 @@ spec:
   replicas: {{ .Values.proxy.replicaCount }}
   image: "{{ .Values.images.proxy.repository }}:{{ .Values.images.proxy.tag }}"
   imagePullPolicy: {{ .Values.images.proxy.pullPolicy }}
-  webSocketServiceEnabled: {{ .Values.proxy.websocket.enabled }}
   logConfig:
     level: {{ .Values.proxy.logConfig.level }}
     format: {{ .Values.proxy.logConfig.format }}
@@ -152,6 +151,9 @@ spec:
       authenticationProviders: {{ include "pulsar.authenticationProviders" . }}
 {{- include "pulsar.authConfiguration" . | indent 6 }}
       superUserRoles: "{{ .Values.auth.superUsers.proxy }}"
+      {{- end }}
+      {{- if .Values..proxy.websocket.enabled }}
+      PULSAR_PREFIX_webSocketServiceEnabled: "true"
       {{- end }}
       {{- if and (.Values.tls.enabled) (.Values.tls.proxy.enabled) }}
       {{- if .Values.certs.internal_issuer.enabled }}

--- a/charts/sn-platform/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-cluster.yaml
@@ -152,7 +152,7 @@ spec:
 {{- include "pulsar.authConfiguration" . | indent 6 }}
       superUserRoles: "{{ .Values.auth.superUsers.proxy }}"
       {{- end }}
-      {{- if .Values..proxy.websocket.enabled }}
+      {{- if .Values.proxy.websocket.enabled }}
       PULSAR_PREFIX_webSocketServiceEnabled: "true"
       {{- end }}
       {{- if and (.Values.tls.enabled) (.Values.tls.proxy.enabled) }}


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - Name the pull request in the form "[charts/<chart-name>] Title of the pull request".
    Skip *[charts/<chart-name>]* if the PR doesn't change a specific chart. E.g. `[docs] Fix typo in README`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.

**(The sections below can be removed for hotfixes of typos)**
-->

*(If this PR fixes a github issue, please add `Fixes #<xyz>`.)*

Fixes #<xyz>

*(or if this PR is one task of a github issue, please add `Master Issue: #<xyz>` to link to the master issue.)*

Master Issue: #<xyz>

### Motivation

*Explain here the context, and why you're making that change. What is the problem you're trying to solve.*

### Modifications

*Describe the modifications you've done.*

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

