### PR TITLE
Replace presto with trino

### DIFF
--- a/charts/pulsar/templates/presto/presto-coordinator-configmap.yaml
+++ b/charts/pulsar/templates/presto/presto-coordinator-configmap.yaml
@@ -113,7 +113,7 @@ data:
 {{- if .Values.presto.security.authentication.jwt.enabled }}
     # JWT Authentication
     http-server.authentication.type=JWT
-    http-server.authentication.jwt.key-file={{ template "pulsar.home" . }}/conf/presto/{{ .Values.presto.security.authentication.jwt.publicKeyFileName }}
+    http-server.authentication.jwt.key-file={{ template "pulsar.home" . }}/trino/conf/{{ .Values.presto.security.authentication.jwt.publicKeyFileName }}
 {{- end }}
 
   log.properties: |
@@ -270,13 +270,13 @@ data:
   access-control.properties: |
     # access-control.properties
     access-control.name=file
-    security.config-file={{ template "pulsar.home" . }}/conf/presto/rules.json
+    security.config-file={{ template "pulsar.home" . }}/trino/conf/rules.json
     security.refresh-period=60s
 {{- end}}
 {{- if .Values.presto.security.authentication.password.enabled }}
   password-authenticator.properties: |
     password-authenticator.name=file
-    file.password-file={{ template "pulsar.home" . }}/presto/{{ .Values.presto.security.authentication.password.passwordFileName }}
+    file.password-file={{ template "pulsar.home" . }}/trino/{{ .Values.presto.security.authentication.password.passwordFileName }}
     file.refresh-period=60s
 {{- end}}
 {{- end }}

--- a/charts/pulsar/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/pulsar/templates/presto/presto-coordinator-statefulset.yaml
@@ -135,12 +135,11 @@ spec:
             {{- end }}
             {{- else }}
             - >-
-              cp {{ template "pulsar.home" . }}/conf/presto/node.properties.template {{ template "pulsar.home" . }}/conf/presto/node.properties;
-              echo "node.id=${HOSTNAME}" >> {{ template "pulsar.home" . }}/conf/presto/node.properties ;
-              echo "node.internal-address=${HOSTNAME}.{{ template "presto.service" . }}.{{ template "pulsar.namespace" . }}.svc.cluster.local" >> {{ template "pulsar.home" . }}/conf/presto/node.properties ;
-              ln -s {{ template "pulsar.home" . }}/conf/presto {{ template "pulsar.home" . }}/lib/presto/etc;
+              cp {{ template "pulsar.home" . }}/trino/conf/node.properties.template {{ template "pulsar.home" . }}/trino/conf/node.properties;
+              echo "node.id=${HOSTNAME}" >> {{ template "pulsar.home" . }}/trino/conf/node.properties ;
+              echo "node.internal-address=${HOSTNAME}.{{ template "presto.service" . }}.{{ template "pulsar.namespace" . }}.svc.cluster.local" >> {{ template "pulsar.home" . }}/trino/conf/node.properties ;
               bin/pulsar sql-worker run \
-                --etc-dir={{ template "pulsar.home" . }}/conf/presto \
+                --etc-dir={{ template "pulsar.home" . }}/trino/conf \
                 --data-dir={{ template "pulsar.home" . }}/data;
             {{- end }}
           env:
@@ -161,38 +160,38 @@ spec:
                 key: AWS_SECRET_ACCESS_KEY
           {{- end }}
           volumeMounts:
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/node.properties.template
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/node.properties.template
               name: config-volume
               subPath: node.properties
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/log.properties
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/log.properties
               name: config-volume
               subPath: log.properties
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/jvm.config
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/jvm.config
               name: config-volume
               subPath: jvm.config
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/config.properties
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/config.properties
               name: config-volume
               subPath: config.properties
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/catalog/pulsar.properties
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/catalog/pulsar.properties
               name: config-volume
               subPath: pulsar.properties
             {{- if or .Values.presto.security.authentication.jwt.enabled .Values.presto.security.authentication.password.enabled }}
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/rules.json
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/rules.json
               name: config-volume
               subPath: rules.json
             {{- end}}
             {{- if .Values.presto.security.authentication.password.enabled }}
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/password-authenticator.properties
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/password-authenticator.properties
               name: config-volume
               subPath: password-authenticator.properties
