### PR TITLE
Make build-in prom compatible with mergeMetrics feature

### DIFF
--- a/charts/sn-platform-slim/templates/_helpers.tpl
+++ b/charts/sn-platform-slim/templates/_helpers.tpl
@@ -78,6 +78,15 @@ sidecar.istio.io/inject: "true"
 {{- end }}
 
 {{/*
+Create the monitoring template labels.
+*/}}
+{{- define "pulsar.monitoring.template.labels" -}}
+app: {{ template "pulsar.name" . }}
+release: {{ .Release.Name }}
+cluster: {{ template "pulsar.fullname" . }}
+{{- end }}
+
+{{/*
 Create the match labels.
 */}}
 {{- define "pulsar.matchLabels" -}}

--- a/charts/sn-platform-slim/templates/grafana/grafana-deployment.yaml
+++ b/charts/sn-platform-slim/templates/grafana/grafana-deployment.yaml
@@ -24,7 +24,11 @@ spec:
   template:
     metadata:
       labels:
+        {{- if and .Values.istio.enabled .Values.istio.mergeMetrics }}
+        {{- include "pulsar.monitoring.template.labels" . | nindent 8 }}
+        {{- else }}
         {{- include "pulsar.template.labels" . | nindent 8 }}
+        {{- end }}
         component: {{ .Values.grafana.component }}
 {{- with .Values.grafana.labels }}
 {{ toYaml . | indent 8 }}

--- a/charts/sn-platform-slim/templates/grafana/grafana-statefulset.yaml
+++ b/charts/sn-platform-slim/templates/grafana/grafana-statefulset.yaml
@@ -25,7 +25,11 @@ spec:
   template:
     metadata:
       labels:
+        {{- if and .Values.istio.enabled .Values.istio.mergeMetrics }}
+        {{- include "pulsar.monitoring.template.labels" . | nindent 8 }}
+        {{- else }}
         {{- include "pulsar.template.labels" . | nindent 8 }}
+        {{- end }}
         component: {{ .Values.grafana.component }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/grafana/grafana-configmap.yaml") . | sha256sum }}

--- a/charts/sn-platform-slim/templates/prometheus/prometheus-configmap.yaml
+++ b/charts/sn-platform-slim/templates/prometheus/prometheus-configmap.yaml
@@ -53,7 +53,7 @@ data:
             - {{ template "pulsar.namespace" . }}
 {{- end }}
 {{- if .Values.istio.enabled }}
-{{- if .Values.istio.migration }} 
+{{- if or .Values.istio.migration .Values.istio.mergeMetrics }}
       scheme: http
       enable_http2: false
 {{- else }}

--- a/charts/sn-platform-slim/templates/prometheus/prometheus-configmap.yaml
+++ b/charts/sn-platform-slim/templates/prometheus/prometheus-configmap.yaml
@@ -52,8 +52,8 @@ data:
           names:
             - {{ template "pulsar.namespace" . }}
 {{- end }}
-{{- if .Values.istio.enabled }}
-{{- if or .Values.istio.migration .Values.istio.mergeMetrics }}
+{{- if and .Values.istio.enabled (not .Values.istio.mergeMetrics) }}
+{{- if .Values.istio.migration }}
       scheme: http
       enable_http2: false
 {{- else }}

--- a/charts/sn-platform-slim/templates/prometheus/prometheus-statefulset.yaml
+++ b/charts/sn-platform-slim/templates/prometheus/prometheus-statefulset.yaml
@@ -27,13 +27,17 @@ spec:
   template:
     metadata:
       labels:
+        {{- if and .Values.istio.enabled .Values.istio.mergeMetrics }}
+        {{- include "pulsar.monitoring.template.labels" . | nindent 8 }}
+        {{- else }}
         {{- include "pulsar.template.labels" . | nindent 8 }}
+        {{- end }}
         component: {{ .Values.prometheus.component }}
 {{- with .Values.prometheus.labels }}
 {{ toYaml . | indent 8 }}
 {{- end }}
       annotations:
-        {{- if .Values.istio.enabled }}
+        {{- if and .Values.istio.enabled (not .Values.istio.mergeMetrics ) }}
         # ref: https://istio.io/latest/docs/ops/integrations/prometheus/#tls-settings
         traffic.sidecar.istio.io/includeOutboundIPRanges: ""  # do not intercept any outbound traffic
         # configure an env variable `OUTPUT_CERTS` to write certificates to the given folder
@@ -154,7 +158,7 @@ spec:
           mountPath: /etc/config
         - name: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}-{{ .Values.prometheus.volumes.data.name }}"
           mountPath: /prometheus
