### PR TITLE
feat: split KoP schema registry namespace

### DIFF
--- a/charts/sn-platform-slim/templates/_helpers.tpl
+++ b/charts/sn-platform-slim/templates/_helpers.tpl
@@ -228,6 +228,10 @@ bookkeeper
 pulsar-schema
 {{- end -}}
 
+{{- define "pulsar.oxia.kafkaSchema.namespace" -}}
+kafka-schema
+{{- end -}}
+
 {{- define "pulsar.oxia.function.namespace" -}}
 function
 {{- end -}}
@@ -242,6 +246,10 @@ oxia://{{ template "pulsar.oxia.service.address" . }}/{{ template "pulsar.oxia.b
 
 {{- define "pulsar.oxia.schema.url" -}}
 oxia://{{ template "pulsar.oxia.service.address" . }}/{{ template "pulsar.oxia.schema.namespace" . }}
+{{- end -}}
+
+{{- define "pulsar.oxia.kafkaSchema.url" -}}
+oxia://{{ template "pulsar.oxia.service.address" . }}/{{ template "pulsar.oxia.kafkaSchema.namespace" . }}
 {{- end -}}
 
 {{- define "pulsar.oxia.metadata.url" -}}

--- a/charts/sn-platform-slim/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform-slim/templates/broker/broker-cluster.yaml
@@ -232,12 +232,6 @@ spec:
     {{- if .Values.pulsar_metadata.clusterName }}
     clusterName: {{ .Values.pulsar_metadata.clusterName }}
     {{- end }}
-    {{- if include "pulsar.metadata.isOxia" . }}
-    oxiaBasedSystemTopic:
-      enabled: true
-      schemaStorageUrl: "{{ template "pulsar.oxia.schema.url" . }}"
-      topicPoliciesServiceClassName: "io.streamnative.pulsar.OxiaTopicPoliciesService"
-    {{- end }}
     {{- if .Values.broker.functionmesh.enabled }}
     function:
       enabled: true
@@ -340,6 +334,12 @@ spec:
       PULSAR_PREFIX_metadataStoreUrl: "{{ template "pulsar.oxia.metadata.url" . }}"
       PULSAR_PREFIX_configurationMetadataStoreUrl: "{{ template "pulsar.oxia.metadata.url" . }}"
       PULSAR_PREFIX_enablePackagesManagement: "false"
+      PULSAR_PREFIX_kafkaGroupOffsetsStoreInMetadata: "true"
+      PULSAR_PREFIX_kafkaProducerStateStoreInMetadata: "true"
+      PULSAR_PREFIX_kafkaSchemaRegistryStoreInOxia: "true"
+      PULSAR_PREFIX_oxiaSchemaStorageUrl: "{{ template "pulsar.oxia.schema.url" . }}"
+      PULSAR_PREFIX_oxiaSchemaRegistryUrl: "{{ template "pulsar.oxia.kafkaSchema.url" . }}"
+      PULSAR_PREFIX_topicPoliciesServiceClassName: "io.streamnative.pulsar.OxiaTopicPoliciesService"
       {{- end }}
 {{- with .Values.broker.configData }}
 {{ toYaml . | indent 6 }}

--- a/charts/sn-platform-slim/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform-slim/templates/broker/broker-cluster.yaml
@@ -328,6 +328,9 @@ spec:
     {{- end }}
 
     {{- end }}
+    {{- if include "pulsar.metadata.isOxia" . }}
+    useStorageCatalog: true
+    {{- end }}
     custom:
       PULSAR_PREFIX_additionalServletDirectory: "./brokerAdditionalServlet"
       {{- if include "pulsar.metadata.isOxia" . }}
@@ -337,8 +340,12 @@ spec:
       PULSAR_PREFIX_kafkaGroupOffsetsStoreInMetadata: "true"
       PULSAR_PREFIX_kafkaProducerStateStoreInMetadata: "true"
       PULSAR_PREFIX_kafkaSchemaRegistryStoreInOxia: "true"