-            - mountPath: {{ template "pulsar.home" . }}/presto
+            - mountPath: {{ template "pulsar.home" . }}/trino
               name: password-file-volume
             {{- end}}
             {{- if .Values.presto.security.authentication.jwt.enabled }}
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/access-control.properties
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/access-control.properties
               name: config-volume
               subPath: access-control.properties
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/{{ .Values.presto.security.authentication.jwt.publicKeyFileName }}
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/{{ .Values.presto.security.authentication.jwt.publicKeyFileName }}
               name: public-key-volume
               subPath: {{ .Values.presto.security.authentication.jwt.publicKeyConfigMapKey  }}
             {{- end}}

--- a/charts/pulsar/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/pulsar/templates/presto/presto-coordinator-statefulset.yaml
@@ -159,6 +159,8 @@ spec:
                 name: {{ .Values.broker.offload.s3.secret }}
                 key: AWS_SECRET_ACCESS_KEY
           {{- end }}
+          securityContext:
+            runAsUser: 0
           volumeMounts:
             - mountPath: {{ template "pulsar.home" . }}/trino/conf/node.properties.template
               name: config-volume

--- a/charts/pulsar/templates/presto/presto-coordinator-statefulset.yaml
+++ b/charts/pulsar/templates/presto/presto-coordinator-statefulset.yaml
@@ -137,7 +137,6 @@ spec:
             - >-
               cp {{ template "pulsar.home" . }}/trino/conf/node.properties.template {{ template "pulsar.home" . }}/trino/conf/node.properties;
               echo "node.id=${HOSTNAME}" >> {{ template "pulsar.home" . }}/trino/conf/node.properties ;
-              echo "node.internal-address=${HOSTNAME}.{{ template "presto.service" . }}.{{ template "pulsar.namespace" . }}.svc.cluster.local" >> {{ template "pulsar.home" . }}/trino/conf/node.properties ;
               bin/pulsar sql-worker run \
                 --etc-dir={{ template "pulsar.home" . }}/trino/conf \
                 --data-dir={{ template "pulsar.home" . }}/data;

--- a/charts/pulsar/templates/presto/presto-worker-statefulset.yaml
+++ b/charts/pulsar/templates/presto/presto-worker-statefulset.yaml
@@ -164,6 +164,8 @@ spec:
                 name: {{ .Values.broker.offload.s3.secret }}
                 key: AWS_SECRET_ACCESS_KEY
           {{- end }}
+          securityContext:
+            runAsUser: 0
           volumeMounts:
             - mountPath: {{ template "pulsar.home" . }}/trino/conf/node.properties.template
               name: config-volume

--- a/charts/pulsar/templates/presto/presto-worker-statefulset.yaml
+++ b/charts/pulsar/templates/presto/presto-worker-statefulset.yaml
@@ -142,7 +142,6 @@ spec:
             - >-
               cp {{ template "pulsar.home" . }}/trino/conf/node.properties.template {{ template "pulsar.home" . }}/trino/conf/node.properties;
               echo "node.id=${HOSTNAME}" >> {{ template "pulsar.home" . }}/trino/conf/node.properties ;
-              echo "node.internal-address=${HOSTNAME}.{{ template "presto.worker.service" . }}.{{ template "pulsar.namespace" . }}.svc.cluster.local" >> {{ template "pulsar.home" . }}/trino/conf/node.properties ;
               bin/pulsar sql-worker run \
                 --etc-dir={{ template "pulsar.home" . }}/trino/conf \
                 --data-dir={{ template "pulsar.home" . }}/data;

--- a/charts/pulsar/templates/presto/presto-worker-statefulset.yaml
+++ b/charts/pulsar/templates/presto/presto-worker-statefulset.yaml
@@ -140,12 +140,11 @@ spec:
             {{- end }}
             {{- else }}
             - >-