-        {{- if .Values.istio.enabled }}
+        {{- if and .Values.istio.enabled (not .Values.istio.mergeMetrics ) }}
         - name: istio-certs
           mountPath: /etc/prom-certs/
         {{- end }}
@@ -163,7 +167,7 @@ spec:
       - name: config-volume
         configMap:
           name: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}"
-      {{- if .Values.istio.enabled }}
+      {{- if and .Values.istio.enabled (not .Values.istio.mergeMetrics )}}
       - emptyDir:
           medium: Memory
         name: istio-certs

--- a/charts/sn-platform-slim/values.yaml
+++ b/charts/sn-platform-slim/values.yaml
@@ -2144,7 +2144,7 @@ istio:
   migration: false
   # istio labels used to inject sidecars if it's not `sidecar.istio.io/inject: "true"`
   labels: {}
-  # If you're using the prometheus in this chart, please keep mergeMetrics disabled.
+  # mergeMetrics should be enabled if you want to scrape pulsar metrics from an external prometheus not running on Istio
   mergeMetrics: false
   gateway:
     # gateway selector if it's not `istio: ingressgateway`

--- a/charts/sn-platform-slim/values.yaml
+++ b/charts/sn-platform-slim/values.yaml
@@ -794,7 +794,7 @@ bookkeeper:
     enabled: false
     minReplicas: 1
     maxReplicas: 4
-    metrics: {}
+    metrics: []
   # The field logConfig can be used to change the log level and log format of pods.
   # The logConfig field is optional. If it is not specified, the component will use the default log configuration /pulsar/conf/log4j2.yaml.
   # f it is specified will dynamically change the log level and log format of the component by changing the CR.
@@ -1038,7 +1038,7 @@ broker:
     enabled: false
     minReplicas: 1
     maxReplicas: 4
-    metrics: {}
+    metrics: []
   # The field logConfig can be used to change the log level and log format of pods.
   # The logConfig field is optional. If it is not specified, the component will use the default log configuration /pulsar/conf/log4j2.yaml.
   # If it is specified will dynamically change the log level and log format of the component by changing the CR.
@@ -2145,6 +2145,7 @@ istio:
   # istio labels used to inject sidecars if it's not `sidecar.istio.io/inject: "true"`
   labels: {}
   # mergeMetrics should be enabled if you want to scrape pulsar metrics from an external prometheus not running on Istio
+  # prometheus and grafana will not be Istio injected if mergeMetrics is enabled
   mergeMetrics: false
   gateway:
     # gateway selector if it's not `istio: ingressgateway`

--- a/charts/sn-platform/templates/_helpers.tpl
+++ b/charts/sn-platform/templates/_helpers.tpl
@@ -78,6 +78,15 @@ sidecar.istio.io/inject: "true"
 {{- end }}
 
 {{/*
+Create the monitoring template labels.
+*/}}
+{{- define "pulsar.monitoring.template.labels" -}}
+app: {{ template "pulsar.name" . }}
+release: {{ .Release.Name }}
+cluster: {{ template "pulsar.fullname" . }}
+{{- end }}
+
+{{/*
 Create the match labels.
 */}}
 {{- define "pulsar.matchLabels" -}}

--- a/charts/sn-platform/templates/grafana/grafana-deployment.yaml
+++ b/charts/sn-platform/templates/grafana/grafana-deployment.yaml
@@ -24,7 +24,11 @@ spec:
   template:
     metadata:
       labels:
+        {{- if and .Values.istio.enabled .Values.istio.mergeMetrics }}
+        {{- include "pulsar.monitoring.template.labels" . | nindent 8 }}
+        {{- else }}
         {{- include "pulsar.template.labels" . | nindent 8 }}
+        {{- end }}
         component: {{ .Values.grafana.component }}
 {{- with .Values.grafana.labels }}
 {{ toYaml . | indent 8 }}

--- a/charts/sn-platform/templates/grafana/grafana-statefulset.yaml
+++ b/charts/sn-platform/templates/grafana/grafana-statefulset.yaml
@@ -25,7 +25,11 @@ spec:
   template:
     metadata:
       labels:
+        {{- if and .Values.istio.enabled .Values.istio.mergeMetrics }}
+        {{- include "pulsar.monitoring.template.labels" . | nindent 8 }}
+        {{- else }}
         {{- include "pulsar.template.labels" . | nindent 8 }}
