### PR TITLE
Fix CI after removal of pulsar-operator

### DIFF
--- a/ct.yaml
+++ b/ct.yaml
@@ -5,7 +5,6 @@
 chart-dirs:
   - charts
 charts:
-  - charts/pulsar-operator
   - charts/sn-platform
   - charts/sn-platform-slim
 debug: true


### PR DESCRIPTION

### Motivation

CI fails:
```
Error: Error linting charts: Could not read 'Chart.yaml': open charts/pulsar-operator/Chart.yaml: no such file or directory
```

### Modifications

- remove charts/pulsar-operator from ct.yaml

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