-              cp {{ template "pulsar.home" . }}/conf/presto/node.properties.template {{ template "pulsar.home" . }}/conf/presto/node.properties;
-              echo "node.id=${HOSTNAME}" >> {{ template "pulsar.home" . }}/conf/presto/node.properties ;
-              echo "node.internal-address=${HOSTNAME}.{{ template "presto.worker.service" . }}.{{ template "pulsar.namespace" . }}.svc.cluster.local" >> {{ template "pulsar.home" . }}/conf/presto/node.properties ;
-              ln -s {{ template "pulsar.home" . }}/conf/presto {{ template "pulsar.home" . }}/lib/presto/etc;
+              cp {{ template "pulsar.home" . }}/trino/conf/node.properties.template {{ template "pulsar.home" . }}/trino/conf/node.properties;
+              echo "node.id=${HOSTNAME}" >> {{ template "pulsar.home" . }}/trino/conf/node.properties ;
+              echo "node.internal-address=${HOSTNAME}.{{ template "presto.worker.service" . }}.{{ template "pulsar.namespace" . }}.svc.cluster.local" >> {{ template "pulsar.home" . }}/trino/conf/node.properties ;
               bin/pulsar sql-worker run \
-                --etc-dir={{ template "pulsar.home" . }}/conf/presto \
+                --etc-dir={{ template "pulsar.home" . }}/trino/conf \
                 --data-dir={{ template "pulsar.home" . }}/data;
             {{- end }}
           env:
@@ -166,19 +165,19 @@ spec:
                 key: AWS_SECRET_ACCESS_KEY
           {{- end }}
           volumeMounts:
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/node.properties.template
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/node.properties.template
               name: config-volume
               subPath: node.properties
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/log.properties
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/log.properties
               name: config-volume
               subPath: log.properties
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/jvm.config
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/jvm.config
               name: config-volume
               subPath: jvm.config
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/config.properties
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/config.properties
               name: config-volume
               subPath: config.properties
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/catalog/pulsar.properties
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/catalog/pulsar.properties
               name: config-volume
               subPath: pulsar.properties
             - mountPath: /presto/health_check.sh

--- a/charts/sn-platform/templates/presto/presto-coordinator-configmap.yaml
+++ b/charts/sn-platform/templates/presto/presto-coordinator-configmap.yaml
@@ -115,7 +115,7 @@ data:
 {{- if .Values.presto.security.authentication.jwt.enabled }}
     # JWT Authentication
     http-server.authentication.type=JWT
-    http-server.authentication.jwt.key-file={{ template "pulsar.home" . }}/conf/presto/{{ .Values.presto.security.authentication.jwt.publicKeyFileName }}
+    http-server.authentication.jwt.key-file={{ template "pulsar.home" . }}/trino/conf/{{ .Values.presto.security.authentication.jwt.publicKeyFileName }}
 {{- end }}
     {{- if .Values.presto.coordinator.config.custom }}
     {{- range $k, $v := .Values.presto.coordinator.config.custom }}
@@ -279,13 +279,13 @@ data:
   access-control.properties: |
     # access-control.properties
     access-control.name=file
-    security.config-file={{ template "pulsar.home" . }}/conf/presto/rules.json
+    security.config-file={{ template "pulsar.home" . }}/trino/conf/rules.json
     security.refresh-period=60s
 {{- end}}
 {{- if .Values.presto.security.authentication.password.enabled }}
   password-authenticator.properties: |
     password-authenticator.name=file
-    file.password-file={{ template "pulsar.home" . }}/presto/{{ .Values.presto.security.authentication.password.passwordFileName }}
+    file.password-file={{ template "pulsar.home" . }}/trino/{{ .Values.presto.security.authentication.password.passwordFileName }}
     file.refresh-period=60s
 {{- end}}
 {{- end }}

--- a/charts/sn-platform/templates/presto/presto-coordinator-deployment.yaml
+++ b/charts/sn-platform/templates/presto/presto-coordinator-deployment.yaml
@@ -120,7 +120,6 @@ spec:
             - >-
               cp {{ template "pulsar.home" . }}/trino/conf/node.properties.template {{ template "pulsar.home" . }}/trino/conf/node.properties;
               echo "node.id=${HOSTNAME}" >> {{ template "pulsar.home" . }}/trino/conf/node.properties ;
-              echo "node.internal-address=$(echo ${POD_IP} | tr "." "-").{{ template "presto.service" . }}.{{ template "pulsar.namespace" . }}.svc.cluster.local" >> {{ template "pulsar.home" . }}/trino/conf/node.properties ;
               {{- if .Values.tls.presto.enabled }}
               set -ex;
               mkdir -p /pulsar/jks;