+        {{- end }}
         component: {{ .Values.grafana.component }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/grafana/grafana-configmap.yaml") . | sha256sum }}

--- a/charts/sn-platform/templates/prometheus/prometheus-configmap.yaml
+++ b/charts/sn-platform/templates/prometheus/prometheus-configmap.yaml
@@ -53,7 +53,7 @@ data:
             - {{ template "pulsar.namespace" . }}
 {{- end }}
 {{- if .Values.istio.enabled }}
-{{- if .Values.istio.migration }} 
+{{- if or .Values.istio.migration .Values.istio.mergeMetrics }}
       scheme: http
       enable_http2: false
 {{- else }}

--- a/charts/sn-platform/templates/prometheus/prometheus-configmap.yaml
+++ b/charts/sn-platform/templates/prometheus/prometheus-configmap.yaml
@@ -52,8 +52,8 @@ data:
           names:
             - {{ template "pulsar.namespace" . }}
 {{- end }}
-{{- if .Values.istio.enabled }}
-{{- if or .Values.istio.migration .Values.istio.mergeMetrics }}
+{{- if and .Values.istio.enabled (not .Values.istio.mergeMetrics) }}
+{{- if .Values.istio.migration }}
       scheme: http
       enable_http2: false
 {{- else }}

--- a/charts/sn-platform/templates/prometheus/prometheus-statefulset.yaml
+++ b/charts/sn-platform/templates/prometheus/prometheus-statefulset.yaml
@@ -27,13 +27,17 @@ spec:
   template:
     metadata:
       labels:
+        {{- if and .Values.istio.enabled .Values.istio.mergeMetrics }}
+        {{- include "pulsar.monitoring.template.labels" . | nindent 8 }}
+        {{- else }}
         {{- include "pulsar.template.labels" . | nindent 8 }}
+        {{- end }}
         component: {{ .Values.prometheus.component }}
 {{- with .Values.prometheus.labels }}
 {{ toYaml . | indent 8 }}
 {{- end }}
       annotations:
-        {{- if .Values.istio.enabled }}
+        {{- if and .Values.istio.enabled (not .Values.istio.mergeMetrics ) }}
         # ref: https://istio.io/latest/docs/ops/integrations/prometheus/#tls-settings
         traffic.sidecar.istio.io/includeOutboundIPRanges: ""  # do not intercept any outbound traffic
         # configure an env variable `OUTPUT_CERTS` to write certificates to the given folder
@@ -154,7 +158,7 @@ spec:
           mountPath: /etc/config
         - name: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}-{{ .Values.prometheus.volumes.data.name }}"
           mountPath: /prometheus
-        {{- if .Values.istio.enabled }}
+        {{- if and .Values.istio.enabled (not .Values.istio.mergeMetrics ) }}
         - name: istio-certs
           mountPath: /etc/prom-certs/
         {{- end }}
@@ -163,7 +167,7 @@ spec:
       - name: config-volume
         configMap:
           name: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}"
-      {{- if .Values.istio.enabled }}
+      {{- if and .Values.istio.enabled (not .Values.istio.mergeMetrics ) }}
       - emptyDir:
           medium: Memory
         name: istio-certs

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -2509,7 +2509,7 @@ istio:
   migration: false
   # istio labels used to inject sidecars if it's not `sidecar.istio.io/inject: "true"`
   labels: {}
-  # If you're using the prometheus in this chart, please keep mergeMetrics disabled.
+  # mergeMetrics should be enabled if you want to scrape pulsar metrics from an external prometheus not running on Istio
   mergeMetrics: false
   gateway:
     # gateway selector if it's not `istio: ingressgateway`

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -2510,6 +2510,7 @@ istio:
   # istio labels used to inject sidecars if it's not `sidecar.istio.io/inject: "true"`
   labels: {}
   # mergeMetrics should be enabled if you want to scrape pulsar metrics from an external prometheus not running on Istio
+  # prometheus and grafana will not be Istio injected if mergeMetrics is enabled
   mergeMetrics: false
   gateway:
     # gateway selector if it's not `istio: ingressgateway`


### PR DESCRIPTION
### Motivation

Allow external non-Istio prometheus and build-in prometheus to scrape Pulsar metrics simultaneously

### Modifications

- Disable Istio Injection on Prom and Grafana when mergeMetrics enabled
- Scrape Metrics with http when mergeMetrics enabled

### Verifying this change

- [x] Make sure that the change passes the CI checks.


This change is a trivial rework / code cleanup without any test coverage.

### Documentation

Check the box below.

Need to update docs? 

- [ ] `doc-required` 
  
  (If you need help on updating docs, create a doc issue)
  
- [x] `no-need-doc` 
  
  (Please explain why)
  
- [ ] `doc` 
  
  (If this PR contains doc changes)