-      PULSAR_PREFIX_oxiaSchemaStorageUrl: "{{ template "pulsar.oxia.schema.url" . }}"
+      {{- $oxia := default dict .Values.oxia }}
+      {{- $storageCatalog := default dict $oxia.storageCatalog }}
+      PULSAR_PREFIX_oxiaSchemaStorageUrl: {{ default (include "pulsar.oxia.schema.url" .) $storageCatalog.schemaStorageUrl | quote }}
       PULSAR_PREFIX_oxiaSchemaRegistryUrl: "{{ template "pulsar.oxia.kafkaSchema.url" . }}"
+      PULSAR_PREFIX_schemaRegistryUrl: {{ default (include "pulsar.oxia.kafkaSchema.url" .) $storageCatalog.schemaRegistryUrl | quote }}
+      PULSAR_PREFIX_schemaRegistryStorageClassName: {{ default "io.streamnative.pulsar.schema.OxiaSchemaStorageFactory" $storageCatalog.schemaRegistryStorageClassName | quote }}
       PULSAR_PREFIX_topicPoliciesServiceClassName: "io.streamnative.pulsar.OxiaTopicPoliciesService"
       {{- end }}
 {{- with .Values.broker.configData }}

--- a/charts/sn-platform-slim/templates/oxia/oxia-namespace.yaml
+++ b/charts/sn-platform-slim/templates/oxia/oxia-namespace.yaml
@@ -6,8 +6,9 @@
 {{- $brokerNamespace := dict "name" (include "pulsar.oxia.broker.namespace" .) "type" "broker" }}
 {{- $bookkeeperNamespace := dict "name" (include "pulsar.oxia.bookkeeper.namespace" .) "type" "bookkeeper" }}
 {{- $schemaNamespace := dict "name" (include "pulsar.oxia.schema.namespace" .) "type" "pulsar-schema" }}
+{{- $kafkaSchemaNamespace := dict "name" (include "pulsar.oxia.kafkaSchema.namespace" .) "type" "kafka-schema" }}
 {{- $functionNamespace := dict "name" (include "pulsar.oxia.function.namespace" .) "type" "function" }}
-{{- $namespaces := list $brokerNamespace $bookkeeperNamespace $schemaNamespace $functionNamespace }}
+{{- $namespaces := list $brokerNamespace $bookkeeperNamespace $schemaNamespace $kafkaSchemaNamespace $functionNamespace }}
 {{- range $index, $oxiaNamespace := $namespaces }}
 {{- if $index }}
 ---

--- a/charts/sn-platform-slim/templates/oxia/storage-catalog.yaml
+++ b/charts/sn-platform-slim/templates/oxia/storage-catalog.yaml
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2019 - 2024 StreamNative, Inc.. All Rights Reserved.
+#
+# deploy StorageCatalog only when `pulsar_metadata.provider` is oxia
+{{- if and .Values.components.broker (include "pulsar.metadata.isOxia" .) }}
+{{- $oxia := default dict .Values.oxia }}
+{{- $storageCatalog := default dict $oxia.storageCatalog }}
+apiVersion: k8s.streamnative.io/v1alpha1
+kind: StorageCatalog
+metadata:
+  name: "{{ template "pulsar.fullname" . }}"
+  namespace: {{ template "pulsar.namespace" . }}
+  labels:
+    {{- include "pulsar.standardLabels" . | nindent 4 }}
+    component: broker
+spec:
+  oxiaMetadataServiceUrl: {{ default (include "pulsar.oxia.metadata.url" .) $storageCatalog.oxiaMetadataServiceUrl | quote }}
+  schemaStorageUrl: {{ default (include "pulsar.oxia.schema.url" .) $storageCatalog.schemaStorageUrl | quote }}
+  schemaRegistryUrl: {{ default (include "pulsar.oxia.kafkaSchema.url" .) $storageCatalog.schemaRegistryUrl | quote }}
+  schemaRegistryStorageClassName: {{ default "io.streamnative.pulsar.schema.OxiaSchemaStorageFactory" $storageCatalog.schemaRegistryStorageClassName | quote }}
+  {{- with $storageCatalog.storageUrl }}
+  storageUrl: {{ . | quote }}
+  {{- end }}
+  {{- with $storageCatalog.backendStorageType }}
+  backendStorageType: {{ . | quote }}
+  {{- end }}
+  {{- with $storageCatalog.bucket }}
+  bucket: {{ . | quote }}
+  {{- end }}
+  {{- with $storageCatalog.prefix }}
+  prefix: {{ . | quote }}
+  {{- end }}
+  {{- with $storageCatalog.region }}
+  region: {{ . | quote }}
+  {{- end }}
+  {{- if hasKey $storageCatalog "useOwnStorage" }}
+  useOwnStorage: {{ $storageCatalog.useOwnStorage }}
+  {{- end }}
+{{- end }}