--- a/charts/sn-platform/templates/presto/presto-coordinator-deployment.yaml
+++ b/charts/sn-platform/templates/presto/presto-coordinator-deployment.yaml
@@ -118,10 +118,9 @@ spec:
           command: ["sh", "-c"]
           args:
             - >-
-              cp {{ template "pulsar.home" . }}/conf/presto/node.properties.template {{ template "pulsar.home" . }}/conf/presto/node.properties;
-              echo "node.id=${HOSTNAME}" >> {{ template "pulsar.home" . }}/conf/presto/node.properties ;
-              echo "node.internal-address=$(echo ${POD_IP} | tr "." "-").{{ template "presto.service" . }}.{{ template "pulsar.namespace" . }}.svc.cluster.local" >> {{ template "pulsar.home" . }}/conf/presto/node.properties ;
-              ln -s {{ template "pulsar.home" . }}/conf/presto {{ template "pulsar.home" . }}/lib/presto/etc;
+              cp {{ template "pulsar.home" . }}/trino/conf/node.properties.template {{ template "pulsar.home" . }}/trino/conf/node.properties;
+              echo "node.id=${HOSTNAME}" >> {{ template "pulsar.home" . }}/trino/conf/node.properties ;
+              echo "node.internal-address=$(echo ${POD_IP} | tr "." "-").{{ template "presto.service" . }}.{{ template "pulsar.namespace" . }}.svc.cluster.local" >> {{ template "pulsar.home" . }}/trino/conf/node.properties ;
               {{- if .Values.tls.presto.enabled }}
               set -ex;
               mkdir -p /pulsar/jks;
@@ -132,7 +131,7 @@ spec:
               {{- end }}
               {{- end }}
               bin/pulsar sql-worker run \
-                --etc-dir={{ template "pulsar.home" . }}/conf/presto \
+                --etc-dir={{ template "pulsar.home" . }}/trino/conf \
                 --data-dir={{ template "pulsar.home" . }}/data;
           env:
           - name: POD_IP
@@ -152,38 +151,38 @@ spec:
                 key: AWS_SECRET_ACCESS_KEY
           {{- end }}
           volumeMounts:
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/node.properties.template
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/node.properties.template
               name: config-volume
               subPath: node.properties
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/log.properties
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/log.properties
               name: config-volume
               subPath: log.properties
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/jvm.config
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/jvm.config
               name: config-volume
               subPath: jvm.config
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/config.properties
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/config.properties
               name: config-volume
               subPath: config.properties
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/catalog/pulsar.properties
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/catalog/pulsar.properties
               name: config-volume
               subPath: pulsar.properties
             {{- if or .Values.presto.security.authentication.jwt.enabled .Values.presto.security.authentication.password.enabled }}
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/rules.json
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/rules.json
               name: config-volume
               subPath: rules.json
             {{- end}}
             {{- if .Values.presto.security.authentication.password.enabled }}
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/password-authenticator.properties
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/password-authenticator.properties
               name: config-volume
               subPath: password-authenticator.properties
-            - mountPath: {{ template "pulsar.home" . }}/presto
+            - mountPath: {{ template "pulsar.home" . }}/trino
               name: password-file-volume
             {{- end}}
             {{- if .Values.presto.security.authentication.jwt.enabled }}
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/access-control.properties
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/access-control.properties
               name: config-volume
               subPath: access-control.properties
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/{{ .Values.presto.security.authentication.jwt.publicKeyFileName }}
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/{{ .Values.presto.security.authentication.jwt.publicKeyFileName }}
               name: public-key-volume
               subPath: {{ .Values.presto.security.authentication.jwt.publicKeyConfigMapKey  }}
             {{- end}}

--- a/charts/sn-platform/templates/presto/presto-coordinator-deployment.yaml
+++ b/charts/sn-platform/templates/presto/presto-coordinator-deployment.yaml
@@ -150,6 +150,8 @@ spec:
                 name: {{ .Values.broker.offload.s3.secret }}
                 key: AWS_SECRET_ACCESS_KEY
           {{- end }}
