### PR TITLE
fix: remove default BookKeeper stats provider

### DIFF
--- a/charts/sn-platform-slim/templates/bookkeeper/_bookkeeper.tpl
+++ b/charts/sn-platform-slim/templates/bookkeeper/_bookkeeper.tpl
@@ -139,8 +139,6 @@ zkLedgersRootPath: "{{ .Values.metadataPrefix }}/ledgers"
 # enable bookkeeper http server
 httpServerEnabled: "true"
 httpServerPort: "{{ .Values.bookkeeper.ports.http }}"
-# config the stats provider
-statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
 # use hostname as the bookie id
 useHostNameAsBookieID: "true"
 {{- end }}

--- a/charts/sn-platform-slim/templates/bookkeeper/bookkeeper-cluster.yaml
+++ b/charts/sn-platform-slim/templates/bookkeeper/bookkeeper-cluster.yaml
@@ -203,8 +203,6 @@ spec:
       # enable bookkeeper http server
       httpServerEnabled: "true"
       httpServerPort: "{{ .Values.bookkeeper.ports.http }}"
-      # config the stats provider
-      statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
       # use hostname as the bookie id
       useHostNameAsBookieID: "true"
       {{- if .Values.components.autorecovery }}

--- a/charts/sn-platform/templates/bookkeeper/_bookkeeper.tpl
+++ b/charts/sn-platform/templates/bookkeeper/_bookkeeper.tpl
@@ -139,8 +139,6 @@ zkLedgersRootPath: "{{ .Values.metadataPrefix }}/ledgers"
 # enable bookkeeper http server
 httpServerEnabled: "true"
 httpServerPort: "{{ .Values.bookkeeper.ports.http }}"
-# config the stats provider
-statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
 # use hostname as the bookie id
 useHostNameAsBookieID: "true"
 {{- end }}

--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
@@ -192,8 +192,6 @@ spec:
       # enable bookkeeper http server
       httpServerEnabled: "true"
       httpServerPort: "{{ .Values.bookkeeper.ports.http }}"
-      # config the stats provider
-      statsProviderClass: org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider
       # use hostname as the bookie id
       useHostNameAsBookieID: "true"
       {{- if .Values.components.autorecovery }}


### PR DESCRIPTION
## Motivation
- Pulsar images that include apache/pulsar#25534 no longer include `org.apache.bookkeeper.stats.prometheus.PrometheusMetricsProvider`.
- The charts currently render that BookKeeper stats provider by default, which can cause BookKeeper pods to fail with `ClassNotFoundException` when using newer Pulsar images.
- The image already carries the appropriate default BookKeeper configuration, so the chart should avoid forcing a provider class.

## Modifications
- Removed the default `statsProviderClass` from the BookKeeper common config template.
- Removed the default `statsProviderClass` from the BookKeeperCluster template in both `sn-platform` and `sn-platform-slim`.

## Testing
- Rendered `sn-platform-slim` with `helm template` and confirmed no `statsProviderClass` or BookKeeper Prometheus provider class is emitted by the rendered BookKeeperCluster.