--- a/charts/sn-platform-slim/values.yaml
+++ b/charts/sn-platform-slim/values.yaml
@@ -1159,18 +1159,6 @@ pulsar_metadata:
   #     limits:
   #       cpu: "1"
   #       memory: "1Gi"
-  # storageCatalog:
-  #   oxiaMetadataServiceUrl: ""
-  #   schemaStorageUrl: ""
-  #   schemaRegistryUrl: ""
-  #   schemaRegistryStorageClassName: io.streamnative.pulsar.schema.OxiaSchemaStorageFactory
-  #   storageUrl: ""
-  #   backendStorageType: S3
-  #   bucket: ""
-  #   prefix: ""
-  #   region: ""
-  #   useOwnStorage: false
-
 ## deprecated: move to broker.kop
 # kop:
 #   ports:

--- a/charts/sn-platform-slim/values.yaml
+++ b/charts/sn-platform-slim/values.yaml
@@ -108,19 +108,19 @@ monitoring:
 images:
   coordinator:
     repository: streamnative/sn-platform-slim
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
   zookeeper:
     repository: streamnative/sn-platform-slim
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
     customTools:
       backup:
         repository: "streamnative/pulsar-metadata-tool"
-        tag: "3.3.3.3"
+        tag: "4.2.1.1"
         pullPolicy: IfNotPresent
       restore:
         repository: "streamnative/pulsar-metadata-tool"
-        tag: "3.3.3.3"
+        tag: "4.2.1.1"
         pullPolicy: IfNotPresent
   oxia:
     repository: oxia/oxia
@@ -128,36 +128,36 @@ images:
     pullPolicy: IfNotPresent
   bookie:
     repository: streamnative/sn-platform-slim
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   autorecovery:
     repository: streamnative/sn-platform-slim
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   broker:
     repository: streamnative/sn-platform-slim
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   proxy:
     repository: streamnative/sn-platform-slim
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   pulsar_detector:
     repository: streamnative/sn-platform-slim
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   functions:
     repository: streamnative/sn-platform-slim
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   function_worker:
     repository: streamnative/sn-platform-slim
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   # NOTE: allow overriding the toolset image
   toolset:
     repository: streamnative/sn-platform-slim
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
     # deprecated: use images.busybox instead
     busybox:
@@ -196,7 +196,7 @@ images:
     pullPolicy: "IfNotPresent"
   pulsar_metadata:
     repository: streamnative/sn-platform-slim
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   configmapReload:
     repository: jimmidyson/configmap-reload
@@ -1159,6 +1159,17 @@ pulsar_metadata:
   #     limits:
   #       cpu: "1"
   #       memory: "1Gi"
+  # storageCatalog:
+  #   oxiaMetadataServiceUrl: ""
+  #   schemaStorageUrl: ""
+  #   schemaRegistryUrl: ""
+  #   schemaRegistryStorageClassName: io.streamnative.pulsar.schema.OxiaSchemaStorageFactory
+  #   storageUrl: ""
+  #   backendStorageType: S3
+  #   bucket: ""
+  #   prefix: ""
+  #   region: ""
+  #   useOwnStorage: false
 
 ## deprecated: move to broker.kop
 # kop:

--- a/charts/sn-platform-slim/values.yaml
+++ b/charts/sn-platform-slim/values.yaml
@@ -108,19 +108,19 @@ monitoring:
 images:
   coordinator:
     repository: streamnative/sn-platform-slim
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
   zookeeper:
     repository: streamnative/sn-platform-slim
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
     customTools:
       backup:
         repository: "streamnative/pulsar-metadata-tool"
-        tag: "4.2.1.1"
+        tag: "3.3.3.3"
         pullPolicy: IfNotPresent
       restore:
         repository: "streamnative/pulsar-metadata-tool"