+          securityContext:
+            runAsUser: 0
           volumeMounts:
             - mountPath: {{ template "pulsar.home" . }}/trino/conf/node.properties.template
               name: config-volume

--- a/charts/sn-platform/templates/presto/presto-worker-configmap.yaml
+++ b/charts/sn-platform/templates/presto/presto-worker-configmap.yaml
@@ -258,9 +258,9 @@ data:
   health_check.sh: |
     #!/bin/bash
     {{- if .Values.tls.presto.enabled }}
-    curl --silent https://{{ template "presto.service" . }}:{{ .Values.presto.coordinator.ports.https }}/v1/node -k | tr "," "\n" | grep --silent $(echo ${POD_IP} | tr "." "-")
+    curl --header "X-Trino-User: test-user" --silent https://{{ template "presto.service" . }}:{{ .Values.presto.coordinator.ports.https }}/v1/node -k | tr "," "\n" | grep --silent $(echo ${POD_IP} | tr "." "-")
     {{- else }}
-    curl --silent http://{{ template "presto.service" . }}:{{ .Values.presto.coordinator.ports.http }}/v1/node | tr "," "\n" | grep --silent $(echo ${POD_IP} | tr "." "-")
+    curl --header "X-Trino-User: test-user" --silent http://{{ template "presto.service" . }}:{{ .Values.presto.coordinator.ports.http }}/v1/node | tr "," "\n" | grep --silent $(echo ${POD_IP} | tr "." "-")
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sn-platform/templates/presto/presto-worker-configmap.yaml
+++ b/charts/sn-platform/templates/presto/presto-worker-configmap.yaml
@@ -258,9 +258,9 @@ data:
   health_check.sh: |
     #!/bin/bash
     {{- if .Values.tls.presto.enabled }}
-    curl --header "X-Trino-User: test-user" --silent https://{{ template "presto.service" . }}:{{ .Values.presto.coordinator.ports.https }}/v1/node -k | tr "," "\n" | grep --silent $(echo ${POD_IP} | tr "." "-")
+    curl --header "X-Trino-User: test-user" --silent https://{{ template "presto.service" . }}:{{ .Values.presto.coordinator.ports.https }}/v1/node -k | tr "," "\n" | grep ${POD_IP}
     {{- else }}
-    curl --header "X-Trino-User: test-user" --silent http://{{ template "presto.service" . }}:{{ .Values.presto.coordinator.ports.http }}/v1/node | tr "," "\n" | grep --silent $(echo ${POD_IP} | tr "." "-")
+    curl --header "X-Trino-User: test-user" --silent http://{{ template "presto.service" . }}:{{ .Values.presto.coordinator.ports.http }}/v1/node | tr "," "\n" | grep ${POD_IP}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/sn-platform/templates/presto/presto-worker-deployment.yaml
+++ b/charts/sn-platform/templates/presto/presto-worker-deployment.yaml
@@ -111,7 +111,6 @@ spec:
             - >-
               cp {{ template "pulsar.home" . }}/trino/conf/node.properties.template {{ template "pulsar.home" . }}/trino/conf/node.properties;
               echo "node.id=${HOSTNAME}" >> {{ template "pulsar.home" . }}/trino/conf/node.properties ;
-              echo "node.internal-address=$(echo ${POD_IP} | tr "." "-").{{ template "presto.worker.service" . }}.{{ template "pulsar.namespace" . }}.svc.cluster.local" >> {{ template "pulsar.home" . }}/trino/conf/node.properties ;
               {{- if .Values.tls.presto.enabled }}
               set -ex;
               mkdir -p /pulsar/jks;

--- a/charts/sn-platform/templates/presto/presto-worker-deployment.yaml
+++ b/charts/sn-platform/templates/presto/presto-worker-deployment.yaml
@@ -141,6 +141,8 @@ spec:
                 name: {{ .Values.broker.offload.s3.secret }}
                 key: AWS_SECRET_ACCESS_KEY
           {{- end }}
+          securityContext:
+            runAsUser: 0
           volumeMounts:
             - mountPath: {{ template "pulsar.home" . }}/trino/conf/node.properties.template
               name: config-volume

--- a/charts/sn-platform/templates/presto/presto-worker-deployment.yaml
+++ b/charts/sn-platform/templates/presto/presto-worker-deployment.yaml
@@ -109,21 +109,20 @@ spec:
           command: ["sh", "-c"]
           args:
             - >-
