### PR TITLE
fix: duplicate brokerClientAuthenticationPlugin definition when oauth and jwt are enabled simultaneously

### DIFF
--- a/charts/sn-platform-slim/templates/_helpers.tpl
+++ b/charts/sn-platform-slim/templates/_helpers.tpl
@@ -217,9 +217,10 @@ brokerClientAuthenticationParameters: '{{ .Values.auth.oauth.brokerClientAuthent
 {{- if .Values.auth.oauth.oauthSubjectClaim }}
 PULSAR_PREFIX_oauthSubjectClaim: "{{ .Values.auth.oauth.oauthSubjectClaim }}"
 {{- end }}
-{{- end }}
+{{- else }}
 {{- if .Values.auth.authentication.jwt.enabled }}
 brokerClientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/sn-platform/templates/_helpers.tpl
+++ b/charts/sn-platform/templates/_helpers.tpl
@@ -229,9 +229,10 @@ brokerClientAuthenticationParameters: '{{ .Values.auth.oauth.brokerClientAuthent
 {{- if .Values.auth.oauth.oauthSubjectClaim }}
 PULSAR_PREFIX_oauthSubjectClaim: "{{ .Values.auth.oauth.oauthSubjectClaim }}"
 {{- end }}
-{{- end }}
+{{- else }}
 {{- if .Values.auth.authentication.jwt.enabled }}
 brokerClientAuthenticationPlugin: "org.apache.pulsar.client.impl.auth.AuthenticationToken"
+{{- end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
### Motivation

There will be a duplicate brokerClientAuthenticationPlugin definition when oauth and jwt are enabled simultaneously.

### Modifications

Rearrange the conditions so that in `pulsar.authConfiguration` template, the jwt handling is in the else branch of the oauth enabled condition.


### Verifying this change

- [ ] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

