### PR TITLE
fix: enable default config v2 for oxia charts

### DIFF
--- a/charts/sn-platform-slim/templates/bookkeeper/bookkeeper-cluster.yaml
+++ b/charts/sn-platform-slim/templates/bookkeeper/bookkeeper-cluster.yaml
@@ -10,6 +10,9 @@ metadata:
   namespace: {{ template "pulsar.namespace" . }}
   annotations:
     "cloud.streamnative.io/enable-config-prefix": "false"
+    {{- if and (include "pulsar.metadata.isOxia" .) (not (hasKey (default dict .Values.bookkeeper.bookKeeperCluster.annotations) "cloud.streamnative.io/config-profile")) }}
+    "cloud.streamnative.io/config-profile": "default-config-v2"
+    {{- end }}
     {{- with .Values.bookkeeper.bookKeeperCluster.annotations -}}
     {{ toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/sn-platform-slim/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform-slim/templates/broker/broker-cluster.yaml
@@ -11,6 +11,9 @@ metadata:
   namespace: {{ template "pulsar.namespace" . }}
   annotations:
     "cloud.streamnative.io/enable-config-prefix": "false"
+    {{- if and (include "pulsar.metadata.isOxia" .) (not (hasKey (default dict .Values.broker.pulsarBroker.annotations) "cloud.streamnative.io/config-profile")) }}
+    "cloud.streamnative.io/config-profile": "default-config-v2"
+    {{- end }}
     {{- with .Values.broker.pulsarBroker.annotations -}}
     {{ toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/sn-platform-slim/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform-slim/templates/proxy/proxy-cluster.yaml
@@ -11,6 +11,9 @@ metadata:
   namespace: {{ template "pulsar.namespace" . }}
   annotations:
     "cloud.streamnative.io/enable-config-prefix": "false"
+    {{- if and (include "pulsar.metadata.isOxia" .) (not (hasKey (default dict .Values.proxy.pulsarProxy.annotations) "cloud.streamnative.io/config-profile")) }}
+    "cloud.streamnative.io/config-profile": "default-config-v2"
+    {{- end }}
     {{- with .Values.proxy.pulsarProxy.annotations -}}
     {{ toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
+++ b/charts/sn-platform/templates/bookkeeper/bookkeeper-cluster.yaml
@@ -10,6 +10,9 @@ metadata:
   namespace: {{ template "pulsar.namespace" . }}
   annotations:
     "cloud.streamnative.io/enable-config-prefix": "false"
+    {{- if and (include "pulsar.metadata.isOxia" .) (not (hasKey (default dict .Values.bookkeeper.bookKeeperCluster.annotations) "cloud.streamnative.io/config-profile")) }}
+    "cloud.streamnative.io/config-profile": "default-config-v2"
+    {{- end }}
     {{- with .Values.bookkeeper.bookKeeperCluster.annotations -}}
     {{ toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/sn-platform/templates/broker/broker-cluster.yaml
+++ b/charts/sn-platform/templates/broker/broker-cluster.yaml
@@ -11,6 +11,9 @@ metadata:
   namespace: {{ template "pulsar.namespace" . }}
   annotations:
     "cloud.streamnative.io/enable-config-prefix": "false"
+    {{- if and (include "pulsar.metadata.isOxia" .) (not (hasKey (default dict .Values.broker.pulsarBroker.annotations) "cloud.streamnative.io/config-profile")) }}
+    "cloud.streamnative.io/config-profile": "default-config-v2"
+    {{- end }}
     {{- with .Values.broker.pulsarBroker.annotations -}}
     {{ toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/sn-platform/templates/proxy/proxy-cluster.yaml
+++ b/charts/sn-platform/templates/proxy/proxy-cluster.yaml
@@ -11,6 +11,9 @@ metadata:
   namespace: {{ template "pulsar.namespace" . }}
   annotations:
     "cloud.streamnative.io/enable-config-prefix": "false"
+    {{- if and (include "pulsar.metadata.isOxia" .) (not (hasKey (default dict .Values.proxy.pulsarProxy.annotations) "cloud.streamnative.io/config-profile")) }}
+    "cloud.streamnative.io/config-profile": "default-config-v2"
+    {{- end }}
     {{- with .Values.proxy.pulsarProxy.annotations -}}
     {{ toYaml . | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
## Motivation
- Oxia-backed Pulsar clusters need the operator's default config v2 profile enabled on PulsarBroker, BookKeeperCluster, and PulsarProxy resources.
- The operator does not enable DEFAULT_CONFIG_V2 by default, so the charts need to opt Oxia installs into the profile explicitly.

## Modifications
- Add cloud.streamnative.io/config-profile: default-config-v2 to sn-platform and sn-platform-slim broker, bookkeeper, and proxy CR templates when pulsar_metadata.provider is oxia.
- Preserve explicit user-provided cloud.streamnative.io/config-profile annotations so custom profiles are not overwritten.
- Leave non-Oxia metadata installs unchanged.

## Testing
- git diff --check origin/master...HEAD
- helm lint ./charts/sn-platform-slim -f examples/sn-platform/values-oxia.yaml
- helm lint ./charts/sn-platform -f examples/sn-platform/values-oxia.yaml
- helm template render checks for Oxia, default metadata, and explicit config-profile override cases on both charts
- Applied the sn-platform-slim chart to a local kind cluster and verified PulsarBroker, BookKeeperCluster, and PulsarProxy CR annotations plus broker healthcheck