### PR TITLE
Support Istio migration mode

### DIFF
--- a/charts/sn-platform-slim/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform-slim/templates/broker/broker-cluster.yaml
@@ -167,6 +167,10 @@ spec:
   {{- if and .Values.istio.enabled .Values.ingress.broker.enabled }}
   istio:
     enabled: true
+    {{- if .Values.istio.migration }}
+    mtls:
+      mode: permissive
+    {{- end }}
     gateway:
       selector:
 {{- include "pulsar.istio.gateway.selector" . | indent 8 }}

--- a/charts/sn-platform-slim/templates/istio/default-peerauthentication.yaml
+++ b/charts/sn-platform-slim/templates/istio/default-peerauthentication.yaml
@@ -25,5 +25,9 @@ metadata:
   namespace: {{ template "pulsar.namespace" . }}
 spec:
   mtls:
+{{- if .Values.istio.migration }}
+    mode: PERMISSIVE
+{{- else }}
     mode: STRICT
+{{- end }}
 {{- end }}

--- a/charts/sn-platform-slim/values.yaml
+++ b/charts/sn-platform-slim/values.yaml
@@ -2092,6 +2092,7 @@ extraResources: []
 
 istio:
   enabled: false
+  migration: false
   # istio labels used to inject sidecars if it's not `sidecar.istio.io/inject: "true"`
   labels: {}
   # If you're using the prometheus in this chart, please keep mergeMetrics disabled.

--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -171,6 +171,10 @@ spec:
   {{- if and .Values.istio.enabled .Values.ingress.broker.enabled }}
   istio:
     enabled: true
+    {{- if .Values.istio.migration }}
+    mtls:
+      mode: permissive
+    {{- end }}
     gateway:
       selector:
 {{- include "pulsar.istio.gateway.selector" . | indent 8 }}

--- a/charts/sn-platform/templates/istio/default-peerauthentication.yaml
+++ b/charts/sn-platform/templates/istio/default-peerauthentication.yaml
@@ -25,5 +25,9 @@ metadata:
   namespace: {{ template "pulsar.namespace" . }}
 spec:
   mtls:
+{{- if .Values.istio.migration }}
+    mode: PERMISSIVE
+{{- else }}
     mode: STRICT
+{{- end }}
 {{- end }}

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -2454,6 +2454,7 @@ custom_metric_server:
 
 istio:
   enabled: false
+  migration: false
   # istio labels used to inject sidecars if it's not `sidecar.istio.io/inject: "true"`
   labels: {}
   # If you're using the prometheus in this chart, please keep mergeMetrics disabled.


### PR DESCRIPTION
Fixes #1110 

### Motivation

Support migrate workloads from non-Istio to Istio

### Modifications

- Make mtls mode permissive for Istio migration

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [x] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [ ] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

