### PR TITLE
Remove unused log conf

### DIFF
--- a/charts/sn-platform-slim/templates/bookkeeper/bookkeeper-cluster.yaml
+++ b/charts/sn-platform-slim/templates/bookkeeper/bookkeeper-cluster.yaml
@@ -180,7 +180,6 @@ spec:
       PULSAR_PREFIX_ledgerDirectories: "/pulsar/data/bookkeeper/ledgers"
       {{- end }}
 {{- include "pulsar.bookkeeper.config.tls" . | nindent 6 }}
-{{ (.Files.Glob "conf/bookie/log4j2.yaml").AsConfig | indent 6 }}
   autoRecovery:
     {{- if .Values.components.autorecovery }}
     replicas: {{ .Values.autorecovery.replicaCount }}

--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
@@ -180,7 +180,6 @@ spec:
       PULSAR_PREFIX_ledgerDirectories: "/pulsar/data/bookkeeper/ledgers"
       {{- end }}
 {{- include "pulsar.bookkeeper.config.tls" . | nindent 6 }}
-{{ (.Files.Glob "conf/bookie/log4j2.yaml").AsConfig | indent 6 }}
   autoRecovery:
     {{- if .Values.components.autorecovery }}
     replicas: {{ .Values.autorecovery.replicaCount }}


### PR DESCRIPTION
I think this is a legacy issue to use hard code log4j2 config.

Now we are using `logConfig` in CR.

Fixes https://github.com/streamnative/eng-support-tickets/issues/1881