-        tag: "4.2.1.1"
+        tag: "3.3.3.3"
         pullPolicy: IfNotPresent
   oxia:
     repository: oxia/oxia
@@ -128,36 +128,36 @@ images:
     pullPolicy: IfNotPresent
   bookie:
     repository: streamnative/sn-platform-slim
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   autorecovery:
     repository: streamnative/sn-platform-slim
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   broker:
     repository: streamnative/sn-platform-slim
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   proxy:
     repository: streamnative/sn-platform-slim
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   pulsar_detector:
     repository: streamnative/sn-platform-slim
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   functions:
     repository: streamnative/sn-platform-slim
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   function_worker:
     repository: streamnative/sn-platform-slim
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   # NOTE: allow overriding the toolset image
   toolset:
     repository: streamnative/sn-platform-slim
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
     # deprecated: use images.busybox instead
     busybox:
@@ -196,7 +196,7 @@ images:
     pullPolicy: "IfNotPresent"
   pulsar_metadata:
     repository: streamnative/sn-platform-slim
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   configmapReload:
     repository: jimmidyson/configmap-reload

--- a/charts/sn-platform/templates/_helpers.tpl
+++ b/charts/sn-platform/templates/_helpers.tpl
@@ -226,6 +226,10 @@ bookkeeper
 pulsar-schema
 {{- end -}}
 
+{{- define "pulsar.oxia.kafkaSchema.namespace" -}}
+kafka-schema
+{{- end -}}
+
 {{- define "pulsar.oxia.function.namespace" -}}
 function
 {{- end -}}
@@ -240,6 +244,10 @@ oxia://{{ template "pulsar.oxia.service.address" . }}/{{ template "pulsar.oxia.b
 
 {{- define "pulsar.oxia.schema.url" -}}
 oxia://{{ template "pulsar.oxia.service.address" . }}/{{ template "pulsar.oxia.schema.namespace" . }}
+{{- end -}}
+
+{{- define "pulsar.oxia.kafkaSchema.url" -}}
+oxia://{{ template "pulsar.oxia.service.address" . }}/{{ template "pulsar.oxia.kafkaSchema.namespace" . }}
 {{- end -}}
 
 {{- define "pulsar.oxia.metadata.url" -}}

--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -329,6 +329,9 @@ spec:
     {{- end }}
 
     {{- end }}
+    {{- if include "pulsar.metadata.isOxia" . }}
+    useStorageCatalog: true
+    {{- end }}
     custom:
       PULSAR_PREFIX_additionalServletDirectory: "./brokerAdditionalServlet"
       {{- if include "pulsar.metadata.isOxia" . }}
@@ -338,8 +341,12 @@ spec:
       PULSAR_PREFIX_kafkaGroupOffsetsStoreInMetadata: "true"
       PULSAR_PREFIX_kafkaProducerStateStoreInMetadata: "true"
       PULSAR_PREFIX_kafkaSchemaRegistryStoreInOxia: "true"
-      PULSAR_PREFIX_oxiaSchemaStorageUrl: "{{ template "pulsar.oxia.schema.url" . }}"
+      {{- $oxia := default dict .Values.oxia }}
+      {{- $storageCatalog := default dict $oxia.storageCatalog }}
+      PULSAR_PREFIX_oxiaSchemaStorageUrl: {{ default (include "pulsar.oxia.schema.url" .) $storageCatalog.schemaStorageUrl | quote }}
       PULSAR_PREFIX_oxiaSchemaRegistryUrl: "{{ template "pulsar.oxia.kafkaSchema.url" . }}"
+      PULSAR_PREFIX_schemaRegistryUrl: {{ default (include "pulsar.oxia.kafkaSchema.url" .) $storageCatalog.schemaRegistryUrl | quote }}
+      PULSAR_PREFIX_schemaRegistryStorageClassName: {{ default "io.streamnative.pulsar.schema.OxiaSchemaStorageFactory" $storageCatalog.schemaRegistryStorageClassName | quote }}
       PULSAR_PREFIX_topicPoliciesServiceClassName: "io.streamnative.pulsar.OxiaTopicPoliciesService"
       {{- end }}
 {{- with .Values.broker.configData }}

