### PR TITLE
Load the pulsar env as the program start options

### DIFF
--- a/charts/pulsar/templates/bookkeeper/bookkeeper-cluster-initialize.yaml
+++ b/charts/pulsar/templates/bookkeeper/bookkeeper-cluster-initialize.yaml
@@ -56,7 +56,7 @@ spec:
             {{- include "pulsar.toolset.zookeeper.tls.settings" . | nindent 12 }}
             {{ if and .Values.tls.enabled .Values.tls.zookeeper.enabled }}
             export "$(cat conf/pulsar_env.sh | xargs)";
-            export "OPTS=${EXTRA_OPTS}";
+            export OPTS="${PULSAR_EXTRA_OPTS} ${EXTRA_OPTS}";
             env;
             {{- end }}
             bin/pulsar-metadata-tool cleanup


### PR DESCRIPTION
---

### Motivation

When enable tls for the zookeeper, it will write the TLS properties with PULSAR_EXTRA_OPTS as the key into the pulsar-env.sh file. The metadata tool also needs the PULSAR_EXTRA_OPTS to get the zookeeper TLS configurations. So import the PULSAR_EXTRA_OPTS into the OPTS to load the zookeeper TLS configuration.

