### PR TITLE
chore: bump default Oxia image to 0.16.7

### DIFF
--- a/charts/sn-platform-slim/values.yaml
+++ b/charts/sn-platform-slim/values.yaml
@@ -124,7 +124,7 @@ images:
         pullPolicy: IfNotPresent
   oxia:
     repository: oxia/oxia
-    tag: "0.16.6"
+    tag: "0.16.7"
     pullPolicy: IfNotPresent
   bookie:
     repository: streamnative/sn-platform-slim

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -134,7 +134,7 @@ images:
         pullPolicy: IfNotPresent
   oxia:
     repository: oxia/oxia
-    tag: "0.16.6"
+    tag: "0.16.7"
     pullPolicy: IfNotPresent
   bookie:
     repository: streamnative/sn-platform


### PR DESCRIPTION
## Motivation
- Update the default Oxia image used by the platform charts to the requested 0.16.7 release.

## Modifications
- Bumped `images.oxia.tag` from `0.16.6` to `0.16.7` in `sn-platform`.
- Bumped `images.oxia.tag` from `0.16.6` to `0.16.7` in `sn-platform-slim`.

## Testing
- Parsed both chart values files with Ruby YAML loader and verified `images.oxia.tag` is `0.16.7`.
- Verified no remaining `0.16.6` chart defaults with `rg`.
- Ran `git diff --check`.