--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -233,12 +233,6 @@ spec:
     {{- if .Values.pulsar_metadata.clusterName }}
     clusterName: {{ .Values.pulsar_metadata.clusterName }}
     {{- end }}
-    {{- if include "pulsar.metadata.isOxia" . }}
-    oxiaBasedSystemTopic:
-      enabled: true
-      schemaStorageUrl: "{{ template "pulsar.oxia.schema.url" . }}"
-      topicPoliciesServiceClassName: "io.streamnative.pulsar.OxiaTopicPoliciesService"
-    {{- end }}
     {{- if .Values.broker.functionmesh.enabled }}
     function:
       enabled: true
@@ -341,6 +335,12 @@ spec:
       PULSAR_PREFIX_metadataStoreUrl: "{{ template "pulsar.oxia.metadata.url" . }}"
       PULSAR_PREFIX_configurationMetadataStoreUrl: "{{ template "pulsar.oxia.metadata.url" . }}"
       PULSAR_PREFIX_enablePackagesManagement: "false"
+      PULSAR_PREFIX_kafkaGroupOffsetsStoreInMetadata: "true"
+      PULSAR_PREFIX_kafkaProducerStateStoreInMetadata: "true"
+      PULSAR_PREFIX_kafkaSchemaRegistryStoreInOxia: "true"
+      PULSAR_PREFIX_oxiaSchemaStorageUrl: "{{ template "pulsar.oxia.schema.url" . }}"
+      PULSAR_PREFIX_oxiaSchemaRegistryUrl: "{{ template "pulsar.oxia.kafkaSchema.url" . }}"
+      PULSAR_PREFIX_topicPoliciesServiceClassName: "io.streamnative.pulsar.OxiaTopicPoliciesService"
       {{- end }}
 {{- with .Values.broker.configData }}
 {{ toYaml . | indent 6 }}

--- a/charts/sn-platform/templates/oxia/oxia-namespace.yaml
+++ b/charts/sn-platform/templates/oxia/oxia-namespace.yaml
@@ -6,8 +6,9 @@
 {{- $brokerNamespace := dict "name" (include "pulsar.oxia.broker.namespace" .) "type" "broker" }}
 {{- $bookkeeperNamespace := dict "name" (include "pulsar.oxia.bookkeeper.namespace" .) "type" "bookkeeper" }}
 {{- $schemaNamespace := dict "name" (include "pulsar.oxia.schema.namespace" .) "type" "pulsar-schema" }}
+{{- $kafkaSchemaNamespace := dict "name" (include "pulsar.oxia.kafkaSchema.namespace" .) "type" "kafka-schema" }}
 {{- $functionNamespace := dict "name" (include "pulsar.oxia.function.namespace" .) "type" "function" }}
-{{- $namespaces := list $brokerNamespace $bookkeeperNamespace $schemaNamespace $functionNamespace }}
+{{- $namespaces := list $brokerNamespace $bookkeeperNamespace $schemaNamespace $kafkaSchemaNamespace $functionNamespace }}
 {{- range $index, $oxiaNamespace := $namespaces }}
 {{- if $index }}
 ---

