### PR TITLE
feat: support oxia metadata store

### DIFF
--- a/charts/sn-platform-slim/templates/_helpers.tpl
+++ b/charts/sn-platform-slim/templates/_helpers.tpl
@@ -190,6 +190,96 @@ Pulsar Cluster Name.
 {{- end }}
 
 {{/*
+Metadata provider selection.
+*/}}
+{{- define "pulsar.metadata.provider" -}}
+{{- default "zookeeper" .Values.pulsar_metadata.provider -}}
+{{- end -}}
+
+{{- define "pulsar.metadata.isZookeeper" -}}
+{{- if eq (include "pulsar.metadata.provider" .) "zookeeper" -}}true{{- end -}}
+{{- end -}}
+
+{{- define "pulsar.metadata.isOxia" -}}
+{{- if eq (include "pulsar.metadata.provider" .) "oxia" -}}true{{- end -}}
+{{- end -}}
+
+{{- define "pulsar.oxia.cluster" -}}
+{{- template "pulsar.fullname" . -}}
+{{- end -}}
+
+{{- define "pulsar.oxia.service" -}}
+{{- template "pulsar.oxia.cluster" . -}}-oxia
+{{- end -}}
+
+{{- define "pulsar.oxia.service.address" -}}
+{{- template "pulsar.oxia.service" . -}}.{{ template "pulsar.namespace" . }}.svc.cluster.local:6648
+{{- end -}}
+
+{{- define "pulsar.oxia.broker.namespace" -}}
+broker
+{{- end -}}
+
+{{- define "pulsar.oxia.bookkeeper.namespace" -}}
+bookkeeper
+{{- end -}}
+
+{{- define "pulsar.oxia.schema.namespace" -}}
+pulsar-schema
+{{- end -}}
+
+{{- define "pulsar.oxia.function.namespace" -}}
+function
+{{- end -}}
+
+{{- define "pulsar.oxia.broker.url" -}}
+oxia://{{ template "pulsar.oxia.service.address" . }}/{{ template "pulsar.oxia.broker.namespace" . }}
+{{- end -}}
+
+{{- define "pulsar.oxia.bookkeeper.url" -}}
+oxia://{{ template "pulsar.oxia.service.address" . }}/{{ template "pulsar.oxia.bookkeeper.namespace" . }}
+{{- end -}}
+
+{{- define "pulsar.oxia.schema.url" -}}
+oxia://{{ template "pulsar.oxia.service.address" . }}/{{ template "pulsar.oxia.schema.namespace" . }}
+{{- end -}}
+
+{{- define "pulsar.oxia.metadata.url" -}}
+{{- template "pulsar.oxia.broker.url" . -}}
+{{- end -}}
+
+{{- define "pulsar.oxia.bookkeeper.metadataServiceUri" -}}
+metadata-store:{{ template "pulsar.oxia.bookkeeper.url" . }}
+{{- end -}}
+
+{{- define "pulsar.oxia.podMonitor.enabled" -}}
+{{- if and .Values.monitoring.prometheus (or (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{- define "pulsar.validate.metadata" -}}
+{{- $provider := include "pulsar.metadata.provider" . -}}
+{{- if and (ne $provider "zookeeper") (ne $provider "oxia") -}}
+{{- fail "pulsar_metadata.provider must be one of: zookeeper, oxia" -}}
+{{- end -}}
+{{- if and (eq $provider "oxia") .Values.metadataPrefix -}}
+{{- fail "metadataPrefix is only supported with pulsar_metadata.provider=zookeeper" -}}
+{{- end -}}
+{{- if and (eq $provider "oxia") .Values.pulsar_metadata.userProvidedZookeepers -}}
+{{- fail "pulsar_metadata.userProvidedZookeepers is only supported with pulsar_metadata.provider=zookeeper" -}}
+{{- end -}}
+{{- if and (eq $provider "oxia") .Values.pulsar_metadata.configurationStoreServers -}}
+{{- fail "pulsar_metadata.configurationStoreServers is only supported with pulsar_metadata.provider=zookeeper" -}}
+{{- end -}}
+{{- if and (eq $provider "oxia") .Values.components.sql_worker -}}
+{{- fail "components.sql_worker is not supported with pulsar_metadata.provider=oxia" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Istio gateway selector
 */}}
 {{- define "pulsar.istio.gateway.selector" -}}
@@ -210,6 +300,15 @@ prometheus.istio.io/merge-metrics: "true"
 {{- else -}}
 prometheus.istio.io/merge-metrics: "false"
 {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Whether Prometheus should use sidecar-issued mTLS certs to scrape workload metrics.
+*/}}
+{{- define "pulsar.istio.prometheus.sidecarMTLS" -}}
+{{- if and .Values.istio.enabled (not .Values.istio.mergeMetrics) (ne (default "" .Values.istio.dataplaneMode) "ambient") -}}
+true
 {{- end -}}
 {{- end -}}
 

--- a/charts/sn-platform-slim/templates/_helpers.tpl
+++ b/charts/sn-platform-slim/templates/_helpers.tpl
@@ -252,6 +252,11 @@ oxia://{{ template "pulsar.oxia.service.address" . }}/{{ template "pulsar.oxia.s
 metadata-store:{{ template "pulsar.oxia.bookkeeper.url" . }}
 {{- end -}}
 
+{{- define "pulsar.oxia.replicaCount" -}}
+{{- $oxia := default dict .Values.oxia -}}
+{{- if hasKey $oxia "replicaCount" -}}{{- $oxia.replicaCount -}}{{- else -}}3{{- end -}}
+{{- end -}}
+
 {{- define "pulsar.oxia.podMonitor.enabled" -}}
 {{- if and .Values.monitoring.prometheus (or (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) -}}
 true
@@ -277,7 +282,7 @@ false
 {{- if and (eq $provider "oxia") .Values.components.sql_worker -}}
 {{- fail "components.sql_worker is not supported with pulsar_metadata.provider=oxia" -}}
 {{- end -}}
-{{- if and (eq $provider "oxia") (lt (int .Values.oxia.replicaCount) 3) -}}
+{{- if and (eq $provider "oxia") (lt (int (include "pulsar.oxia.replicaCount" .)) 3) -}}
 {{- fail "oxia.replicaCount must be at least 3 when pulsar_metadata.provider=oxia" -}}
 {{- end -}}
 {{- end -}}

--- a/charts/sn-platform-slim/templates/_helpers.tpl
+++ b/charts/sn-platform-slim/templates/_helpers.tpl
@@ -277,6 +277,9 @@ false
 {{- if and (eq $provider "oxia") .Values.components.sql_worker -}}
 {{- fail "components.sql_worker is not supported with pulsar_metadata.provider=oxia" -}}
 {{- end -}}
+{{- if and (eq $provider "oxia") (lt (int .Values.oxia.replicaCount) 3) -}}
+{{- fail "oxia.replicaCount must be at least 3 when pulsar_metadata.provider=oxia" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/sn-platform-slim/templates/bookkeeper/_bookkeeper.tpl
+++ b/charts/sn-platform-slim/templates/bookkeeper/_bookkeeper.tpl
@@ -134,8 +134,12 @@ Define bookie tls certs volumes
 Define bookie common config
 */}}
 {{- define "pulsar.bookkeeper.config.common" -}}
+{{- if include "pulsar.metadata.isOxia" . }}
+metadataServiceUri: "{{ template "pulsar.oxia.bookkeeper.metadataServiceUri" . }}"
+{{- else }}
 zkServers: "{{ template "pulsar.zookeeper.connect" . }}"
 zkLedgersRootPath: "{{ .Values.metadataPrefix }}/ledgers"
+{{- end }}
 # enable bookkeeper http server
 httpServerEnabled: "true"
 httpServerPort: "{{ .Values.bookkeeper.ports.http }}"

--- a/charts/sn-platform-slim/templates/bookkeeper/bookkeeper-cluster.yaml
+++ b/charts/sn-platform-slim/templates/bookkeeper/bookkeeper-cluster.yaml
@@ -29,7 +29,11 @@ spec:
 {{- if not .Values.initialize }}
   initialized: true
 {{- end }}
+{{- if include "pulsar.metadata.isOxia" . }}
+  metadataServiceUri: "{{ template "pulsar.oxia.bookkeeper.metadataServiceUri" . }}"
+{{- else }}
   zkServers: "{{ template "pulsar.zookeeper.connect" . }}"
+{{- end }}
   replicas: {{ .Values.bookkeeper.replicaCount }}
   {{- if not (and .Values.components.pulsar_coordinator .Values.images.coordinator) }}
   image: "{{ .Values.images.bookie.repository }}:{{ .Values.images.bookie.tag }}"
@@ -199,7 +203,11 @@ spec:
 {{- with .Values.bookkeeper.configData }}
 {{ toYaml . | indent 6 }}
 {{- end }}
+      {{- if include "pulsar.metadata.isZookeeper" . }}
       zkLedgersRootPath: "{{ .Values.metadataPrefix }}/ledgers"
+      {{- else }}
+      metadataServiceUri: "{{ template "pulsar.oxia.bookkeeper.metadataServiceUri" . }}"
+      {{- end }}
       # enable bookkeeper http server
       httpServerEnabled: "true"
       httpServerPort: "{{ .Values.bookkeeper.ports.http }}"
@@ -351,7 +359,7 @@ spec:
   {{- with .Values.bookkeeper.customization }}
   {{- toYaml . | nindent 2 -}}
   {{- end }}
-  {{- if .Values.zookeeper.customTools.restore.enable}}
+  {{- if and .Values.zookeeper.customTools.restore.enable (include "pulsar.metadata.isZookeeper" .) }}
     - match:
         groupVersionKinds:
           - kind: Job

--- a/charts/sn-platform-slim/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform-slim/templates/broker/broker-cluster.yaml
@@ -30,8 +30,14 @@ spec:
 {{- if not .Values.initialize }}
   initialized: true
 {{- end }}
+{{- if include "pulsar.metadata.isOxia" . }}
+  metadataStoreUrl: "{{ template "pulsar.oxia.metadata.url" . }}"
+  configurationMetadataStoreUrl: "{{ template "pulsar.oxia.metadata.url" . }}"
+  bkMetadataServiceUri: "{{ template "pulsar.oxia.bookkeeper.metadataServiceUri" . }}"
+{{- else }}
   zkServers: "{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
   configurationStoreServers: "{{ template "pulsar.configurationStore.connect" . }}{{ .Values.metadataPrefix }}"
+{{- end }}
 {{- if not .Values.broker.autoScaling.enabled }}
   replicas: {{ .Values.broker.replicaCount }}
 {{- end }}
@@ -226,6 +232,12 @@ spec:
     {{- if .Values.pulsar_metadata.clusterName }}
     clusterName: {{ .Values.pulsar_metadata.clusterName }}
     {{- end }}
+    {{- if include "pulsar.metadata.isOxia" . }}
+    oxiaBasedSystemTopic:
+      enabled: true
+      schemaStorageUrl: "{{ template "pulsar.oxia.schema.url" . }}"
+      topicPoliciesServiceClassName: "io.streamnative.pulsar.OxiaTopicPoliciesService"
+    {{- end }}
     {{- if .Values.broker.functionmesh.enabled }}
     function:
       enabled: true
@@ -324,6 +336,11 @@ spec:
     {{- end }}
     custom:
       PULSAR_PREFIX_additionalServletDirectory: "./brokerAdditionalServlet"
+      {{- if include "pulsar.metadata.isOxia" . }}
+      PULSAR_PREFIX_metadataStoreUrl: "{{ template "pulsar.oxia.metadata.url" . }}"
+      PULSAR_PREFIX_configurationMetadataStoreUrl: "{{ template "pulsar.oxia.metadata.url" . }}"
+      PULSAR_PREFIX_enablePackagesManagement: "false"
+      {{- end }}
 {{- with .Values.broker.configData }}
 {{ toYaml . | indent 6 }}
 {{- end }}

--- a/charts/sn-platform-slim/templates/broker/function-worker-configfile-configmap.yaml
+++ b/charts/sn-platform-slim/templates/broker/function-worker-configfile-configmap.yaml
@@ -65,7 +65,11 @@ data:
     pulsarServiceUrl: {{template "pulsar.function.broker.service.url" . }}
     pulsarWebServiceUrl: {{template "pulsar.function.web.service.url" . }}
     {{- end }}
+    {{- if include "pulsar.metadata.isOxia" . }}
+    configurationMetadataStoreUrl: "{{ template "pulsar.oxia.metadata.url" . }}"
+    {{- else }}
     configurationStoreServers: "{{ template "pulsar.configurationStore.connect" . }}{{ .Values.metadataPrefix }}"
+    {{- end }}
     {{- if .Values.auth.authorization.enabled }}
     authorizationEnabled: "true"
     authorizationProvider: {{ .Values.functions.authorizationProvider }}

--- a/charts/sn-platform-slim/templates/detector/pulsar-detector-deployment.yaml
+++ b/charts/sn-platform-slim/templates/detector/pulsar-detector-deployment.yaml
@@ -56,6 +56,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.pulsar_detector.gracePeriod }}
       {{- if not .Values.istio.enabled }}
       initContainers:
+      {{- if include "pulsar.metadata.isZookeeper" . }}
       # This init container will wait for zookeeper to be ready before
       # deploying the bookies
       - name: wait-zookeeper-ready
@@ -73,6 +74,7 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: /pulsar/logs
+      {{- end }}
       # This init container will wait for at least one broker to be ready before
       # deploying the pulsar-detector
       - name: wait-broker-ready

--- a/charts/sn-platform-slim/templates/extra.yaml
+++ b/charts/sn-platform-slim/templates/extra.yaml
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2019 - 2024 StreamNative, Inc.. All Rights Reserved.
 #
+{{- include "pulsar.validate.metadata" . }}
 {{- range .Values.extraResources }}
 {{ toYaml . }}
 ---

--- a/charts/sn-platform-slim/templates/openshift/scc-rolebinding.yaml
+++ b/charts/sn-platform-slim/templates/openshift/scc-rolebinding.yaml
@@ -3,8 +3,10 @@
 #
 
 {{- if and .Values.openshift.enabled .Values.openshift.scc.enabled -}}
-{{- $sas := list (include "pulsar.zookeeper.serviceAccount" .) -}}
-{{- $sas = append $sas (include "pulsar.bookkeeper.serviceAccount" .) -}}
+{{- $sas := list (include "pulsar.bookkeeper.serviceAccount" .) -}}
+{{- if include "pulsar.metadata.isZookeeper" . -}}
+{{- $sas = append $sas (include "pulsar.zookeeper.serviceAccount" .) -}}
+{{- end -}}
 {{- $sas = append $sas (include "pulsar.broker.serviceAccount" .) -}}
 {{- $sas = append $sas (include "pulsar.proxy.serviceAccount" .) -}}
 {{- $sas = append $sas (include "pulsar.streamnative_console.serviceAccount" .) -}}

--- a/charts/sn-platform-slim/templates/oxia/oxia-cluster.yaml
+++ b/charts/sn-platform-slim/templates/oxia/oxia-cluster.yaml
@@ -1,0 +1,34 @@
+#
+# Copyright (c) 2019 - 2024 StreamNative, Inc.. All Rights Reserved.
+#
+# deploy oxia only when `pulsar_metadata.provider` is oxia
+{{- if include "pulsar.metadata.isOxia" . }}
+apiVersion: k8s.streamnative.io/v1alpha1
+kind: OxiaCluster
+metadata:
+  name: "{{ template "pulsar.oxia.cluster" . }}"
+  namespace: {{ template "pulsar.namespace" . }}
+  labels:
+    {{- include "pulsar.standardLabels" . | nindent 4 }}
+    component: oxia
+{{- if .Values.components.pulsar_coordinator }}
+    k8s.streamnative.io/coordinator-name: "{{ template "pulsar.fullname" . }}-coordinator"
+{{- end }}
+spec:
+  image: "{{ .Values.images.oxia.repository }}:{{ .Values.images.oxia.tag }}"
+  imagePullPolicy: {{ .Values.images.oxia.pullPolicy }}
+  monitoringEnabled: {{ include "pulsar.oxia.podMonitor.enabled" . }}
+  server:
+    replicas: 3
+  {{- if .Values.istio.enabled }}
+  istio:
+    enabled: true
+    {{- if .Values.istio.dataplaneMode }}
+    dataplaneMode: {{ .Values.istio.dataplaneMode }}
+    {{- end }}
+    {{- if .Values.istio.migration }}
+    mtls:
+      mode: permissive
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/sn-platform-slim/templates/oxia/oxia-cluster.yaml
+++ b/charts/sn-platform-slim/templates/oxia/oxia-cluster.yaml
@@ -8,9 +8,16 @@ kind: OxiaCluster
 metadata:
   name: "{{ template "pulsar.oxia.cluster" . }}"
   namespace: {{ template "pulsar.namespace" . }}
+{{- with .Values.oxia.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
-    component: oxia
+    component: {{ .Values.oxia.component }}
+{{- with .Values.oxia.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- if .Values.components.pulsar_coordinator }}
     k8s.streamnative.io/coordinator-name: "{{ template "pulsar.fullname" . }}-coordinator"
 {{- end }}
@@ -18,8 +25,21 @@ spec:
   image: "{{ .Values.images.oxia.repository }}:{{ .Values.images.oxia.tag }}"
   imagePullPolicy: {{ .Values.images.oxia.pullPolicy }}
   monitoringEnabled: {{ include "pulsar.oxia.podMonitor.enabled" . }}
+  {{- with .Values.oxia.labels }}
+  labels:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+  {{- with .Values.oxia.coordinator.resources }}
+  coordinator:
+    resources:
+{{ toYaml . | indent 6 }}
+  {{- end }}
   server:
-    replicas: 3
+    replicas: {{ .Values.oxia.replicaCount }}
+    {{- with .Values.oxia.resources }}
+    resources:
+{{ toYaml . | indent 6 }}
+    {{- end }}
   {{- if .Values.istio.enabled }}
   istio:
     enabled: true

--- a/charts/sn-platform-slim/templates/oxia/oxia-cluster.yaml
+++ b/charts/sn-platform-slim/templates/oxia/oxia-cluster.yaml
@@ -3,19 +3,21 @@
 #
 # deploy oxia only when `pulsar_metadata.provider` is oxia
 {{- if include "pulsar.metadata.isOxia" . }}
+{{- $oxia := default dict .Values.oxia }}
+{{- $dataserver := default dict $oxia.dataserver }}
 apiVersion: k8s.streamnative.io/v1alpha1
 kind: OxiaCluster
 metadata:
   name: "{{ template "pulsar.oxia.cluster" . }}"
   namespace: {{ template "pulsar.namespace" . }}
-{{- with .Values.oxia.annotations }}
+{{- with $oxia.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: oxia
-{{- with .Values.oxia.labels }}
+{{- with $oxia.labels }}
 {{ toYaml . | indent 4 }}
 {{- end }}
 {{- if .Values.components.pulsar_coordinator }}
@@ -25,11 +27,11 @@ spec:
   image: "{{ .Values.images.oxia.repository }}:{{ .Values.images.oxia.tag }}"
   imagePullPolicy: {{ .Values.images.oxia.pullPolicy }}
   monitoringEnabled: {{ include "pulsar.oxia.podMonitor.enabled" . }}
-  {{- with .Values.oxia.labels }}
+  {{- with $oxia.labels }}
   labels:
 {{ toYaml . | indent 4 }}
   {{- end }}
-  {{- with .Values.oxia.coordinator }}
+  {{- with $oxia.coordinator }}
   {{- with .resources }}
   coordinator:
     resources:
@@ -37,8 +39,8 @@ spec:
   {{- end }}
   {{- end }}
   server:
-    replicas: {{ .Values.oxia.replicaCount }}
-    {{- with .Values.oxia.resources }}
+    replicas: {{ include "pulsar.oxia.replicaCount" . }}
+    {{- with $dataserver.resources }}
     resources:
 {{ toYaml . | indent 6 }}
     {{- end }}

--- a/charts/sn-platform-slim/templates/oxia/oxia-cluster.yaml
+++ b/charts/sn-platform-slim/templates/oxia/oxia-cluster.yaml
@@ -14,7 +14,7 @@ metadata:
 {{- end }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
-    component: {{ .Values.oxia.component }}
+    component: oxia
 {{- with .Values.oxia.labels }}
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/charts/sn-platform-slim/templates/oxia/oxia-cluster.yaml
+++ b/charts/sn-platform-slim/templates/oxia/oxia-cluster.yaml
@@ -5,6 +5,8 @@
 {{- if include "pulsar.metadata.isOxia" . }}
 {{- $oxia := default dict .Values.oxia }}
 {{- $dataserver := default dict $oxia.dataserver }}
+{{- $oxiaIstio := default dict $oxia.istio }}
+{{- $istioRevision := index (default dict .Values.istio.labels) "istio.io/rev" }}
 apiVersion: k8s.streamnative.io/v1alpha1
 kind: OxiaCluster
 metadata:
@@ -47,12 +49,28 @@ spec:
   {{- if .Values.istio.enabled }}
   istio:
     enabled: true
+    {{- with $istioRevision }}
+    revision: {{ . | quote }}
+    {{- end }}
     {{- if .Values.istio.dataplaneMode }}
     dataplaneMode: {{ .Values.istio.dataplaneMode }}
     {{- end }}
     {{- if .Values.istio.migration }}
     mtls:
       mode: permissive
+    {{- end }}
+    {{- if $oxiaIstio.authRules }}
+    authRules:
+{{ toYaml $oxiaIstio.authRules | indent 4 }}
+    {{- else }}
+    authRules:
+    - toOperation:
+      - ports:
+        - "6648"
+        - "6649"
+        - "8080"
+        - "6650"
+        - "8081"
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/sn-platform-slim/templates/oxia/oxia-cluster.yaml
+++ b/charts/sn-platform-slim/templates/oxia/oxia-cluster.yaml
@@ -29,10 +29,12 @@ spec:
   labels:
 {{ toYaml . | indent 4 }}
   {{- end }}
-  {{- with .Values.oxia.coordinator.resources }}
+  {{- with .Values.oxia.coordinator }}
+  {{- with .resources }}
   coordinator:
     resources:
 {{ toYaml . | indent 6 }}
+  {{- end }}
   {{- end }}
   server:
     replicas: {{ .Values.oxia.replicaCount }}

--- a/charts/sn-platform-slim/templates/oxia/oxia-namespace.yaml
+++ b/charts/sn-platform-slim/templates/oxia/oxia-namespace.yaml
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2019 - 2024 StreamNative, Inc.. All Rights Reserved.
+#
+# deploy oxia namespaces only when `pulsar_metadata.provider` is oxia
+{{- if include "pulsar.metadata.isOxia" . }}
+{{- $namespaces := list
+  (dict "name" (include "pulsar.oxia.broker.namespace" .) "type" "broker")
+  (dict "name" (include "pulsar.oxia.bookkeeper.namespace" .) "type" "bookkeeper")
+  (dict "name" (include "pulsar.oxia.schema.namespace" .) "type" "pulsar-schema")
+  (dict "name" (include "pulsar.oxia.function.namespace" .) "type" "function")
+}}
+{{- range $index, $oxiaNamespace := $namespaces }}
+{{- if $index }}
+---
+{{- end }}
+apiVersion: k8s.streamnative.io/v1alpha1
+kind: OxiaNamespace
+metadata:
+  name: "{{ template "pulsar.oxia.cluster" $ }}-{{ $oxiaNamespace.type }}"
+  namespace: {{ template "pulsar.namespace" $ }}
+  labels:
+    {{- include "pulsar.standardLabels" $ | nindent 4 }}
+    component: oxia
+spec:
+  namespaceConfig:
+    name: "{{ $oxiaNamespace.name }}"
+    initialShardCount: 1
+    replicationFactor: 3
+    notificationsEnabled: true
+  clusterRef:
+    name: "{{ template "pulsar.oxia.cluster" $ }}"
+    namespace: {{ template "pulsar.namespace" $ }}
+  ownerRef:
+    name: "{{ template "pulsar.fullname" $ }}"
+    namespace: {{ template "pulsar.namespace" $ }}
+{{- end }}
+{{- end }}

--- a/charts/sn-platform-slim/templates/oxia/oxia-namespace.yaml
+++ b/charts/sn-platform-slim/templates/oxia/oxia-namespace.yaml
@@ -3,12 +3,11 @@
 #
 # deploy oxia namespaces only when `pulsar_metadata.provider` is oxia
 {{- if include "pulsar.metadata.isOxia" . }}
-{{- $namespaces := list
-  (dict "name" (include "pulsar.oxia.broker.namespace" .) "type" "broker")
-  (dict "name" (include "pulsar.oxia.bookkeeper.namespace" .) "type" "bookkeeper")
-  (dict "name" (include "pulsar.oxia.schema.namespace" .) "type" "pulsar-schema")
-  (dict "name" (include "pulsar.oxia.function.namespace" .) "type" "function")
-}}
+{{- $brokerNamespace := dict "name" (include "pulsar.oxia.broker.namespace" .) "type" "broker" }}
+{{- $bookkeeperNamespace := dict "name" (include "pulsar.oxia.bookkeeper.namespace" .) "type" "bookkeeper" }}
+{{- $schemaNamespace := dict "name" (include "pulsar.oxia.schema.namespace" .) "type" "pulsar-schema" }}
+{{- $functionNamespace := dict "name" (include "pulsar.oxia.function.namespace" .) "type" "function" }}
+{{- $namespaces := list $brokerNamespace $bookkeeperNamespace $schemaNamespace $functionNamespace }}
 {{- range $index, $oxiaNamespace := $namespaces }}
 {{- if $index }}
 ---

--- a/charts/sn-platform-slim/templates/prometheus/prometheus-configmap.yaml
+++ b/charts/sn-platform-slim/templates/prometheus/prometheus-configmap.yaml
@@ -57,7 +57,7 @@ data:
           names:
             - {{ template "pulsar.namespace" . }}
 {{- end }}
-{{- if and .Values.istio.enabled (not .Values.istio.mergeMetrics) }}
+{{- if eq (include "pulsar.istio.prometheus.sidecarMTLS" .) "true" }}
 {{- if .Values.istio.migration }}
       scheme: http
       enable_http2: false
@@ -83,6 +83,12 @@ data:
         action: drop
         regex: "{{ .Values.prometheus.component }}|{{ .Values.grafana.component }}|{{ .Values.toolset.component }}|{{ .Values.streamnative_console.component }}"
 {{- end }}
+{{- if include "pulsar.metadata.isOxia" . }}
+      # Oxia has two metrics ports. Dedicated Oxia scrape config below handles both.
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
+        action: drop
+        regex: "{{ template "pulsar.oxia.service" . }}"
+{{- end }}
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true
@@ -100,8 +106,13 @@ data:
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: kubernetes_namespace
+      - source_labels: [__meta_kubernetes_pod_label_cloud_streamnative_io_component]
+        action: replace
+        regex: (.+)
+        target_label: job
       - source_labels: [__meta_kubernetes_pod_label_component]
         action: replace
+        regex: (.+)
         target_label: job
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
@@ -110,6 +121,60 @@ data:
 {{- if .Values.prometheus.customRelabelConfigs -}}
 {{- with .Values.prometheus.customRelabelConfigs }}
 {{ toYaml . | indent 6 }}
+{{- end }}
+{{- end }}
+{{- if include "pulsar.metadata.isOxia" . }}
+    - job_name: 'oxia'
+{{- if .Values.prometheus.sampleLimit }}
+      sample_limit: {{ .Values.prometheus.sampleLimit }}
+{{- end }}
+      kubernetes_sd_configs:
+      - role: pod
+{{- if or .Values.istio.enabled (not .Values.prometheus.serviceAccount.clusterRole) }}
+        namespaces:
+          names:
+            - {{ template "pulsar.namespace" . }}
+{{- end }}
+{{- if eq (include "pulsar.istio.prometheus.sidecarMTLS" .) "true" }}
+{{- if .Values.istio.migration }}
+      scheme: http
+      enable_http2: false
+{{- else }}
+      scheme: https
+      # Disable http2 for Prometheus issue: https://github.com/prometheus/prometheus/issues/10213
+      enable_http2: false
+      tls_config:
+        ca_file: /etc/prom-certs/root-cert.pem
+        cert_file: /etc/prom-certs/cert-chain.pem
+        key_file: /etc/prom-certs/key.pem
+        insecure_skip_verify: true
+{{- end }}
+{{- end }}
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
+        action: keep
+        regex: "{{ template "pulsar.oxia.service" . }}"
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+        action: keep
+        regex: oxia-cluster
+      - source_labels: [__meta_kubernetes_pod_container_port_name]
+        action: keep
+        regex: metrics|coord-metrics
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: kubernetes_namespace
+      - target_label: job
+        replacement: oxia
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod_name
+      metric_relabel_configs:
+{{- if .Values.prometheus.customRelabelConfigs -}}
+{{- with .Values.prometheus.customRelabelConfigs }}
+{{ toYaml . | indent 6 }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- if and .Values.prometheus.serviceAccount.clusterRole (or (not (hasKey .Values.prometheus.scrape "kubernetesNodes")) (eq .Values.prometheus.scrape.kubernetesNodes true)) }}

--- a/charts/sn-platform-slim/templates/prometheus/prometheus-statefulset.yaml
+++ b/charts/sn-platform-slim/templates/prometheus/prometheus-statefulset.yaml
@@ -37,7 +37,7 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
       annotations:
-        {{- if and .Values.istio.enabled (not .Values.istio.mergeMetrics ) }}
+        {{- if eq (include "pulsar.istio.prometheus.sidecarMTLS" .) "true" }}
         # ref: https://istio.io/latest/docs/ops/integrations/prometheus/#tls-settings
         traffic.sidecar.istio.io/includeOutboundIPRanges: ""  # do not intercept any outbound traffic
         # configure an env variable `OUTPUT_CERTS` to write certificates to the given folder
@@ -158,7 +158,7 @@ spec:
           mountPath: /etc/config
         - name: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}-{{ .Values.prometheus.volumes.data.name }}"
           mountPath: /prometheus
-        {{- if and .Values.istio.enabled (not .Values.istio.mergeMetrics ) }}
+        {{- if eq (include "pulsar.istio.prometheus.sidecarMTLS" .) "true" }}
         - name: istio-certs
           mountPath: /etc/prom-certs/
         {{- end }}
@@ -167,7 +167,7 @@ spec:
       - name: config-volume
         configMap:
           name: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}"
-      {{- if and .Values.istio.enabled (not .Values.istio.mergeMetrics )}}
+      {{- if eq (include "pulsar.istio.prometheus.sidecarMTLS" .) "true" }}
       - emptyDir:
           medium: Memory
         name: istio-certs

--- a/charts/sn-platform-slim/templates/zookeeper/gen-zk-conf.yaml
+++ b/charts/sn-platform-slim/templates/zookeeper/gen-zk-conf.yaml
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2019 - 2024 StreamNative, Inc.. All Rights Reserved.
 #
-
+{{- if include "pulsar.metadata.isZookeeper" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -66,3 +66,4 @@ data:
             echo $MY_ID > $DATA_DIR/myid
         fi
     fi
+{{- end }}

--- a/charts/sn-platform-slim/templates/zookeeper/zookeeper-authorizationpolicy.yaml
+++ b/charts/sn-platform-slim/templates/zookeeper/zookeeper-authorizationpolicy.yaml
@@ -2,7 +2,7 @@
 # Copyright (c) 2019 - 2024 StreamNative, Inc.. All Rights Reserved.
 #
 
-{{- if and .Values.components.zookeeper .Values.istio.enabled }}
+{{- if and .Values.components.zookeeper .Values.istio.enabled (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:

--- a/charts/sn-platform-slim/templates/zookeeper/zookeeper-backup-clusterrolebinding.yaml
+++ b/charts/sn-platform-slim/templates/zookeeper/zookeeper-backup-clusterrolebinding.yaml
@@ -3,7 +3,7 @@
 #
 
 {{- if .Values.zookeeper.customTools.serviceAccount.clusterRole }}
-{{- if and .Values.zookeeper.customTools.backup.enable .Values.zookeeper.customTools.serviceAccount.create }}
+{{- if and .Values.zookeeper.customTools.backup.enable .Values.zookeeper.customTools.serviceAccount.create (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/sn-platform-slim/templates/zookeeper/zookeeper-backup-configmap.yaml
+++ b/charts/sn-platform-slim/templates/zookeeper/zookeeper-backup-configmap.yaml
@@ -3,7 +3,7 @@
 #
 
 # deploy zookeeper only when `zookeeper.customTools.backup.enable` is true
-{{- if .Values.zookeeper.customTools.backup.enable }}
+{{- if and .Values.zookeeper.customTools.backup.enable (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/sn-platform-slim/templates/zookeeper/zookeeper-backup-rolebinding.yaml
+++ b/charts/sn-platform-slim/templates/zookeeper/zookeeper-backup-rolebinding.yaml
@@ -3,7 +3,7 @@
 #
 
 {{- if not .Values.zookeeper.customTools.serviceAccount.clusterRole }}
-{{- if and .Values.zookeeper.customTools.backup.enable .Values.zookeeper.customTools.serviceAccount.create }}
+{{- if and .Values.zookeeper.customTools.backup.enable .Values.zookeeper.customTools.serviceAccount.create (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/sn-platform-slim/templates/zookeeper/zookeeper-backup-service.yaml
+++ b/charts/sn-platform-slim/templates/zookeeper/zookeeper-backup-service.yaml
@@ -3,7 +3,7 @@
 #
 
 # deploy zookeeper only when `zookeeper.customTools.backup.enable` is true
-{{- if .Values.zookeeper.customTools.backup.enable }}
+{{- if and .Values.zookeeper.customTools.backup.enable (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/sn-platform-slim/templates/zookeeper/zookeeper-backup-serviceaccount.yaml
+++ b/charts/sn-platform-slim/templates/zookeeper/zookeeper-backup-serviceaccount.yaml
@@ -2,7 +2,7 @@
 # Copyright (c) 2019 - 2024 StreamNative, Inc.. All Rights Reserved.
 #
 
-{{- if .Values.zookeeper.customTools.serviceAccount.create }}
+{{- if and .Values.zookeeper.customTools.serviceAccount.create (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sn-platform-slim/templates/zookeeper/zookeeper-backup-statefulset.yaml
+++ b/charts/sn-platform-slim/templates/zookeeper/zookeeper-backup-statefulset.yaml
@@ -3,7 +3,7 @@
 #
 
 # deploy zookeeper only when `zookeeper.customTools.backup.enable` is true
-{{- if .Values.zookeeper.customTools.backup.enable }}
+{{- if and .Values.zookeeper.customTools.backup.enable (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/sn-platform-slim/templates/zookeeper/zookeeper-cluster.yaml
+++ b/charts/sn-platform-slim/templates/zookeeper/zookeeper-cluster.yaml
@@ -2,7 +2,7 @@
 # Copyright (c) 2019 - 2024 StreamNative, Inc.. All Rights Reserved.
 #
 # deploy zookeeper only when `components.zookeeper` is true
-{{- if .Values.components.zookeeper }}
+{{- if and .Values.components.zookeeper (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: zookeeper.streamnative.io/v1alpha1
 kind: ZooKeeperCluster
 metadata:

--- a/charts/sn-platform-slim/templates/zookeeper/zookeeper-restore-clusterrolebinding.yaml
+++ b/charts/sn-platform-slim/templates/zookeeper/zookeeper-restore-clusterrolebinding.yaml
@@ -3,7 +3,7 @@
 #
 
 {{- if .Values.zookeeper.customTools.serviceAccount.clusterRole }}
-{{- if and .Values.zookeeper.customTools.restore.enable .Values.zookeeper.customTools.serviceAccount.create }}
+{{- if and .Values.zookeeper.customTools.restore.enable .Values.zookeeper.customTools.serviceAccount.create (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/sn-platform-slim/templates/zookeeper/zookeeper-restore-configmap.yaml
+++ b/charts/sn-platform-slim/templates/zookeeper/zookeeper-restore-configmap.yaml
@@ -3,7 +3,7 @@
 #
 
 # deploy zookeeper only when `zookeeper.customTools.restore.enable` is true
-{{- if .Values.zookeeper.customTools.restore.enable }}
+{{- if and .Values.zookeeper.customTools.restore.enable (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/sn-platform-slim/templates/zookeeper/zookeeper-restore-rolebinding.yaml
+++ b/charts/sn-platform-slim/templates/zookeeper/zookeeper-restore-rolebinding.yaml
@@ -3,7 +3,7 @@
 #
 
 {{- if not .Values.zookeeper.customTools.serviceAccount.clusterRole }}
-{{- if and .Values.zookeeper.customTools.restore.enable .Values.zookeeper.customTools.serviceAccount.create }}
+{{- if and .Values.zookeeper.customTools.restore.enable .Values.zookeeper.customTools.serviceAccount.create (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/sn-platform-slim/templates/zookeeper/zookeeper-restore-serviceaccount.yaml
+++ b/charts/sn-platform-slim/templates/zookeeper/zookeeper-restore-serviceaccount.yaml
@@ -2,7 +2,7 @@
 # Copyright (c) 2019 - 2024 StreamNative, Inc.. All Rights Reserved.
 #
 
-{{- if .Values.zookeeper.customTools.serviceAccount.create }}
+{{- if and .Values.zookeeper.customTools.serviceAccount.create (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sn-platform-slim/templates/zookeeper/zookeeper-service-account.yaml
+++ b/charts/sn-platform-slim/templates/zookeeper/zookeeper-service-account.yaml
@@ -2,7 +2,7 @@
 # Copyright (c) 2019 - 2024 StreamNative, Inc.. All Rights Reserved.
 #
 
-{{- if and .Values.components.zookeeper .Values.zookeeper.serviceAccount.create }}
+{{- if and .Values.components.zookeeper .Values.zookeeper.serviceAccount.create (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sn-platform-slim/templates/zookeeper/zookeeper-storageclass.yaml
+++ b/charts/sn-platform-slim/templates/zookeeper/zookeeper-storageclass.yaml
@@ -3,7 +3,7 @@
 #
 
 # deploy zookeeper only when `components.zookeeper` is true
-{{- if .Values.components.zookeeper }}
+{{- if and .Values.components.zookeeper (include "pulsar.metadata.isZookeeper" .) }}
 {{- if and .Values.volumes.persistence .Values.zookeeper.volumes.persistence }}
 
 # define the storage class for data directory

--- a/charts/sn-platform-slim/values.yaml
+++ b/charts/sn-platform-slim/values.yaml
@@ -1159,6 +1159,15 @@ pulsar_metadata:
   #     limits:
   #       cpu: "1"
   #       memory: "1Gi"
+  # istio:
+  #   authRules:
+  #   - toOperation:
+  #     - ports:
+  #       - "6648"
+  #       - "6649"
+  #       - "8080"
+  #       - "6650"
+  #       - "8081"
 
 ## deprecated: move to broker.kop
 # kop:

--- a/charts/sn-platform-slim/values.yaml
+++ b/charts/sn-platform-slim/values.yaml
@@ -122,6 +122,10 @@ images:
         repository: "streamnative/pulsar-metadata-tool"
         tag: "3.3.3.3"
         pullPolicy: IfNotPresent
+  oxia:
+    repository: oxia/oxia
+    tag: "0.16.4"
+    pullPolicy: IfNotPresent
   bookie:
     repository: streamnative/sn-platform-slim
     tag: "3.3.3.3"
@@ -1114,6 +1118,8 @@ autorecovery:
 ## metadata deployed
 pulsar_metadata:
   component: pulsar-init
+  # metadata provider. Valid values: zookeeper, oxia
+  provider: zookeeper
   # set the cluster name. if empty or not specified,
   # it will use helm release name to generate a cluster name.
   clusterName: ""

--- a/charts/sn-platform-slim/values.yaml
+++ b/charts/sn-platform-slim/values.yaml
@@ -1159,15 +1159,6 @@ pulsar_metadata:
   #     limits:
   #       cpu: "1"
   #       memory: "1Gi"
-  # istio:
-  #   authRules:
-  #   - toOperation:
-  #     - ports:
-  #       - "6648"
-  #       - "6649"
-  #       - "8080"
-  #       - "6650"
-  #       - "8081"
 
 ## deprecated: move to broker.kop
 # kop:

--- a/charts/sn-platform-slim/values.yaml
+++ b/charts/sn-platform-slim/values.yaml
@@ -1137,7 +1137,6 @@ pulsar_metadata:
 ## Oxia metadata store.
 ## Used only when pulsar_metadata.provider is oxia.
 oxia:
-  component: oxia
   # The number of Oxia server replicas to run. Must be at least 3 for Oxia metadata deployments.
   replicaCount: 3
   # Labels added to the OxiaCluster CR and propagated to generated Oxia resources.

--- a/charts/sn-platform-slim/values.yaml
+++ b/charts/sn-platform-slim/values.yaml
@@ -124,7 +124,7 @@ images:
         pullPolicy: IfNotPresent
   oxia:
     repository: oxia/oxia
-    tag: "0.16.4"
+    tag: "0.16.6"
     pullPolicy: IfNotPresent
   bookie:
     repository: streamnative/sn-platform-slim
@@ -1138,20 +1138,27 @@ pulsar_metadata:
 ## Used only when pulsar_metadata.provider is oxia.
 oxia:
   # The number of Oxia server replicas to run. Must be at least 3 for Oxia metadata deployments.
-  replicaCount: 3
+  # replicaCount: 3
   # labels:
   #   example: value
   # annotations:
   #   example: value
-  # resources:
-  #   requests:
-  #     cpu: "0.5"
-  #     memory: "1Gi"
+  # dataserver:
+  #   resources:
+  #     requests:
+  #       cpu: "0.5"
+  #       memory: "1Gi"
+  #     limits:
+  #       cpu: "2"
+  #       memory: "4Gi"
   # coordinator:
   #   resources:
   #     requests:
   #       cpu: "0.25"
   #       memory: "512Mi"
+  #     limits:
+  #       cpu: "1"
+  #       memory: "1Gi"
 
 ## deprecated: move to broker.kop
 # kop:

--- a/charts/sn-platform-slim/values.yaml
+++ b/charts/sn-platform-slim/values.yaml
@@ -1136,7 +1136,7 @@ pulsar_metadata:
 
 ## Oxia metadata store.
 ## Used only when pulsar_metadata.provider is oxia.
-oxia:
+# oxia:
   # The number of Oxia server replicas to run. Must be at least 3 for Oxia metadata deployments.
   # replicaCount: 3
   # labels:

--- a/charts/sn-platform-slim/values.yaml
+++ b/charts/sn-platform-slim/values.yaml
@@ -108,19 +108,19 @@ monitoring:
 images:
   coordinator:
     repository: streamnative/sn-platform-slim
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
   zookeeper:
     repository: streamnative/sn-platform-slim
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
     customTools:
       backup:
         repository: "streamnative/pulsar-metadata-tool"
-        tag: "3.3.3.3"
+        tag: "4.2.1.1"
         pullPolicy: IfNotPresent
       restore:
         repository: "streamnative/pulsar-metadata-tool"
-        tag: "3.3.3.3"
+        tag: "4.2.1.1"
         pullPolicy: IfNotPresent
   oxia:
     repository: oxia/oxia
@@ -128,36 +128,36 @@ images:
     pullPolicy: IfNotPresent
   bookie:
     repository: streamnative/sn-platform-slim
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   autorecovery:
     repository: streamnative/sn-platform-slim
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   broker:
     repository: streamnative/sn-platform-slim
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   proxy:
     repository: streamnative/sn-platform-slim
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   pulsar_detector:
     repository: streamnative/sn-platform-slim
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   functions:
     repository: streamnative/sn-platform-slim
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   function_worker:
     repository: streamnative/sn-platform-slim
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   # NOTE: allow overriding the toolset image
   toolset:
     repository: streamnative/sn-platform-slim
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
     # deprecated: use images.busybox instead
     busybox:
@@ -196,7 +196,7 @@ images:
     pullPolicy: "IfNotPresent"
   pulsar_metadata:
     repository: streamnative/sn-platform-slim
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   configmapReload:
     repository: jimmidyson/configmap-reload

--- a/charts/sn-platform-slim/values.yaml
+++ b/charts/sn-platform-slim/values.yaml
@@ -1134,6 +1134,22 @@ pulsar_metadata:
   #
   # configurationStoreServers: "zk04:2181,zk05:2181,zk06:2181"
 
+## Oxia metadata store.
+## Used only when pulsar_metadata.provider is oxia.
+oxia:
+  component: oxia
+  # The number of Oxia server replicas to run. Must be at least 3 for Oxia metadata deployments.
+  replicaCount: 3
+  # Labels added to the OxiaCluster CR and propagated to generated Oxia resources.
+  labels: {}
+  # Annotations added to the OxiaCluster CR.
+  annotations: {}
+  # Resources requests/limits for Oxia server containers.
+  resources: {}
+  coordinator:
+    # Resources requests/limits for Oxia coordinator containers.
+    resources: {}
+
 ## deprecated: move to broker.kop
 # kop:
 #   ports:

--- a/charts/sn-platform-slim/values.yaml
+++ b/charts/sn-platform-slim/values.yaml
@@ -108,19 +108,19 @@ monitoring:
 images:
   coordinator:
     repository: streamnative/sn-platform-slim
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
   zookeeper:
     repository: streamnative/sn-platform-slim
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
     customTools:
       backup:
         repository: "streamnative/pulsar-metadata-tool"
-        tag: "4.2.1.1"
+        tag: "3.3.3.3"
         pullPolicy: IfNotPresent
       restore:
         repository: "streamnative/pulsar-metadata-tool"
-        tag: "4.2.1.1"
+        tag: "3.3.3.3"
         pullPolicy: IfNotPresent
   oxia:
     repository: oxia/oxia
@@ -128,36 +128,36 @@ images:
     pullPolicy: IfNotPresent
   bookie:
     repository: streamnative/sn-platform-slim
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   autorecovery:
     repository: streamnative/sn-platform-slim
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   broker:
     repository: streamnative/sn-platform-slim
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   proxy:
     repository: streamnative/sn-platform-slim
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   pulsar_detector:
     repository: streamnative/sn-platform-slim
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   functions:
     repository: streamnative/sn-platform-slim
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   function_worker:
     repository: streamnative/sn-platform-slim
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   # NOTE: allow overriding the toolset image
   toolset:
     repository: streamnative/sn-platform-slim
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
     # deprecated: use images.busybox instead
     busybox:
@@ -196,7 +196,7 @@ images:
     pullPolicy: "IfNotPresent"
   pulsar_metadata:
     repository: streamnative/sn-platform-slim
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   configmapReload:
     repository: jimmidyson/configmap-reload

--- a/charts/sn-platform-slim/values.yaml
+++ b/charts/sn-platform-slim/values.yaml
@@ -1139,15 +1139,19 @@ pulsar_metadata:
 oxia:
   # The number of Oxia server replicas to run. Must be at least 3 for Oxia metadata deployments.
   replicaCount: 3
-  # Labels added to the OxiaCluster CR and propagated to generated Oxia resources.
-  labels: {}
-  # Annotations added to the OxiaCluster CR.
-  annotations: {}
-  # Resources requests/limits for Oxia server containers.
-  resources: {}
-  coordinator:
-    # Resources requests/limits for Oxia coordinator containers.
-    resources: {}
+  # labels:
+  #   example: value
+  # annotations:
+  #   example: value
+  # resources:
+  #   requests:
+  #     cpu: "0.5"
+  #     memory: "1Gi"
+  # coordinator:
+  #   resources:
+  #     requests:
+  #       cpu: "0.25"
+  #       memory: "512Mi"
 
 ## deprecated: move to broker.kop
 # kop:

--- a/charts/sn-platform/templates/_helpers.tpl
+++ b/charts/sn-platform/templates/_helpers.tpl
@@ -188,6 +188,96 @@ Pulsar Cluster Name.
 {{- end }}
 
 {{/*
+Metadata provider selection.
+*/}}
+{{- define "pulsar.metadata.provider" -}}
+{{- default "zookeeper" .Values.pulsar_metadata.provider -}}
+{{- end -}}
+
+{{- define "pulsar.metadata.isZookeeper" -}}
+{{- if eq (include "pulsar.metadata.provider" .) "zookeeper" -}}true{{- end -}}
+{{- end -}}
+
+{{- define "pulsar.metadata.isOxia" -}}
+{{- if eq (include "pulsar.metadata.provider" .) "oxia" -}}true{{- end -}}
+{{- end -}}
+
+{{- define "pulsar.oxia.cluster" -}}
+{{- template "pulsar.fullname" . -}}
+{{- end -}}
+
+{{- define "pulsar.oxia.service" -}}
+{{- template "pulsar.oxia.cluster" . -}}-oxia
+{{- end -}}
+
+{{- define "pulsar.oxia.service.address" -}}
+{{- template "pulsar.oxia.service" . -}}.{{ template "pulsar.namespace" . }}.svc.cluster.local:6648
+{{- end -}}
+
+{{- define "pulsar.oxia.broker.namespace" -}}
+broker
+{{- end -}}
+
+{{- define "pulsar.oxia.bookkeeper.namespace" -}}
+bookkeeper
+{{- end -}}
+
+{{- define "pulsar.oxia.schema.namespace" -}}
+pulsar-schema
+{{- end -}}
+
+{{- define "pulsar.oxia.function.namespace" -}}
+function
+{{- end -}}
+
+{{- define "pulsar.oxia.broker.url" -}}
+oxia://{{ template "pulsar.oxia.service.address" . }}/{{ template "pulsar.oxia.broker.namespace" . }}
+{{- end -}}
+
+{{- define "pulsar.oxia.bookkeeper.url" -}}
+oxia://{{ template "pulsar.oxia.service.address" . }}/{{ template "pulsar.oxia.bookkeeper.namespace" . }}
+{{- end -}}
+
+{{- define "pulsar.oxia.schema.url" -}}
+oxia://{{ template "pulsar.oxia.service.address" . }}/{{ template "pulsar.oxia.schema.namespace" . }}
+{{- end -}}
+
+{{- define "pulsar.oxia.metadata.url" -}}
+{{- template "pulsar.oxia.broker.url" . -}}
+{{- end -}}
+
+{{- define "pulsar.oxia.bookkeeper.metadataServiceUri" -}}
+metadata-store:{{ template "pulsar.oxia.bookkeeper.url" . }}
+{{- end -}}
+
+{{- define "pulsar.oxia.podMonitor.enabled" -}}
+{{- if and .Values.monitoring.prometheus (or (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}
+
+{{- define "pulsar.validate.metadata" -}}
+{{- $provider := include "pulsar.metadata.provider" . -}}
+{{- if and (ne $provider "zookeeper") (ne $provider "oxia") -}}
+{{- fail "pulsar_metadata.provider must be one of: zookeeper, oxia" -}}
+{{- end -}}
+{{- if and (eq $provider "oxia") .Values.metadataPrefix -}}
+{{- fail "metadataPrefix is only supported with pulsar_metadata.provider=zookeeper" -}}
+{{- end -}}
+{{- if and (eq $provider "oxia") .Values.pulsar_metadata.userProvidedZookeepers -}}
+{{- fail "pulsar_metadata.userProvidedZookeepers is only supported with pulsar_metadata.provider=zookeeper" -}}
+{{- end -}}
+{{- if and (eq $provider "oxia") .Values.pulsar_metadata.configurationStoreServers -}}
+{{- fail "pulsar_metadata.configurationStoreServers is only supported with pulsar_metadata.provider=zookeeper" -}}
+{{- end -}}
+{{- if and (eq $provider "oxia") .Values.components.sql_worker -}}
+{{- fail "components.sql_worker is not supported with pulsar_metadata.provider=oxia" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Istio gateway selector
 */}}
 {{- define "pulsar.istio.gateway.selector" -}}
@@ -208,6 +298,15 @@ prometheus.istio.io/merge-metrics: "true"
 {{- else -}}
 prometheus.istio.io/merge-metrics: "false"
 {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Whether Prometheus should use sidecar-issued mTLS certs to scrape workload metrics.
+*/}}
+{{- define "pulsar.istio.prometheus.sidecarMTLS" -}}
+{{- if and .Values.istio.enabled (not .Values.istio.mergeMetrics) (ne (default "" .Values.istio.dataplaneMode) "ambient") -}}
+true
 {{- end -}}
 {{- end -}}
 

--- a/charts/sn-platform/templates/_helpers.tpl
+++ b/charts/sn-platform/templates/_helpers.tpl
@@ -275,6 +275,9 @@ false
 {{- if and (eq $provider "oxia") .Values.components.sql_worker -}}
 {{- fail "components.sql_worker is not supported with pulsar_metadata.provider=oxia" -}}
 {{- end -}}
+{{- if and (eq $provider "oxia") (lt (int .Values.oxia.replicaCount) 3) -}}
+{{- fail "oxia.replicaCount must be at least 3 when pulsar_metadata.provider=oxia" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/sn-platform/templates/_helpers.tpl
+++ b/charts/sn-platform/templates/_helpers.tpl
@@ -250,6 +250,11 @@ oxia://{{ template "pulsar.oxia.service.address" . }}/{{ template "pulsar.oxia.s
 metadata-store:{{ template "pulsar.oxia.bookkeeper.url" . }}
 {{- end -}}
 
+{{- define "pulsar.oxia.replicaCount" -}}
+{{- $oxia := default dict .Values.oxia -}}
+{{- if hasKey $oxia "replicaCount" -}}{{- $oxia.replicaCount -}}{{- else -}}3{{- end -}}
+{{- end -}}
+
 {{- define "pulsar.oxia.podMonitor.enabled" -}}
 {{- if and .Values.monitoring.prometheus (or (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) -}}
 true
@@ -275,7 +280,7 @@ false
 {{- if and (eq $provider "oxia") .Values.components.sql_worker -}}
 {{- fail "components.sql_worker is not supported with pulsar_metadata.provider=oxia" -}}
 {{- end -}}
-{{- if and (eq $provider "oxia") (lt (int .Values.oxia.replicaCount) 3) -}}
+{{- if and (eq $provider "oxia") (lt (int (include "pulsar.oxia.replicaCount" .)) 3) -}}
 {{- fail "oxia.replicaCount must be at least 3 when pulsar_metadata.provider=oxia" -}}
 {{- end -}}
 {{- end -}}

--- a/charts/sn-platform/templates/bookkeeper/_bookkeeper.tpl
+++ b/charts/sn-platform/templates/bookkeeper/_bookkeeper.tpl
@@ -134,8 +134,12 @@ Define bookie tls certs volumes
 Define bookie common config
 */}}
 {{- define "pulsar.bookkeeper.config.common" -}}
+{{- if include "pulsar.metadata.isOxia" . }}
+metadataServiceUri: "{{ template "pulsar.oxia.bookkeeper.metadataServiceUri" . }}"
+{{- else }}
 zkServers: "{{ template "pulsar.zookeeper.connect" . }}"
 zkLedgersRootPath: "{{ .Values.metadataPrefix }}/ledgers"
+{{- end }}
 # enable bookkeeper http server
 httpServerEnabled: "true"
 httpServerPort: "{{ .Values.bookkeeper.ports.http }}"

--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
@@ -29,7 +29,11 @@ spec:
 {{- if not .Values.initialize }}
   initialized: true
 {{- end }}
+{{- if include "pulsar.metadata.isOxia" . }}
+  metadataServiceUri: "{{ template "pulsar.oxia.bookkeeper.metadataServiceUri" . }}"
+{{- else }}
   zkServers: "{{ template "pulsar.zookeeper.connect" . }}"
+{{- end }}
   replicas: {{ .Values.bookkeeper.replicaCount }}
   {{- if not (and .Values.components.pulsar_coordinator .Values.images.coordinator) }}
   image: "{{ .Values.images.bookie.repository }}:{{ .Values.images.bookie.tag }}"
@@ -176,6 +180,14 @@ spec:
         {{- include "pulsar.bookkeeper.ledgers.storage.class" . | nindent 8 }}
     reclaimPolicy: {{ .Values.bookkeeper.volumes.reclaimPolicy | default "Delete" }}
   {{- end }}
+  {{- if .Values.istio.enabled }}
+  istio:
+    enabled: true
+    {{- if .Values.istio.migration }}
+    mtls:
+      mode: permissive
+    {{- end }}
+  {{- end }}
   config:
     {{- with .Values.bookkeeper.rackAwareTopologyLabels }}
     rackAwareTopologyLabels:
@@ -188,7 +200,11 @@ spec:
 {{- with .Values.bookkeeper.configData }}
 {{ toYaml . | indent 6 }}
 {{- end }}
+      {{- if include "pulsar.metadata.isZookeeper" . }}
       zkLedgersRootPath: "{{ .Values.metadataPrefix }}/ledgers"
+      {{- else }}
+      metadataServiceUri: "{{ template "pulsar.oxia.bookkeeper.metadataServiceUri" . }}"
+      {{- end }}
       # enable bookkeeper http server
       httpServerEnabled: "true"
       httpServerPort: "{{ .Values.bookkeeper.ports.http }}"
@@ -340,7 +356,7 @@ spec:
   {{- with .Values.bookkeeper.customization }}
   {{- toYaml . | nindent 2 -}}
   {{- end }}
-  {{- if .Values.zookeeper.customTools.restore.enable}}
+  {{- if and .Values.zookeeper.customTools.restore.enable (include "pulsar.metadata.isZookeeper" .) }}
     - match:
         groupVersionKinds:
           - kind: Job

--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -30,8 +30,14 @@ spec:
 {{- if not .Values.initialize }}
   initialized: true
 {{- end }}
+{{- if include "pulsar.metadata.isOxia" . }}
+  metadataStoreUrl: "{{ template "pulsar.oxia.metadata.url" . }}"
+  configurationMetadataStoreUrl: "{{ template "pulsar.oxia.metadata.url" . }}"
+  bkMetadataServiceUri: "{{ template "pulsar.oxia.bookkeeper.metadataServiceUri" . }}"
+{{- else }}
   zkServers: "{{ template "pulsar.zookeeper.connect" . }}{{ .Values.metadataPrefix }}"
   configurationStoreServers: "{{ template "pulsar.configurationStore.connect" . }}{{ .Values.metadataPrefix }}"
+{{- end }}
 {{- if not .Values.broker.autoScaling.enabled }}
   replicas: {{ .Values.broker.replicaCount }}
 {{- end }}
@@ -171,13 +177,14 @@ spec:
     certSecretName: "{{ template "pulsar.broker.tls.secret.name" . }}"
     trustCertsEnabled: {{ .Values.tls.broker.trustCertsEnabled }}
   {{- end }}
-  {{- if and .Values.istio.enabled .Values.ingress.broker.enabled }}
+  {{- if .Values.istio.enabled }}
   istio:
     enabled: true
     {{- if .Values.istio.migration }}
     mtls:
       mode: permissive
     {{- end }}
+    {{- if .Values.ingress.broker.enabled }}
     gateway:
       selector:
 {{- include "pulsar.istio.gateway.selector" . | indent 8 }}
@@ -190,6 +197,7 @@ spec:
         trustCertsEnabled: {{ .Values.tls.broker.gateway.trustCertsEnabled }}
         mode: "passthrough"
       {{- end }}
+    {{- end }}
   {{- end }}
   {{- if and .Values.broker.pulsarBroker.networking .Values.broker.pulsarBroker.networking.podService .Values.broker.pulsarBroker.networking.podService.enabled }}
   networking:
@@ -224,6 +232,12 @@ spec:
   config:
     {{- if .Values.pulsar_metadata.clusterName }}
     clusterName: {{ .Values.pulsar_metadata.clusterName }}
+    {{- end }}
+    {{- if include "pulsar.metadata.isOxia" . }}
+    oxiaBasedSystemTopic:
+      enabled: true
+      schemaStorageUrl: "{{ template "pulsar.oxia.schema.url" . }}"
+      topicPoliciesServiceClassName: "io.streamnative.pulsar.OxiaTopicPoliciesService"
     {{- end }}
     {{- if .Values.broker.functionmesh.enabled }}
     function:
@@ -323,6 +337,11 @@ spec:
     {{- end }}
     custom:
       PULSAR_PREFIX_additionalServletDirectory: "./brokerAdditionalServlet"
+      {{- if include "pulsar.metadata.isOxia" . }}
+      PULSAR_PREFIX_metadataStoreUrl: "{{ template "pulsar.oxia.metadata.url" . }}"
+      PULSAR_PREFIX_configurationMetadataStoreUrl: "{{ template "pulsar.oxia.metadata.url" . }}"
+      PULSAR_PREFIX_enablePackagesManagement: "false"
+      {{- end }}
 {{- with .Values.broker.configData }}
 {{ toYaml . | indent 6 }}
 {{- end }}

--- a/charts/sn-platform/templates/broker/function-worker-configfile-configmap.yaml
+++ b/charts/sn-platform/templates/broker/function-worker-configfile-configmap.yaml
@@ -65,7 +65,11 @@ data:
     pulsarServiceUrl: {{template "pulsar.function.broker.service.url" . }}
     pulsarWebServiceUrl: {{template "pulsar.function.web.service.url" . }}
     {{- end }}
+    {{- if include "pulsar.metadata.isOxia" . }}
+    configurationMetadataStoreUrl: "{{ template "pulsar.oxia.metadata.url" . }}"
+    {{- else }}
     configurationStoreServers: "{{ template "pulsar.configurationStore.connect" . }}{{ .Values.metadataPrefix }}"
+    {{- end }}
     {{- if .Values.auth.authorization.enabled }}
     authorizationEnabled: "true"
     authorizationProvider: {{ .Values.functions.authorizationProvider }}

--- a/charts/sn-platform/templates/detector/pulsar-detector-deployment.yaml
+++ b/charts/sn-platform/templates/detector/pulsar-detector-deployment.yaml
@@ -56,6 +56,7 @@ spec:
       terminationGracePeriodSeconds: {{ .Values.pulsar_detector.gracePeriod }}
       {{- if not .Values.istio.enabled }}
       initContainers:
+      {{- if include "pulsar.metadata.isZookeeper" . }}
       # This init container will wait for zookeeper to be ready before
       # deploying the bookies
       - name: wait-zookeeper-ready
@@ -73,6 +74,7 @@ spec:
         volumeMounts:
         - name: tmp
           mountPath: /pulsar/logs
+      {{- end }}
       # This init container will wait for at least one broker to be ready before
       # deploying the pulsar-detector
       - name: wait-broker-ready

--- a/charts/sn-platform/templates/extra.yaml
+++ b/charts/sn-platform/templates/extra.yaml
@@ -1,6 +1,7 @@
 #
 # Copyright (c) 2019 - 2024 StreamNative, Inc.. All Rights Reserved.
 #
+{{- include "pulsar.validate.metadata" . }}
 {{- range .Values.extraResources }}
 {{ toYaml . }}
 ---

--- a/charts/sn-platform/templates/openshift/scc-rolebinding.yaml
+++ b/charts/sn-platform/templates/openshift/scc-rolebinding.yaml
@@ -4,7 +4,9 @@
 
 {{- if and .Values.openshift.enabled .Values.openshift.scc.enabled -}}
 {{- $sas := list (include "pulsar.vault.serviceAccount" .) -}}
+{{- if include "pulsar.metadata.isZookeeper" . -}}
 {{- $sas = append $sas (include "pulsar.zookeeper.serviceAccount" .) -}}
+{{- end -}}
 {{- $sas = append $sas (include "pulsar.bookkeeper.serviceAccount" .) -}}
 {{- $sas = append $sas (include "pulsar.broker.serviceAccount" .) -}}
 {{- $sas = append $sas (include "pulsar.proxy.serviceAccount" .) -}}

--- a/charts/sn-platform/templates/oxia/oxia-cluster.yaml
+++ b/charts/sn-platform/templates/oxia/oxia-cluster.yaml
@@ -23,9 +23,6 @@ spec:
   {{- if .Values.istio.enabled }}
   istio:
     enabled: true
-    {{- if .Values.istio.dataplaneMode }}
-    dataplaneMode: {{ .Values.istio.dataplaneMode }}
-    {{- end }}
     {{- if .Values.istio.migration }}
     mtls:
       mode: permissive

--- a/charts/sn-platform/templates/oxia/oxia-cluster.yaml
+++ b/charts/sn-platform/templates/oxia/oxia-cluster.yaml
@@ -8,9 +8,16 @@ kind: OxiaCluster
 metadata:
   name: "{{ template "pulsar.oxia.cluster" . }}"
   namespace: {{ template "pulsar.namespace" . }}
+{{- with .Values.oxia.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
-    component: oxia
+    component: {{ .Values.oxia.component }}
+{{- with .Values.oxia.labels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
 {{- if .Values.components.pulsar_coordinator }}
     k8s.streamnative.io/coordinator-name: "{{ template "pulsar.fullname" . }}-coordinator"
 {{- end }}
@@ -18,8 +25,21 @@ spec:
   image: "{{ .Values.images.oxia.repository }}:{{ .Values.images.oxia.tag }}"
   imagePullPolicy: {{ .Values.images.oxia.pullPolicy }}
   monitoringEnabled: {{ include "pulsar.oxia.podMonitor.enabled" . }}
+  {{- with .Values.oxia.labels }}
+  labels:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+  {{- with .Values.oxia.coordinator.resources }}
+  coordinator:
+    resources:
+{{ toYaml . | indent 6 }}
+  {{- end }}
   server:
-    replicas: 3
+    replicas: {{ .Values.oxia.replicaCount }}
+    {{- with .Values.oxia.resources }}
+    resources:
+{{ toYaml . | indent 6 }}
+    {{- end }}
   {{- if .Values.istio.enabled }}
   istio:
     enabled: true

--- a/charts/sn-platform/templates/oxia/oxia-cluster.yaml
+++ b/charts/sn-platform/templates/oxia/oxia-cluster.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2019 - 2024 StreamNative, Inc.. All Rights Reserved.
+#
+# deploy oxia only when `pulsar_metadata.provider` is oxia
+{{- if include "pulsar.metadata.isOxia" . }}
+apiVersion: k8s.streamnative.io/v1alpha1
+kind: OxiaCluster
+metadata:
+  name: "{{ template "pulsar.oxia.cluster" . }}"
+  namespace: {{ template "pulsar.namespace" . }}
+  labels:
+    {{- include "pulsar.standardLabels" . | nindent 4 }}
+    component: oxia
+{{- if .Values.components.pulsar_coordinator }}
+    k8s.streamnative.io/coordinator-name: "{{ template "pulsar.fullname" . }}-coordinator"
+{{- end }}
+spec:
+  image: "{{ .Values.images.oxia.repository }}:{{ .Values.images.oxia.tag }}"
+  imagePullPolicy: {{ .Values.images.oxia.pullPolicy }}
+  monitoringEnabled: {{ include "pulsar.oxia.podMonitor.enabled" . }}
+  server:
+    replicas: 3
+  {{- if .Values.istio.enabled }}
+  istio:
+    enabled: true
+    {{- if .Values.istio.migration }}
+    mtls:
+      mode: permissive
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/sn-platform/templates/oxia/oxia-cluster.yaml
+++ b/charts/sn-platform/templates/oxia/oxia-cluster.yaml
@@ -3,19 +3,21 @@
 #
 # deploy oxia only when `pulsar_metadata.provider` is oxia
 {{- if include "pulsar.metadata.isOxia" . }}
+{{- $oxia := default dict .Values.oxia }}
+{{- $dataserver := default dict $oxia.dataserver }}
 apiVersion: k8s.streamnative.io/v1alpha1
 kind: OxiaCluster
 metadata:
   name: "{{ template "pulsar.oxia.cluster" . }}"
   namespace: {{ template "pulsar.namespace" . }}
-{{- with .Values.oxia.annotations }}
+{{- with $oxia.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}
 {{- end }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
     component: oxia
-{{- with .Values.oxia.labels }}
+{{- with $oxia.labels }}
 {{ toYaml . | indent 4 }}
 {{- end }}
 {{- if .Values.components.pulsar_coordinator }}
@@ -25,11 +27,11 @@ spec:
   image: "{{ .Values.images.oxia.repository }}:{{ .Values.images.oxia.tag }}"
   imagePullPolicy: {{ .Values.images.oxia.pullPolicy }}
   monitoringEnabled: {{ include "pulsar.oxia.podMonitor.enabled" . }}
-  {{- with .Values.oxia.labels }}
+  {{- with $oxia.labels }}
   labels:
 {{ toYaml . | indent 4 }}
   {{- end }}
-  {{- with .Values.oxia.coordinator }}
+  {{- with $oxia.coordinator }}
   {{- with .resources }}
   coordinator:
     resources:
@@ -37,8 +39,8 @@ spec:
   {{- end }}
   {{- end }}
   server:
-    replicas: {{ .Values.oxia.replicaCount }}
-    {{- with .Values.oxia.resources }}
+    replicas: {{ include "pulsar.oxia.replicaCount" . }}
+    {{- with $dataserver.resources }}
     resources:
 {{ toYaml . | indent 6 }}
     {{- end }}

--- a/charts/sn-platform/templates/oxia/oxia-cluster.yaml
+++ b/charts/sn-platform/templates/oxia/oxia-cluster.yaml
@@ -14,7 +14,7 @@ metadata:
 {{- end }}
   labels:
     {{- include "pulsar.standardLabels" . | nindent 4 }}
-    component: {{ .Values.oxia.component }}
+    component: oxia
 {{- with .Values.oxia.labels }}
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/charts/sn-platform/templates/oxia/oxia-cluster.yaml
+++ b/charts/sn-platform/templates/oxia/oxia-cluster.yaml
@@ -5,6 +5,8 @@
 {{- if include "pulsar.metadata.isOxia" . }}
 {{- $oxia := default dict .Values.oxia }}
 {{- $dataserver := default dict $oxia.dataserver }}
+{{- $oxiaIstio := default dict $oxia.istio }}
+{{- $istioRevision := index (default dict .Values.istio.labels) "istio.io/rev" }}
 apiVersion: k8s.streamnative.io/v1alpha1
 kind: OxiaCluster
 metadata:
@@ -47,9 +49,25 @@ spec:
   {{- if .Values.istio.enabled }}
   istio:
     enabled: true
+    {{- with $istioRevision }}
+    revision: {{ . | quote }}
+    {{- end }}
     {{- if .Values.istio.migration }}
     mtls:
       mode: permissive
+    {{- end }}
+    {{- if $oxiaIstio.authRules }}
+    authRules:
+{{ toYaml $oxiaIstio.authRules | indent 4 }}
+    {{- else }}
+    authRules:
+    - toOperation:
+      - ports:
+        - "6648"
+        - "6649"
+        - "8080"
+        - "6650"
+        - "8081"
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/sn-platform/templates/oxia/oxia-cluster.yaml
+++ b/charts/sn-platform/templates/oxia/oxia-cluster.yaml
@@ -29,10 +29,12 @@ spec:
   labels:
 {{ toYaml . | indent 4 }}
   {{- end }}
-  {{- with .Values.oxia.coordinator.resources }}
+  {{- with .Values.oxia.coordinator }}
+  {{- with .resources }}
   coordinator:
     resources:
 {{ toYaml . | indent 6 }}
+  {{- end }}
   {{- end }}
   server:
     replicas: {{ .Values.oxia.replicaCount }}

--- a/charts/sn-platform/templates/oxia/oxia-cluster.yaml
+++ b/charts/sn-platform/templates/oxia/oxia-cluster.yaml
@@ -23,6 +23,9 @@ spec:
   {{- if .Values.istio.enabled }}
   istio:
     enabled: true
+    {{- if .Values.istio.dataplaneMode }}
+    dataplaneMode: {{ .Values.istio.dataplaneMode }}
+    {{- end }}
     {{- if .Values.istio.migration }}
     mtls:
       mode: permissive

--- a/charts/sn-platform/templates/oxia/oxia-namespace.yaml
+++ b/charts/sn-platform/templates/oxia/oxia-namespace.yaml
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2019 - 2024 StreamNative, Inc.. All Rights Reserved.
+#
+# deploy oxia namespaces only when `pulsar_metadata.provider` is oxia
+{{- if include "pulsar.metadata.isOxia" . }}
+{{- $namespaces := list
+  (dict "name" (include "pulsar.oxia.broker.namespace" .) "type" "broker")
+  (dict "name" (include "pulsar.oxia.bookkeeper.namespace" .) "type" "bookkeeper")
+  (dict "name" (include "pulsar.oxia.schema.namespace" .) "type" "pulsar-schema")
+  (dict "name" (include "pulsar.oxia.function.namespace" .) "type" "function")
+}}
+{{- range $index, $oxiaNamespace := $namespaces }}
+{{- if $index }}
+---
+{{- end }}
+apiVersion: k8s.streamnative.io/v1alpha1
+kind: OxiaNamespace
+metadata:
+  name: "{{ template "pulsar.oxia.cluster" $ }}-{{ $oxiaNamespace.type }}"
+  namespace: {{ template "pulsar.namespace" $ }}
+  labels:
+    {{- include "pulsar.standardLabels" $ | nindent 4 }}
+    component: oxia
+spec:
+  namespaceConfig:
+    name: "{{ $oxiaNamespace.name }}"
+    initialShardCount: 1
+    replicationFactor: 3
+    notificationsEnabled: true
+  clusterRef:
+    name: "{{ template "pulsar.oxia.cluster" $ }}"
+    namespace: {{ template "pulsar.namespace" $ }}
+  ownerRef:
+    name: "{{ template "pulsar.fullname" $ }}"
+    namespace: {{ template "pulsar.namespace" $ }}
+{{- end }}
+{{- end }}

--- a/charts/sn-platform/templates/oxia/oxia-namespace.yaml
+++ b/charts/sn-platform/templates/oxia/oxia-namespace.yaml
@@ -3,12 +3,11 @@
 #
 # deploy oxia namespaces only when `pulsar_metadata.provider` is oxia
 {{- if include "pulsar.metadata.isOxia" . }}
-{{- $namespaces := list
-  (dict "name" (include "pulsar.oxia.broker.namespace" .) "type" "broker")
-  (dict "name" (include "pulsar.oxia.bookkeeper.namespace" .) "type" "bookkeeper")
-  (dict "name" (include "pulsar.oxia.schema.namespace" .) "type" "pulsar-schema")
-  (dict "name" (include "pulsar.oxia.function.namespace" .) "type" "function")
-}}
+{{- $brokerNamespace := dict "name" (include "pulsar.oxia.broker.namespace" .) "type" "broker" }}
+{{- $bookkeeperNamespace := dict "name" (include "pulsar.oxia.bookkeeper.namespace" .) "type" "bookkeeper" }}
+{{- $schemaNamespace := dict "name" (include "pulsar.oxia.schema.namespace" .) "type" "pulsar-schema" }}
+{{- $functionNamespace := dict "name" (include "pulsar.oxia.function.namespace" .) "type" "function" }}
+{{- $namespaces := list $brokerNamespace $bookkeeperNamespace $schemaNamespace $functionNamespace }}
 {{- range $index, $oxiaNamespace := $namespaces }}
 {{- if $index }}
 ---

--- a/charts/sn-platform/templates/prometheus/prometheus-configmap.yaml
+++ b/charts/sn-platform/templates/prometheus/prometheus-configmap.yaml
@@ -57,7 +57,7 @@ data:
           names:
             - {{ template "pulsar.namespace" . }}
 {{- end }}
-{{- if and .Values.istio.enabled (not .Values.istio.mergeMetrics) }}
+{{- if eq (include "pulsar.istio.prometheus.sidecarMTLS" .) "true" }}
 {{- if .Values.istio.migration }}
       scheme: http
       enable_http2: false
@@ -83,6 +83,12 @@ data:
         action: drop
         regex: "{{ .Values.prometheus.component }}|{{ .Values.grafana.component }}|{{ .Values.toolset.component }}|{{ .Values.streamnative_console.component }}"
 {{- end }}
+{{- if include "pulsar.metadata.isOxia" . }}
+      # Oxia has two metrics ports. Dedicated Oxia scrape config below handles both.
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
+        action: drop
+        regex: "{{ template "pulsar.oxia.service" . }}"
+{{- end }}
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true
@@ -100,8 +106,13 @@ data:
       - source_labels: [__meta_kubernetes_namespace]
         action: replace
         target_label: kubernetes_namespace
+      - source_labels: [__meta_kubernetes_pod_label_cloud_streamnative_io_component]
+        action: replace
+        regex: (.+)
+        target_label: job
       - source_labels: [__meta_kubernetes_pod_label_component]
         action: replace
+        regex: (.+)
         target_label: job
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
@@ -110,6 +121,60 @@ data:
 {{- if .Values.prometheus.customRelabelConfigs -}}
 {{- with .Values.prometheus.customRelabelConfigs }}
 {{ toYaml . | indent 6 }}
+{{- end }}
+{{- end }}
+{{- if include "pulsar.metadata.isOxia" . }}
+    - job_name: 'oxia'
+{{- if .Values.prometheus.sampleLimit }}
+      sample_limit: {{ .Values.prometheus.sampleLimit }}
+{{- end }}
+      kubernetes_sd_configs:
+      - role: pod
+{{- if or .Values.istio.enabled (not .Values.prometheus.serviceAccount.clusterRole) }}
+        namespaces:
+          names:
+            - {{ template "pulsar.namespace" . }}
+{{- end }}
+{{- if eq (include "pulsar.istio.prometheus.sidecarMTLS" .) "true" }}
+{{- if .Values.istio.migration }}
+      scheme: http
+      enable_http2: false
+{{- else }}
+      scheme: https
+      # Disable http2 for Prometheus issue: https://github.com/prometheus/prometheus/issues/10213
+      enable_http2: false
+      tls_config:
+        ca_file: /etc/prom-certs/root-cert.pem
+        cert_file: /etc/prom-certs/cert-chain.pem
+        key_file: /etc/prom-certs/key.pem
+        insecure_skip_verify: true
+{{- end }}
+{{- end }}
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
+        action: keep
+        regex: "{{ template "pulsar.oxia.service" . }}"
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+        action: keep
+        regex: oxia-cluster
+      - source_labels: [__meta_kubernetes_pod_container_port_name]
+        action: keep
+        regex: metrics|coord-metrics
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: kubernetes_namespace
+      - target_label: job
+        replacement: oxia
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: kubernetes_pod_name
+      metric_relabel_configs:
+{{- if .Values.prometheus.customRelabelConfigs -}}
+{{- with .Values.prometheus.customRelabelConfigs }}
+{{ toYaml . | indent 6 }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- if and .Values.prometheus.serviceAccount.clusterRole (or (not (hasKey .Values.prometheus.scrape "kubernetesNodes")) (eq .Values.prometheus.scrape.kubernetesNodes true)) }}

--- a/charts/sn-platform/templates/prometheus/prometheus-statefulset.yaml
+++ b/charts/sn-platform/templates/prometheus/prometheus-statefulset.yaml
@@ -37,7 +37,7 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
       annotations:
-        {{- if and .Values.istio.enabled (not .Values.istio.mergeMetrics ) }}
+        {{- if eq (include "pulsar.istio.prometheus.sidecarMTLS" .) "true" }}
         # ref: https://istio.io/latest/docs/ops/integrations/prometheus/#tls-settings
         traffic.sidecar.istio.io/includeOutboundIPRanges: ""  # do not intercept any outbound traffic
         # configure an env variable `OUTPUT_CERTS` to write certificates to the given folder
@@ -158,7 +158,7 @@ spec:
           mountPath: /etc/config
         - name: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}-{{ .Values.prometheus.volumes.data.name }}"
           mountPath: /prometheus
-        {{- if and .Values.istio.enabled (not .Values.istio.mergeMetrics ) }}
+        {{- if eq (include "pulsar.istio.prometheus.sidecarMTLS" .) "true" }}
         - name: istio-certs
           mountPath: /etc/prom-certs/
         {{- end }}
@@ -167,7 +167,7 @@ spec:
       - name: config-volume
         configMap:
           name: "{{ template "pulsar.fullname" . }}-{{ .Values.prometheus.component }}"
-      {{- if and .Values.istio.enabled (not .Values.istio.mergeMetrics ) }}
+      {{- if eq (include "pulsar.istio.prometheus.sidecarMTLS" .) "true" }}
       - emptyDir:
           medium: Memory
         name: istio-certs

--- a/charts/sn-platform/templates/zookeeper/gen-zk-conf.yaml
+++ b/charts/sn-platform/templates/zookeeper/gen-zk-conf.yaml
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2019 - 2024 StreamNative, Inc.. All Rights Reserved.
 #
-
+{{- if include "pulsar.metadata.isZookeeper" . }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -66,3 +66,4 @@ data:
             echo $MY_ID > $DATA_DIR/myid
         fi
     fi
+{{- end }}

--- a/charts/sn-platform/templates/zookeeper/zookeeper-authorizationpolicy.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-authorizationpolicy.yaml
@@ -2,7 +2,7 @@
 # Copyright (c) 2019 - 2024 StreamNative, Inc.. All Rights Reserved.
 #
 
-{{- if and .Values.components.zookeeper .Values.istio.enabled }}
+{{- if and .Values.components.zookeeper .Values.istio.enabled (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:

--- a/charts/sn-platform/templates/zookeeper/zookeeper-backup-clusterrolebinding.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-backup-clusterrolebinding.yaml
@@ -3,7 +3,7 @@
 #
 
 {{- if .Values.zookeeper.customTools.serviceAccount.clusterRole }}
-{{- if and .Values.zookeeper.customTools.backup.enable .Values.zookeeper.customTools.serviceAccount.create }}
+{{- if and .Values.zookeeper.customTools.backup.enable .Values.zookeeper.customTools.serviceAccount.create (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/sn-platform/templates/zookeeper/zookeeper-backup-configmap.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-backup-configmap.yaml
@@ -3,7 +3,7 @@
 #
 
 # deploy zookeeper only when `zookeeper.customTools.backup.enable` is true
-{{- if .Values.zookeeper.customTools.backup.enable }}
+{{- if and .Values.zookeeper.customTools.backup.enable (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/sn-platform/templates/zookeeper/zookeeper-backup-rolebinding.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-backup-rolebinding.yaml
@@ -3,7 +3,7 @@
 #
 
 {{- if not .Values.zookeeper.customTools.serviceAccount.clusterRole }}
-{{- if and .Values.zookeeper.customTools.backup.enable .Values.zookeeper.customTools.serviceAccount.create }}
+{{- if and .Values.zookeeper.customTools.backup.enable .Values.zookeeper.customTools.serviceAccount.create (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/sn-platform/templates/zookeeper/zookeeper-backup-service.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-backup-service.yaml
@@ -3,7 +3,7 @@
 #
 
 # deploy zookeeper only when `zookeeper.customTools.backup.enable` is true
-{{- if .Values.zookeeper.customTools.backup.enable }}
+{{- if and .Values.zookeeper.customTools.backup.enable (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/sn-platform/templates/zookeeper/zookeeper-backup-serviceaccount.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-backup-serviceaccount.yaml
@@ -2,7 +2,7 @@
 # Copyright (c) 2019 - 2024 StreamNative, Inc.. All Rights Reserved.
 #
 
-{{- if .Values.zookeeper.customTools.serviceAccount.create }}
+{{- if and .Values.zookeeper.customTools.serviceAccount.create (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sn-platform/templates/zookeeper/zookeeper-backup-statefulset.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-backup-statefulset.yaml
@@ -3,7 +3,7 @@
 #
 
 # deploy zookeeper only when `zookeeper.customTools.backup.enable` is true
-{{- if .Values.zookeeper.customTools.backup.enable }}
+{{- if and .Values.zookeeper.customTools.backup.enable (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-cluster.yaml
@@ -2,7 +2,7 @@
 # Copyright (c) 2019 - 2024 StreamNative, Inc.. All Rights Reserved.
 #
 # deploy zookeeper only when `components.zookeeper` is true
-{{- if .Values.components.zookeeper }}
+{{- if and .Values.components.zookeeper (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: zookeeper.streamnative.io/v1alpha1
 kind: ZooKeeperCluster
 metadata:

--- a/charts/sn-platform/templates/zookeeper/zookeeper-restore-clusterrolebinding.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-restore-clusterrolebinding.yaml
@@ -3,7 +3,7 @@
 #
 
 {{- if .Values.zookeeper.customTools.serviceAccount.clusterRole }}
-{{- if and .Values.zookeeper.customTools.restore.enable .Values.zookeeper.customTools.serviceAccount.create }}
+{{- if and .Values.zookeeper.customTools.restore.enable .Values.zookeeper.customTools.serviceAccount.create (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/sn-platform/templates/zookeeper/zookeeper-restore-configmap.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-restore-configmap.yaml
@@ -3,7 +3,7 @@
 #
 
 # deploy zookeeper only when `zookeeper.customTools.restore.enable` is true
-{{- if .Values.zookeeper.customTools.restore.enable }}
+{{- if and .Values.zookeeper.customTools.restore.enable (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/sn-platform/templates/zookeeper/zookeeper-restore-rolebinding.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-restore-rolebinding.yaml
@@ -3,7 +3,7 @@
 #
 
 {{- if not .Values.zookeeper.customTools.serviceAccount.clusterRole }}
-{{- if and .Values.zookeeper.customTools.restore.enable .Values.zookeeper.customTools.serviceAccount.create }}
+{{- if and .Values.zookeeper.customTools.restore.enable .Values.zookeeper.customTools.serviceAccount.create (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/sn-platform/templates/zookeeper/zookeeper-restore-serviceaccount.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-restore-serviceaccount.yaml
@@ -2,7 +2,7 @@
 # Copyright (c) 2019 - 2024 StreamNative, Inc.. All Rights Reserved.
 #
 
-{{- if .Values.zookeeper.customTools.serviceAccount.create }}
+{{- if and .Values.zookeeper.customTools.serviceAccount.create (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sn-platform/templates/zookeeper/zookeeper-service-account.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-service-account.yaml
@@ -2,7 +2,7 @@
 # Copyright (c) 2019 - 2024 StreamNative, Inc.. All Rights Reserved.
 #
 
-{{- if and .Values.components.zookeeper .Values.zookeeper.serviceAccount.create }}
+{{- if and .Values.components.zookeeper .Values.zookeeper.serviceAccount.create (include "pulsar.metadata.isZookeeper" .) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/sn-platform/templates/zookeeper/zookeeper-storageclass.yaml
+++ b/charts/sn-platform/templates/zookeeper/zookeeper-storageclass.yaml
@@ -3,7 +3,7 @@
 #
 
 # deploy zookeeper only when `components.zookeeper` is true
-{{- if .Values.components.zookeeper }}
+{{- if and .Values.components.zookeeper (include "pulsar.metadata.isZookeeper" .) }}
 {{- if and .Values.volumes.persistence .Values.zookeeper.volumes.persistence }}
 
 # define the storage class for data directory

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1209,6 +1209,22 @@ pulsar_metadata:
   #
   # configurationStoreServers: "zk04:2181,zk05:2181,zk06:2181"
 
+## Oxia metadata store.
+## Used only when pulsar_metadata.provider is oxia.
+oxia:
+  component: oxia
+  # The number of Oxia server replicas to run. Must be at least 3 for Oxia metadata deployments.
+  replicaCount: 3
+  # Labels added to the OxiaCluster CR and propagated to generated Oxia resources.
+  labels: {}
+  # Annotations added to the OxiaCluster CR.
+  annotations: {}
+  # Resources requests/limits for Oxia server containers.
+  resources: {}
+  coordinator:
+    # Resources requests/limits for Oxia coordinator containers.
+    resources: {}
+
 ## deprecated: move to broker.kop
 # kop:
 #   ports:

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1234,6 +1234,15 @@ pulsar_metadata:
   #     limits:
   #       cpu: "1"
   #       memory: "1Gi"
+  # istio:
+  #   authRules:
+  #   - toOperation:
+  #     - ports:
+  #       - "6648"
+  #       - "6649"
+  #       - "8080"
+  #       - "6650"
+  #       - "8081"
 
 ## deprecated: move to broker.kop
 # kop:

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -132,6 +132,10 @@ images:
         repository: "streamnative/pulsar-metadata-tool"
         tag: "3.3.3.3"
         pullPolicy: IfNotPresent
+  oxia:
+    repository: oxia/oxia
+    tag: "0.16.4"
+    pullPolicy: IfNotPresent
   bookie:
     repository: streamnative/sn-platform
     tag: "3.3.3.3"
@@ -1189,6 +1193,8 @@ autorecovery:
 ## metadata deployed
 pulsar_metadata:
   component: pulsar-init
+  # metadata provider. Valid values: zookeeper, oxia
+  provider: zookeeper
   # set the cluster name. if empty or not specified,
   # it will use helm release name to generate a cluster name.
   clusterName: ""

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -134,7 +134,7 @@ images:
         pullPolicy: IfNotPresent
   oxia:
     repository: oxia/oxia
-    tag: "0.16.4"
+    tag: "0.16.6"
     pullPolicy: IfNotPresent
   bookie:
     repository: streamnative/sn-platform
@@ -1213,20 +1213,27 @@ pulsar_metadata:
 ## Used only when pulsar_metadata.provider is oxia.
 oxia:
   # The number of Oxia server replicas to run. Must be at least 3 for Oxia metadata deployments.
-  replicaCount: 3
+  # replicaCount: 3
   # labels:
   #   example: value
   # annotations:
   #   example: value
-  # resources:
-  #   requests:
-  #     cpu: "0.5"
-  #     memory: "1Gi"
+  # dataserver:
+  #   resources:
+  #     requests:
+  #       cpu: "0.5"
+  #       memory: "1Gi"
+  #     limits:
+  #       cpu: "2"
+  #       memory: "4Gi"
   # coordinator:
   #   resources:
   #     requests:
   #       cpu: "0.25"
   #       memory: "512Mi"
+  #     limits:
+  #       cpu: "1"
+  #       memory: "1Gi"
 
 ## deprecated: move to broker.kop
 # kop:

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1214,15 +1214,19 @@ pulsar_metadata:
 oxia:
   # The number of Oxia server replicas to run. Must be at least 3 for Oxia metadata deployments.
   replicaCount: 3
-  # Labels added to the OxiaCluster CR and propagated to generated Oxia resources.
-  labels: {}
-  # Annotations added to the OxiaCluster CR.
-  annotations: {}
-  # Resources requests/limits for Oxia server containers.
-  resources: {}
-  coordinator:
-    # Resources requests/limits for Oxia coordinator containers.
-    resources: {}
+  # labels:
+  #   example: value
+  # annotations:
+  #   example: value
+  # resources:
+  #   requests:
+  #     cpu: "0.5"
+  #     memory: "1Gi"
+  # coordinator:
+  #   resources:
+  #     requests:
+  #       cpu: "0.25"
+  #       memory: "512Mi"
 
 ## deprecated: move to broker.kop
 # kop:

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -2930,6 +2930,11 @@ istio:
   # mergeMetrics should be enabled if you want to scrape pulsar metrics from an external prometheus not running on Istio
   # prometheus and grafana will not be Istio injected if mergeMetrics is enabled
   mergeMetrics: false
+  # Istio data plane mode: "sidecar" or "ambient"
+  # - sidecar: Traditional per-pod sidecars (default if empty)
+  # - ambient: Sidecar-less data plane using ztunnel for L4 mTLS
+  # Leave empty for default behavior (sidecar mode)
+  dataplaneMode: ""
   gateway:
     # gateway selector if it's not `istio: ingressgateway`
     selector: {}

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -2930,11 +2930,6 @@ istio:
   # mergeMetrics should be enabled if you want to scrape pulsar metrics from an external prometheus not running on Istio
   # prometheus and grafana will not be Istio injected if mergeMetrics is enabled
   mergeMetrics: false
-  # Istio data plane mode: "sidecar" or "ambient"
-  # - sidecar: Traditional per-pod sidecars (default if empty)
-  # - ambient: Sidecar-less data plane using ztunnel for L4 mTLS
-  # Leave empty for default behavior (sidecar mode)
-  dataplaneMode: ""
   gateway:
     # gateway selector if it's not `istio: ingressgateway`
     selector: {}

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1212,7 +1212,6 @@ pulsar_metadata:
 ## Oxia metadata store.
 ## Used only when pulsar_metadata.provider is oxia.
 oxia:
-  component: oxia
   # The number of Oxia server replicas to run. Must be at least 3 for Oxia metadata deployments.
   replicaCount: 3
   # Labels added to the OxiaCluster CR and propagated to generated Oxia resources.

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -118,19 +118,19 @@ monitoring:
 images:
   coordinator:
     repository: streamnative/sn-platform-slim
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
   zookeeper:
     repository: streamnative/sn-platform
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
     customTools:
       backup:
         repository: "streamnative/pulsar-metadata-tool"
-        tag: "4.2.1.1"
+        tag: "3.3.3.3"
         pullPolicy: IfNotPresent
       restore:
         repository: "streamnative/pulsar-metadata-tool"
-        tag: "4.2.1.1"
+        tag: "3.3.3.3"
         pullPolicy: IfNotPresent
   oxia:
     repository: oxia/oxia
@@ -138,11 +138,11 @@ images:
     pullPolicy: IfNotPresent
   bookie:
     repository: streamnative/sn-platform
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   presto:
     repository: streamnative/sn-platform
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
     exporter:
       repository: bitnami/jmx-exporter
@@ -151,36 +151,36 @@ images:
   # NOTE: allow overriding the presto worker image
   # presto_worker:
   #   repository: streamnative/sn-platform
-  #   tag: 4.2.1.1
+  #   tag: 3.3.3.3
   #   pullPolicy: IfNotPresent
   autorecovery:
     repository: streamnative/sn-platform
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   broker:
     repository: streamnative/sn-platform
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   proxy:
     repository: streamnative/sn-platform
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   pulsar_detector:
     repository: streamnative/sn-platform
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   functions:
     repository: streamnative/sn-platform
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   function_worker:
     repository: streamnative/sn-platform
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   # NOTE: allow overriding the toolset image
   toolset:
     repository: streamnative/sn-platform
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
     kafka:
       repository: bitnami/kafka
@@ -242,7 +242,7 @@ images:
     pullPolicy: IfNotPresent
   pulsar_metadata:
     repository: streamnative/sn-platform
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   configmapReload:
     repository: jimmidyson/configmap-reload

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -118,19 +118,19 @@ monitoring:
 images:
   coordinator:
     repository: streamnative/sn-platform-slim
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
   zookeeper:
     repository: streamnative/sn-platform
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
     customTools:
       backup:
         repository: "streamnative/pulsar-metadata-tool"
-        tag: "3.3.3.3"
+        tag: "4.2.1.1"
         pullPolicy: IfNotPresent
       restore:
         repository: "streamnative/pulsar-metadata-tool"
-        tag: "3.3.3.3"
+        tag: "4.2.1.1"
         pullPolicy: IfNotPresent
   oxia:
     repository: oxia/oxia
@@ -138,11 +138,11 @@ images:
     pullPolicy: IfNotPresent
   bookie:
     repository: streamnative/sn-platform
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   presto:
     repository: streamnative/sn-platform
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
     exporter:
       repository: bitnami/jmx-exporter
@@ -151,36 +151,36 @@ images:
   # NOTE: allow overriding the presto worker image
   # presto_worker:
   #   repository: streamnative/sn-platform
-  #   tag: 3.3.3.3
+  #   tag: 4.2.1.1
   #   pullPolicy: IfNotPresent
   autorecovery:
     repository: streamnative/sn-platform
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   broker:
     repository: streamnative/sn-platform
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   proxy:
     repository: streamnative/sn-platform
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   pulsar_detector:
     repository: streamnative/sn-platform
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   functions:
     repository: streamnative/sn-platform
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   function_worker:
     repository: streamnative/sn-platform
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   # NOTE: allow overriding the toolset image
   toolset:
     repository: streamnative/sn-platform
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
     kafka:
       repository: bitnami/kafka
@@ -242,7 +242,7 @@ images:
     pullPolicy: IfNotPresent
   pulsar_metadata:
     repository: streamnative/sn-platform
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   configmapReload:
     repository: jimmidyson/configmap-reload

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1234,15 +1234,6 @@ pulsar_metadata:
   #     limits:
   #       cpu: "1"
   #       memory: "1Gi"
-  # istio:
-  #   authRules:
-  #   - toOperation:
-  #     - ports:
-  #       - "6648"
-  #       - "6649"
-  #       - "8080"
-  #       - "6650"
-  #       - "8081"
 
 ## deprecated: move to broker.kop
 # kop:

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1211,7 +1211,7 @@ pulsar_metadata:
 
 ## Oxia metadata store.
 ## Used only when pulsar_metadata.provider is oxia.
-oxia:
+# oxia:
   # The number of Oxia server replicas to run. Must be at least 3 for Oxia metadata deployments.
   # replicaCount: 3
   # labels:

--- a/examples/sn-platform/values-oxia.yaml
+++ b/examples/sn-platform/values-oxia.yaml
@@ -1,0 +1,3 @@
+# Use an in-cluster Oxia metadata store instead of ZooKeeper.
+pulsar_metadata:
+  provider: oxia


### PR DESCRIPTION
## Motivation
- Support Oxia as an in-cluster metadata provider for sn-platform and sn-platform-slim without requiring users to configure service addresses manually.
- Keep ZooKeeper as the default metadata provider and preserve existing ZooKeeper compatibility.
- Ensure bundled Prometheus can scrape both Oxia dataserver and coordinator metrics without requiring Prometheus Operator.

## Modifications
- Added `pulsar_metadata.provider` support for `zookeeper` and `oxia`, with validation for ZooKeeper-only fields.
- Added OxiaCluster and OxiaNamespace templates using Oxia 0.16.6 and split namespaces for broker, bookkeeper, pulsar-schema, and function.
- Added optional `oxia` chart values for custom labels, annotations, server replica count, dataserver resources, and coordinator resources.
- Wired broker, BookKeeper, schema storage, and function-worker config to use Oxia metadata URLs when provider is Oxia.
- Gated ZooKeeper resources so they are not rendered for Oxia metadata deployments.
- Added bundled Prometheus scrape config `job_name: oxia` that scrapes both `metrics` and `coord-metrics` ports.
- Gated Oxia `monitoringEnabled` on the availability of the PodMonitor API so sn-operator only creates PodMonitor when Prometheus Operator CRDs exist.

## Documentation
- No standalone docs page is required for this PR. The user-facing chart knobs are documented in the chart `values.yaml`, and `examples/sn-platform/values-oxia.yaml` shows the minimal Oxia enablement path.

## Testing
- `helm lint charts/sn-platform-slim -f examples/sn-platform/values-oxia.yaml --set istio.enabled=true --set monitoring.prometheus=true --set monitoring.grafana=false`
- `helm lint charts/sn-platform -f examples/sn-platform/values-oxia.yaml --set istio.enabled=true --set monitoring.prometheus=true --set monitoring.grafana=false`
- `helm lint` for the sn-platform and sn-platform-slim CI values.
- `helm template` for both chart variants with Oxia values.
- Rendered OxiaCluster overrides for labels, annotations, replicas, dataserver resources, and coordinator resources.
- Verified `oxia.replicaCount < 3` fails template validation for Oxia metadata deployments.
- Local kind deployment with sn-operator v0.18.10, Istio ambient, no proxy, Oxia 0.16.4, and bundled Prometheus.
- Verified Pulsar producer/consumer smoke test through a perf pod.
- Verified bundled Prometheus ingests `oxia_dataserver_*` and `oxia_coordinator_*` series under `job=oxia`.
- Final chart review after the Oxia 0.16.6 default image bump: helm lint and helm template passed for both chart variants, including minimal Oxia values and explicit dataserver/coordinator resource overrides.