-              cp {{ template "pulsar.home" . }}/conf/presto/node.properties.template {{ template "pulsar.home" . }}/conf/presto/node.properties;
-              echo "node.id=${HOSTNAME}" >> {{ template "pulsar.home" . }}/conf/presto/node.properties ;
-              echo "node.internal-address=$(echo ${POD_IP} | tr "." "-").{{ template "presto.worker.service" . }}.{{ template "pulsar.namespace" . }}.svc.cluster.local" >> {{ template "pulsar.home" . }}/conf/presto/node.properties ;
-              ln -s {{ template "pulsar.home" . }}/conf/presto {{ template "pulsar.home" . }}/lib/presto/etc;
+              cp {{ template "pulsar.home" . }}/trino/conf/node.properties.template {{ template "pulsar.home" . }}/trino/conf/node.properties;
+              echo "node.id=${HOSTNAME}" >> {{ template "pulsar.home" . }}/trino/conf/node.properties ;
+              echo "node.internal-address=$(echo ${POD_IP} | tr "." "-").{{ template "presto.worker.service" . }}.{{ template "pulsar.namespace" . }}.svc.cluster.local" >> {{ template "pulsar.home" . }}/trino/conf/node.properties ;
               {{- if .Values.tls.presto.enabled }}
               set -ex;
               mkdir -p /pulsar/jks;
               openssl pkcs12 -export -in /pulsar/certs/presto/tls.crt -inkey /pulsar/certs/presto/tls.key -out /pulsar/jks/server-cert.p12 -name presto-coordinator -passout "pass:{{ template "pulsar.presto.jks.password" . }}";
               keytool -importkeystore -srckeystore /pulsar/jks/server-cert.p12 -srcstoretype PKCS12 -srcstorepass {{ template "pulsar.presto.jks.password" . }} -alias presto-coordinator -destkeystore /pulsar/jks/presto.keystore.jks -deststorepass {{ template "pulsar.presto.jks.password" . }};
               {{- if .Values.tls.presto.trustCertsEnabled }}
-              echo "y" | keytool -import -alias selfsigned -file /pulsar/certs/presto/ca.crt -keystore /pulsar/jks/trust.jks -trustcacerts -storepass {{ template "pulsar.presto.jks.password" . }}; 
+              echo "y" | keytool -import -alias selfsigned -file /pulsar/certs/presto/ca.crt -keystore /pulsar/jks/trust.jks -trustcacerts -storepass {{ template "pulsar.presto.jks.password" . }};
               {{- end }}
               {{- end }}
               bin/pulsar sql-worker run \
-                --etc-dir={{ template "pulsar.home" . }}/conf/presto \
+                --etc-dir={{ template "pulsar.home" . }}/trino/conf \
                 --data-dir={{ template "pulsar.home" . }}/data;
           env:
           - name: POD_IP
@@ -143,19 +142,19 @@ spec:
                 key: AWS_SECRET_ACCESS_KEY
           {{- end }}
           volumeMounts:
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/node.properties.template
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/node.properties.template
               name: config-volume
               subPath: node.properties
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/log.properties
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/log.properties
               name: config-volume
               subPath: log.properties
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/jvm.config
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/jvm.config
               name: config-volume
               subPath: jvm.config
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/config.properties
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/config.properties
               name: config-volume
               subPath: config.properties
-            - mountPath: {{ template "pulsar.home" . }}/conf/presto/catalog/pulsar.properties
+            - mountPath: {{ template "pulsar.home" . }}/trino/conf/catalog/pulsar.properties
               name: config-volume
               subPath: pulsar.properties
             - mountPath: /presto/health_check.sh


### PR DESCRIPTION
### Motivation

In the pulsar image, presto is named trino. We need to adapt the related charts conf.

### Modifications

- Correct all the `trino` conf path.
- Use root user to run the pod in order to add configuration to `node.properties `
- Remove `node.internal-address` 
- Health check: add header when request trino API and replace internal addr with pod ip

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

Test SQL query pass

![image](https://github.com/streamnative/charts/assets/10069311/65d642e5-ffd8-4c4a-97ac-37053b49af4d)