--- a/charts/sn-platform/templates/oxia/storage-catalog.yaml
+++ b/charts/sn-platform/templates/oxia/storage-catalog.yaml
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2019 - 2024 StreamNative, Inc.. All Rights Reserved.
+#
+# deploy StorageCatalog only when `pulsar_metadata.provider` is oxia
+{{- if and .Values.components.broker (include "pulsar.metadata.isOxia" .) }}
+{{- $oxia := default dict .Values.oxia }}
+{{- $storageCatalog := default dict $oxia.storageCatalog }}
+apiVersion: k8s.streamnative.io/v1alpha1
+kind: StorageCatalog
+metadata:
+  name: "{{ template "pulsar.fullname" . }}"
+  namespace: {{ template "pulsar.namespace" . }}
+  labels:
+    {{- include "pulsar.standardLabels" . | nindent 4 }}
+    component: broker
+spec:
+  oxiaMetadataServiceUrl: {{ default (include "pulsar.oxia.metadata.url" .) $storageCatalog.oxiaMetadataServiceUrl | quote }}
+  schemaStorageUrl: {{ default (include "pulsar.oxia.schema.url" .) $storageCatalog.schemaStorageUrl | quote }}
+  schemaRegistryUrl: {{ default (include "pulsar.oxia.kafkaSchema.url" .) $storageCatalog.schemaRegistryUrl | quote }}
+  schemaRegistryStorageClassName: {{ default "io.streamnative.pulsar.schema.OxiaSchemaStorageFactory" $storageCatalog.schemaRegistryStorageClassName | quote }}
+  {{- with $storageCatalog.storageUrl }}
+  storageUrl: {{ . | quote }}
+  {{- end }}
+  {{- with $storageCatalog.backendStorageType }}
+  backendStorageType: {{ . | quote }}
+  {{- end }}
+  {{- with $storageCatalog.bucket }}
+  bucket: {{ . | quote }}
+  {{- end }}
+  {{- with $storageCatalog.prefix }}
+  prefix: {{ . | quote }}
+  {{- end }}
+  {{- with $storageCatalog.region }}
+  region: {{ . | quote }}
+  {{- end }}
+  {{- if hasKey $storageCatalog "useOwnStorage" }}
+  useOwnStorage: {{ $storageCatalog.useOwnStorage }}
+  {{- end }}
+{{- end }}

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -1234,18 +1234,6 @@ pulsar_metadata:
   #     limits:
   #       cpu: "1"
   #       memory: "1Gi"
-  # storageCatalog:
-  #   oxiaMetadataServiceUrl: ""
-  #   schemaStorageUrl: ""
-  #   schemaRegistryUrl: ""
-  #   schemaRegistryStorageClassName: io.streamnative.pulsar.schema.OxiaSchemaStorageFactory
-  #   storageUrl: ""
-  #   backendStorageType: S3
-  #   bucket: ""
-  #   prefix: ""
-  #   region: ""
-  #   useOwnStorage: false
-
 ## deprecated: move to broker.kop
 # kop:
 #   ports:

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -118,19 +118,19 @@ monitoring:
 images:
   coordinator:
     repository: streamnative/sn-platform-slim
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
   zookeeper:
     repository: streamnative/sn-platform
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
     customTools:
       backup:
         repository: "streamnative/pulsar-metadata-tool"
-        tag: "3.3.3.3"
+        tag: "4.2.1.1"
         pullPolicy: IfNotPresent
       restore:
         repository: "streamnative/pulsar-metadata-tool"
-        tag: "3.3.3.3"
+        tag: "4.2.1.1"
         pullPolicy: IfNotPresent
   oxia:
     repository: oxia/oxia
@@ -138,11 +138,11 @@ images:
     pullPolicy: IfNotPresent
   bookie:
     repository: streamnative/sn-platform
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   presto:
     repository: streamnative/sn-platform
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
     exporter:
       repository: bitnami/jmx-exporter
@@ -151,36 +151,36 @@ images:
   # NOTE: allow overriding the presto worker image
   # presto_worker:
   #   repository: streamnative/sn-platform
-  #   tag: 3.3.3.3
+  #   tag: 4.2.1.1
   #   pullPolicy: IfNotPresent
   autorecovery:
     repository: streamnative/sn-platform
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   broker:
     repository: streamnative/sn-platform
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   proxy:
     repository: streamnative/sn-platform
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   pulsar_detector:
     repository: streamnative/sn-platform
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   functions:
     repository: streamnative/sn-platform
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   function_worker:
     repository: streamnative/sn-platform
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   # NOTE: allow overriding the toolset image
   toolset:
     repository: streamnative/sn-platform
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
     kafka:
       repository: bitnami/kafka
@@ -242,7 +242,7 @@ images:
     pullPolicy: IfNotPresent
   pulsar_metadata:
     repository: streamnative/sn-platform
-    tag: "3.3.3.3"
+    tag: "4.2.1.1"
     pullPolicy: IfNotPresent
   configmapReload:
     repository: jimmidyson/configmap-reload
@@ -1234,6 +1234,17 @@ pulsar_metadata:
   #     limits:
   #       cpu: "1"
   #       memory: "1Gi"
