### PR TITLE
Add min ready seconds for bookkeeper

### DIFF
--- a/charts/sn-platform-slim/templates/bookkeeper/bookkeeper-cluster.yaml
+++ b/charts/sn-platform-slim/templates/bookkeeper/bookkeeper-cluster.yaml
@@ -58,6 +58,9 @@ spec:
     topologySpreadConstraints:
     {{- toYaml . | nindent 4 }}
     {{- end }}
+    {{- if .Values.bookkeeper.minReadySeconds }}
+    minReadySeconds: {{ .Values.bookkeeper.minReadySeconds }}
+    {{- end }}
     {{- if .Values.bookkeeper.serviceAccount.use }}
     serviceAccountName: {{ template "pulsar.bookkeeper.serviceAccount" . }}
     {{- end }}

--- a/charts/sn-platform-slim/values.yaml
+++ b/charts/sn-platform-slim/values.yaml
@@ -849,6 +849,10 @@ bookkeeper:
     runAsNonRoot: true
   tolerations: []
   gracePeriod: 30
+  # The minimum number of seconds for new pods to be ready.
+  # This can add a delay in the startup/restart of the bookkeeper cluster.
+  # default is 0
+  minReadySeconds: 0
   resources:
     requests:
       memory: "512Mi"

--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
@@ -58,6 +58,9 @@ spec:
     topologySpreadConstraints:
     {{- toYaml . | nindent 4 }}
     {{- end }}
+    {{- if .Values.bookkeeper.minReadySeconds }}
+    minReadySeconds: {{ .Values.bookkeeper.minReadySeconds }}
+    {{- end }}
     {{- if .Values.bookkeeper.serviceAccount.use }}
     serviceAccountName: {{ template "pulsar.bookkeeper.serviceAccount" . }}
     {{- end }}

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -924,6 +924,10 @@ bookkeeper:
     runAsNonRoot: true
   tolerations: []
   gracePeriod: 30
+  # The minimum number of seconds for new pods to be ready.
+  # This can add a delay in the startup/restart of the bookkeeper cluster.
+  # default is 0
+  minReadySeconds: 0
   resources:
     requests:
       memory: "512Mi"


### PR DESCRIPTION
```
$ helm template sn-platform-slim | grep -A 10 -B 3 minReadySeconds

    level: INFO
    format: text
  pod:
    minReadySeconds: 1
    serviceAccountName: release-name-sn-platform-slim-bookie-acct
    labels:
      app: sn-platform-slim
      release: release-name
      cluster: release-name-sn-platform-slim
      component: bookie
    annotations:
      prometheus.io/scrape: "true"
      prometheus.io/port: "8000"

$ helm template sn-platform | grep -A 10 -B 3 minReadySeconds
    level: INFO
    format: text
  pod:
    minReadySeconds: 1
    serviceAccountName: release-name-sn-platform-bookie-acct
    labels:
      app: sn-platform
      release: release-name
      cluster: release-name-sn-platform
      component: bookie
    annotations:
      prometheus.io/scrape: "true"
      prometheus.io/port: "8000"
```