+  # storageCatalog:
+  #   oxiaMetadataServiceUrl: ""
+  #   schemaStorageUrl: ""
+  #   schemaRegistryUrl: ""
+  #   schemaRegistryStorageClassName: io.streamnative.pulsar.schema.OxiaSchemaStorageFactory
+  #   storageUrl: ""
+  #   backendStorageType: S3
+  #   bucket: ""
+  #   prefix: ""
+  #   region: ""
+  #   useOwnStorage: false
 
 ## deprecated: move to broker.kop
 # kop:

--- a/charts/sn-platform/values.yaml
+++ b/charts/sn-platform/values.yaml
@@ -118,19 +118,19 @@ monitoring:
 images:
   coordinator:
     repository: streamnative/sn-platform-slim
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
   zookeeper:
     repository: streamnative/sn-platform
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
     customTools:
       backup:
         repository: "streamnative/pulsar-metadata-tool"
-        tag: "4.2.1.1"
+        tag: "3.3.3.3"
         pullPolicy: IfNotPresent
       restore:
         repository: "streamnative/pulsar-metadata-tool"
-        tag: "4.2.1.1"
+        tag: "3.3.3.3"
         pullPolicy: IfNotPresent
   oxia:
     repository: oxia/oxia
@@ -138,11 +138,11 @@ images:
     pullPolicy: IfNotPresent
   bookie:
     repository: streamnative/sn-platform
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   presto:
     repository: streamnative/sn-platform
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
     exporter:
       repository: bitnami/jmx-exporter
@@ -151,36 +151,36 @@ images:
   # NOTE: allow overriding the presto worker image
   # presto_worker:
   #   repository: streamnative/sn-platform
-  #   tag: 4.2.1.1
+  #   tag: 3.3.3.3
   #   pullPolicy: IfNotPresent
   autorecovery:
     repository: streamnative/sn-platform
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   broker:
     repository: streamnative/sn-platform
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   proxy:
     repository: streamnative/sn-platform
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   pulsar_detector:
     repository: streamnative/sn-platform
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   functions:
     repository: streamnative/sn-platform
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   function_worker:
     repository: streamnative/sn-platform
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   # NOTE: allow overriding the toolset image
   toolset:
     repository: streamnative/sn-platform
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
     kafka:
       repository: bitnami/kafka
@@ -242,7 +242,7 @@ images:
     pullPolicy: IfNotPresent
   pulsar_metadata:
     repository: streamnative/sn-platform
-    tag: "4.2.1.1"
+    tag: "3.3.3.3"
     pullPolicy: IfNotPresent
   configmapReload:
     repository: jimmidyson/configmap-reload


### PR DESCRIPTION
## Motivation
- Oxia metadata deployments currently let KoP schema registry fall back to the broker metadata namespace when `oxiaSchemaRegistryUrl` is not set.
- KoP reads `oxiaSchemaRegistryUrl`, while Pulsar schema storage is controlled separately by `schemaRegistryStorageClassName` and `oxiaSchemaStorageUrl`.

## Modifications
- Add a `kafka-schema` Oxia namespace helper and render a matching `OxiaNamespace`.
- Configure KoP schema registry to use `kafka-schema` via `PULSAR_PREFIX_oxiaSchemaRegistryUrl`.
- Replace the `oxiaBasedSystemTopic` chart block with explicit broker custom config so Kafka schema registry, group offsets, producer state, and topic-policy settings are visible in chart output.
- Do not force `schemaRegistryStorageClassName`; the current default `3.3.3.3` image does not include `io.streamnative.pulsar.schema.OxiaSchemaStorageFactory`. Pulsar schema metadata therefore remains on the default schema storage path unless users provide an image/plugin and set that storage class explicitly.

## Testing
- `git diff --check`
- `helm lint charts/sn-platform`
- `helm lint charts/sn-platform-slim`
- `helm template split-schema charts/sn-platform --namespace pulsar --set pulsar_metadata.provider=oxia`
- `helm template split-schema-slim charts/sn-platform-slim --namespace pulsar --set pulsar_metadata.provider=oxia`
- Fresh local kind deployment on context `kind-matt` with `charts/sn-platform-slim`, Oxia metadata, 2 brokers, and existing `sn-license` secret. Verified all pods became ready and rendered config uses `/kafka-schema` for `oxiaSchemaRegistryUrl`.